### PR TITLE
chore: release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/OxideAV/oxideav-webp/compare/v0.0.8...v0.0.9) - 2026-05-03
+
+### Fixed
+
+- *(vp8l)* keep Huffman meta-tree Kraft-complete after length-limit
+
+### Other
+
+- allow style-only clippy lints in Kraft regression test
+
 ## [0.0.8](https://github.com/OxideAV/oxideav-webp/compare/v0.0.7...v0.0.8) - 2026-05-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.0.8 -> 0.0.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/OxideAV/oxideav-webp/compare/v0.0.8...v0.0.9) - 2026-05-03

### Fixed

- *(vp8l)* keep Huffman meta-tree Kraft-complete after length-limit

### Other

- allow style-only clippy lints in Kraft regression test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).