### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/OxideAV/oxideav-webp/compare/v0.1.0...v0.1.1) - 2026-05-05
+
+### Added
+
+- *(vp8l-enc)* two-pass cost-modelled LZ77 + predictor-tile-bits RDO sweep
+
+### Other
+
+- *(changelog)* clean duplicate Unreleased entries after rebase
+- release v0.1.0 ([#14](https://github.com/OxideAV/oxideav-webp/pull/14))
+
 ### Added
 
 - *(vp8l-enc)* **two-pass cost-modelled LZ77** with cost-aware

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/OxideAV/oxideav-webp/compare/v0.1.0...v0.1.1) - 2026-05-05

### Added

- *(vp8l-enc)* two-pass cost-modelled LZ77 + predictor-tile-bits RDO sweep

### Other

- *(changelog)* clean duplicate Unreleased entries after rebase
- release v0.1.0 ([#14](https://github.com/OxideAV/oxideav-webp/pull/14))

### Added

- *(vp8l-enc)* **two-pass cost-modelled LZ77** with cost-aware
  match selection. Pass 1 runs greedy first-match; the resulting
  histogram seeds a per-alphabet bit-cost model
  (`-log2(p) × 16` in 1/16-bit units, capped at 40 bits). Pass 2
  re-walks the LZ77 hash chain and at each position picks the
  candidate match whose bit cost per pixel under the model is
  lowest, plus a one-step lazy-lookahead defer when
  `literal-here + match-at-i+1` is cheaper than `match-here`. Both
  candidate streams score against the SAME model; the cheaper one
  wins. Adds 1-2 % byte savings on photographic content
  (1024×768 photo: -525 B; 64×64 cache stress: -3 B; 128×128
  natural: -14 B vs the K=16 baseline).
- *(vp8l-enc)* **predictor tile-bits RDO sweep** over
  `{8, 16, 32}` px tiles. Previously fixed at 16 px (libwebp
  default); the encoder now picks the smallest output across the
  three tile sizes per image. Wins on smooth photographic content
  where 32-px tiles' smaller predictor sub-image saves a few
  hundred bits, and on dense small-feature content (icons, line
  art) where 8-px tiles' finer per-tile mode accuracy beats the
  side-image overhead. Sweep is gated to predictor-on /
  non-palette trials so the trial budget grows by 3× only on the
  trials that benefit. New `predictor_tile_bits` field on
  `EncoderOptions` lets explicit callers pin a single value.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).