### PR TITLE
chore: release v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/OxideAV/oxideav-webp/compare/v0.0.6...v0.0.7) - 2026-05-03
+
+### Other
+
+- rustfmt — collapse short assert_eq! line in issue #8 test
+- predictor TR at rightmost column uses leftmost pixel of current row
+- drop trait imports redundant on Box<dyn …>
+- silence clippy unnecessary_unwrap + unused ch
+- rustfmt — wrap long arg lists
+- accept Rgb24 (VP8L + VP8) and Yuva420P (VP8+ALPH) input
+- rustfmt — wrap long expect_err line
+- replace .err().expect() with .expect_err() for clippy::err_expect
+- silence clippy::needless_range_loop in test helpers
+- fix CI compile + rustfmt issues from new test files
+- ~57 unit tests for Huffman parser + simple/normal/build edge cases
+
 ### Fixed
 
 - VP8L predictor: top-right (TR) neighbour at the rightmost column now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.0.6 -> 0.0.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.7](https://github.com/OxideAV/oxideav-webp/compare/v0.0.6...v0.0.7) - 2026-05-03

### Other

- rustfmt — collapse short assert_eq! line in issue #8 test
- predictor TR at rightmost column uses leftmost pixel of current row
- drop trait imports redundant on Box<dyn …>
- silence clippy unnecessary_unwrap + unused ch
- rustfmt — wrap long arg lists
- accept Rgb24 (VP8L + VP8) and Yuva420P (VP8+ALPH) input
- rustfmt — wrap long expect_err line
- replace .err().expect() with .expect_err() for clippy::err_expect
- silence clippy::needless_range_loop in test helpers
- fix CI compile + rustfmt issues from new test files
- ~57 unit tests for Huffman parser + simple/normal/build edge cases

### Fixed

- VP8L predictor: top-right (TR) neighbour at the rightmost column now
  uses the leftmost pixel of the current row (column 0 of row y), as
  specified by RFC 9649 §4.1, instead of the LEFT neighbour. The wrong
  TR caused libwebp-encoded streams to decode with cascading per-row
  errors that surfaced as off-by-channel pixel mismatches. Closes #8.
  Both the decoder (`apply_predictor`) and the encoder
  (`predict_argb` mirror) were corrected; pure self-roundtrips were
  bit-exact under both definitions, so the bug only showed up against
  spec-conformant encoders like libwebp.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).