### PR TITLE
chore: release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/OxideAV/oxideav-webp/compare/v0.0.10...v0.0.11) - 2026-05-04
+
+### Added
+
+- *(vp8-enc)* wire per-frequency AC/DC quantiser deltas via vp8 0.1.7
+- *(vp8l-enc)* add K=8 meta-Huffman trial to per-tile grouping sweep
+- *(vp8-enc)* re-wire per-segment LF deltas via vp8 0.1.6
+
+### Fixed
+
+- *(vp8-decode)* bit-exact YUV→RGB + fancy chroma upsample vs libwebp
+
+### Other
+
+- *(vp8l-decode)* bit-exact lossless corpus walker
+
 ### Added
 
 - *(vp8-enc)* per-frequency AC/DC quantiser delta knob. Wires the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.0.10 -> 0.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.11](https://github.com/OxideAV/oxideav-webp/compare/v0.0.10...v0.0.11) - 2026-05-04

### Added

- *(vp8-enc)* wire per-frequency AC/DC quantiser deltas via vp8 0.1.7
- *(vp8l-enc)* add K=8 meta-Huffman trial to per-tile grouping sweep
- *(vp8-enc)* re-wire per-segment LF deltas via vp8 0.1.6

### Fixed

- *(vp8-decode)* bit-exact YUV→RGB + fancy chroma upsample vs libwebp

### Other

- *(vp8l-decode)* bit-exact lossless corpus walker

### Added

- *(vp8-enc)* per-frequency AC/DC quantiser delta knob. Wires the
  `y_dc_delta` / `y2_dc_delta` / `y2_ac_delta` / `uv_dc_delta` /
  `uv_ac_delta` fields published in `oxideav-vp8` 0.1.7 (#417)
  through to the WebP single-frame lossy path via the new
  `encoder_vp8::Vp8FreqDeltas` struct plus
  `encoder_vp8::make_encoder_with_qindex_and_freq_deltas` /
  `make_encoder_with_quality_and_freq_deltas` factories. Defaults
  (all-zero) reproduce the pre-#417 bitstream byte-for-byte; non-zero
  values bias bits toward a specific frequency band (e.g. negative
  `y_dc_delta` for finer luma AC where banding shows up, positive
  `uv_ac_delta` to lighten chroma AC on screen-recording / line-art
  content). Each delta is clamped to `[-15, 15]` by the underlying
  encoder. Closes the deferral noted in `c8c1d69` and bumps
  `oxideav-vp8` minimum version to `0.1.7`.
- *(test)* `vp8_per_frequency_deltas_change_bitstream_and_round_trip`
  encodes the same YUV420P frame twice at the same qindex (zero
  deltas vs a non-trivial mix) and asserts the bitstreams differ,
  both round-trip through `decode_webp`, and both cross-decode
  through libwebp's `dwebp` binary when installed (silent skip
  otherwise — keeps CI green on hosts without libwebp).
- *(vp8l-enc)* extend the meta-Huffman per-tile grouping sweep from
  K = {1, 2, 4} to K = {1, 2, 4, 8}. Each `encode_image_stream` call
  speculatively emits the K=8 candidate (gated on ≥ 16384 px = 128×128
  pixels — below it the eight extra Huffman-tree headers dominate any
  per-cluster savings) alongside the existing K=2 / K=4 trials and
  keeps the byte-smallest. The k-means clustering already generalised
  to arbitrary K so this is a one-line widening of the K-loop plus the
  matching minimum-pixel-count gate. The decoder side already supported
  arbitrary K (the meta-image's group-id field is 16 bits wide). Pushes
  VP8L encoder closer to libwebp's per-tile entropy-image parity on
  fixtures with several visually distinct sub-regions. The K=8 candidate
  is now also probed inside every RDO trial (the 32-trial sweep already
  exercises every transform × cache combination, and the K=8 trial
  rides inside each one), so it picks the winner across the joint
  configuration space without extra outer iterations.
- *(test)* `meta_huffman_k8_round_trips_eight_strip_fixture` +
  `meta_huffman_k8_shrinks_or_matches_smaller_k_on_eight_strip` —
  exercises the K=8 path on a 128×128 fixture with eight horizontal
  strips of distinctly-different statistics; verifies round-trip
  through the in-crate decoder and that the encoded stream is at least
  half the raw RGBA size.
- *(vp8-enc)* re-wire per-segment loop-filter delta tuning. Now that
  `oxideav-vp8` 0.1.6 publishes `Vp8EncoderConfig::segment_lf_deltas`
  (#337), the WebP single-frame lossy config plumbs the
  quality-scaled deltas computed by `segment_lf_deltas_for_qindex`
  into the encoder. Variance-segment 0 (smooth) gets a *lighter*
  deblock so flat regions don't over-smooth; variance-segment 3
  (textured) gets a *heavier* deblock so the coarser per-segment QP's
  DCT block boundaries get masked. Closes the wiring previously
  deferred in `a46ecf2 fix(vp8-enc): drop segment_lf_deltas — not on
  published vp8 0.1.5`. Bumps `oxideav-vp8` minimum version to
  `0.1.6`.
- *(test)* `lossless_corpus` integration test walks the seven
  workspace `docs/image/webp/fixtures/lossless-*` fixtures and asserts
  bit-exact RGBA equality with each `expected.png` ground truth.
  Covers the trivial single-pixel case, opaque RGB, RGBA, photo-like
  content (subtract-green + predictor + LZ77 + Huffman), the
  colour-cache hit path, the colour-indexing/palette transform, and
  the cross-colour transform. All seven fixtures pass on the first
  CI run, which proves the VP8L decoder is bit-exact with libwebp on
  the workspace docs corpus.

### Fixed

- *(vp8-decode)* bit-exact YUV→RGB + chroma upsampling alignment with
  libwebp's reference path. The decoder's YUV→RGB conversion now uses
  libwebp's exact two-stage truncating fixed-point arithmetic
  (`MultHi(v, coeff) = (v*coeff)>>8` per term, then `>> 6` on the sum,
  matching `src/dsp/yuv.h::VP8YUVToR/G/B`) instead of folding the
  shifts into a single `(KY*y + KC*c + …) >> 14` — the previous
  algebraically-equivalent form lost a few low bits of precision per
  channel, biasing every output ~1 LSB high vs libwebp. Chroma
  upsampling now also matches libwebp's "fancy" 9/3/3/1 weighted
  bilinear interpolation (`src/dsp/upsampling.c::UPSAMPLE_FUNC`)
  instead of nearest-neighbour replication. Combined effect on the
  lossy_corpus integration test against libwebp-cwebp ground truth:
  q100 + near-lossless + 1×1 fixtures are now bit-exact (previously
  ~20% per-channel exact match), q75 + with-alpha 73-75% per-channel
  (PSNR 48-50 dB), q1 ~33% (PSNR 42 dB). Three previously
  ReportOnly fixtures promoted to BitExact tier.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).