### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/OxideAV/oxideav-webp/compare/v0.1.2...v0.1.3) - 2026-05-05
+
+### Added
+
+- *(vp8l-enc)* Shannon-entropy colour-transform scoring + full-RDO portrait/brick tests
+- *(vp8l-enc)* Shannon-entropy predictor scoring replaces SAD
+- *(vp8l-enc)* multi-iter Huffman refit + bin-boundary Viterbi probing
+- *(vp8l-enc)* Viterbi-style optimal LZ77 + natural ≥256×256 fixtures
+- *(vp8l-enc)* EntropyImage tile-bits sweep + smart tile-boundary switching
+- *(vp8-enc)* psy-RDO source analysis + per-frame target-size rate control
+
+### Fixed
+
+- *(test/vp8l-viterbi)* u32 underflow in portrait_textured_256 fixture + cap CI cost
+
+### Other
+
+- rustfmt LEN_BIN_STARTS comments + unwrap huffman_lengths call
+- rustfmt sweep on cwebp args (one arg per line per fmt config)
+- auto-register via oxideav_core::register! macro (linkme distributed slice)
+
 ### Changed
 
 - *(vp8l-enc)* **Shannon-entropy colour-transform scoring** replaces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/OxideAV/oxideav-webp/compare/v0.1.2...v0.1.3) - 2026-05-05

### Added

- *(vp8l-enc)* Shannon-entropy colour-transform scoring + full-RDO portrait/brick tests
- *(vp8l-enc)* Shannon-entropy predictor scoring replaces SAD
- *(vp8l-enc)* multi-iter Huffman refit + bin-boundary Viterbi probing
- *(vp8l-enc)* Viterbi-style optimal LZ77 + natural ≥256×256 fixtures
- *(vp8l-enc)* EntropyImage tile-bits sweep + smart tile-boundary switching
- *(vp8-enc)* psy-RDO source analysis + per-frame target-size rate control

### Fixed

- *(test/vp8l-viterbi)* u32 underflow in portrait_textured_256 fixture + cap CI cost

### Other

- rustfmt LEN_BIN_STARTS comments + unwrap huffman_lengths call
- rustfmt sweep on cwebp args (one arg per line per fmt config)
- auto-register via oxideav_core::register! macro (linkme distributed slice)

### Changed

- *(vp8l-enc)* **Shannon-entropy colour-transform scoring** replaces
  sum-of-abs-residuals (SAD) in `choose_color_transform`. For each
  candidate `(g2r, g2b, r2b)` coefficient triple on a tile the encoder
  now builds 256-bin histograms of the transformed R and B byte values
  and scores the tile by `Σ -p_i log2(p_i)` (lower entropy = more
  compressible = wins). This is the same criterion already used by
  `score_predictor_on_tile`, keeping the two selection loops consistent.
  Measured under full RDO on the 256×256 synthetic fixtures vs cwebp 1.6.0
  (`-lossless -m 6 -z 9`): brick-wall-256 improves from **1.0311× to
  1.0301×** (−42 bytes), portrait-textured-256 from **1.0405× to
  1.0398×** (−20 bytes); landscape-256 stays at **0.9949×** (sub-cwebp).
  Full-RDO release-mode tests added for portrait and brick with dwebp
  cross-decode verification.

- *(vp8l-enc)* **Shannon-entropy predictor scoring** replaces sum-of-abs-
  residuals (SAD) for VP8L predictor-mode selection. For each candidate
  mode on a tile, the encoder now builds a 256-bin histogram of
  `(pixel − prediction) mod 256` residuals per channel and scores the
  tile by `Σ -p_i log2(p_i)` (the mode with the lowest total entropy
  wins). This matches cwebp's predictor-mode selection criterion and
  closes the parity gap on natural ≥ 256×256 images. Measured on the
  256×256 landscape fixture: ratio vs cwebp 1.6.0 (`-lossless -m 6 -z 9`)
  drops from **1.0124×** to **0.9949×** (we now produce a smaller output
  than cwebp on that fixture). Portrait-textured-256 and brick-wall-256
  improve from 1.04× / 1.03× to 1.04× / 1.03× at `default_opts`
  (single-config Viterbi), with further headroom available under the full
  RDO sweep.

- *(vp8l-enc)* **Multi-iteration Huffman refit** for ≥ 256×256 images.
  After the Viterbi DP selects the best token stream, the encoder builds
  the exact Huffman code-length tables from that stream's histogram and
  constructs a `CostModel::from_code_lengths` exact model (each symbol's
  cost = `code_length × 16` instead of `−log2(p) × 16`). The Viterbi DP
  is re-run under this exact model; if the candidate stream is cheaper
  under the model, it becomes the new best and the process repeats (up to
  3 extra iterations). Convergence is typically 1–2 iterations on natural-
  image content. Measured on the synthetic 256×256 landscape fixture:
  **−60 bytes (−0.14 %)**, bringing the ratio from `1.0135x` to `1.0124x`
  of cwebp 1.6.0 (`-lossless -m 6 -z 9`).

- *(vp8l-enc)* **Bin-boundary length probing** in the Viterbi DP. The
  previous per-chain-entry length probing used geometric doubling
  (`MIN_MATCH, +1, +1, ..., ×2` above 32). Now uses the VP8L
  length-encoding bin boundaries (`LEN_BIN_STARTS`) as probe points:
  within a bin every length has the same Huffman symbol and extra-bit
  count, so the longest reachable length in each bin is the best probe
  (maximum pixels covered at equal coded cost). Eliminates redundant
  probes within each bin and ensures the DP sees every cost-distinct
  length range.

- *(vp8l-enc)* **Cache-literal parallel consideration** in the Viterbi
  DP. Previously the DP would take a cache-ref at position `i` (when the
  slot held `pixels[i]`) *instead of* considering a literal — missing
  cases where the four literal-channel symbols are collectively cheaper
  than the cache-index code. Now both transitions update `dp[i+1]`
  independently and the cheaper one wins. Fixes the VP8L spec allowance
  that a literal may always be emitted even when a cache hit is available.

### Fixed

- *(vp8l-enc)* Double-add bug in `backref_cost` call sites. During
  experimentation with VP8L special distance codes (codes 1–120), several
  `backref_cost(len, dist + 120)` call sites were reverted incorrectly:
  `backref_cost` adds 120 internally to convert pixel distance to VP8L
  distance code, so passing `dist + 120` produced `dist + 240`. Affected
  sites in `build_symbol_stream` (greedy match cost and lazy-lookahead
  cost) and in the Viterbi DP bin-boundary loop have been corrected to
  pass the raw pixel distance as documented.

### Added

- *(vp8l-enc)* **Viterbi-style optimal LZ77** as a third pass on top
  of the existing two-pass cost-modelled LZ77 pipeline. Pass 3 runs a
  forward dynamic-programming sweep over the LZ77 backward-reference
  graph: at each pixel position `i` it considers (a) literal-at-i,
  (b) cache-ref-at-i (when the colour-cache slot already holds the
  pixel), and (c) every hash-chain backref candidate `(len, dist)`
  reachable from `i` (probing each chain entry at multiple lengths,
  not just `max_len`), and updates `dp[i + span]` with the minimum
  cumulative cost in 1/16-bit units under the same [`CostModel`]
  passes 1 and 2 share. Backtrack from `dp[n]` recovers the optimal
  symbol sequence. The colour-cache state at every position is a
  deterministic function of `pixels[0..i]` (`cache_add` only reads
  the pixel's ARGB value, not the token type that emitted it) so the
  DP is path-independent — a single rolling cache walk pre-fills
  `cache_hit_at[]` / `cache_idx_at[]` arrays and the DP becomes a
  pure forward sweep. A **refit** sub-step rebuilds the cost model
  from the pass-3a Viterbi histogram and re-runs the DP; the lower
  modelled-cost candidate of the two wins. Closes the "lacks Viterbi-
  style optimal LZ77" tail noted in the WebP VP8L row of the
  workspace README. Gated on ≥ 65 536 px (256×256) so smaller
  fixtures stay on the cheaper pass-2 cost-aware-greedy path.
  Measured wins on natural ≥ 256×256 fixtures: **−298 bytes
  (−0.67 %)** on the synthetic 256×256 landscape (sky/foliage/
  foreground), bringing it from `1.0203x` to `1.0135x` of cwebp 1.6.0
  (`-lossless -m 6 -z 9`); 256×256 portrait-on-textured-background
  and 256×256 brick-wall mosaic fixtures land at `1.0403x` and
  `1.0332x` respectively. Residual ~1.5-4 % gap to cwebp on natural
  photos comes from histogram-fitting heuristics + per-tile transform
  selection that operate outside the LZ77 path; full byte-parity on
  every natural-image fixture is a further-rounds target.
- *(test)* `vp8l_viterbi_lz77` integration suite (3 tests):
  `viterbi_outputs_round_trip_through_in_crate_decoder` (3 fixtures
  × 256×256 — landscape / portrait / brick-wall — round-trip bit-
  exact through the in-crate VP8L decoder),
  `viterbi_outputs_decode_through_external_dwebp_on_natural_256`
  (cross-decode through libwebp's `dwebp` binary; silently skipped
  when `dwebp` isn't on PATH), `viterbi_within_5pct_of_cwebp_lossless_on_natural_256`
  (encodes each fixture, runs `cwebp -lossless -m 6 -z 9` against
  the same input, asserts ratio ≤ 1.05x). Per-fixture ratios are
  printed via `eprintln!` for size-tracking visibility across
  releases.

- *(vp8l-enc)* **EntropyImage tile-bits sweep + smart tile-boundary
  switching.** The meta-Huffman per-tile-grouping path (RFC 9649
  §3.7.2.2 EntropyImage / "prefix code groups") used to hard-code
  `meta_bits = 4` (16-pixel tiles); it now sweeps `meta_bits ∈
  {3, 4, 5}` (8 / 16 / 32-pixel tiles) per K trial and keeps the
  byte-smallest (K, meta_bits) tuple. Smaller tiles capture sharper
  per-region histogram differences (text overlays, line-art-heavy
  photos), bigger tiles save the meta-image-overhead bits on
  broad-region content (landscapes with large sky / sand bands).
  K-means iteration count also now scales with K
  (`kmeans_iters_for_k`: 2 for K = 2, 3 for K = 4, 4 for K ≥ 8) so
  the cluster boundaries actually settle on multi-region content
  instead of collapsing to a smaller-K baseline. Closes the
  "lacks EntropyImage transform + smart tile-boundary switching"
  tail noted in the WebP VP8L row of the workspace README.
  Measured win on a synthetic three-region 256×256 photo:
  **−286 bytes (−0.43 %)** vs the fixed-16-px-tile baseline,
  achieving byte-parity with cwebp 1.6.0 (`-lossless -m 6 -z 9`).
  Smaller / more uniform fixtures see no change (the single-group
  baseline still wins, as the meta-Huffman trial path cleanly bails
  out via the `bw.restore` rollback). Heavy 256×256 content with
  several visually distinct regions is where the entropy-image
  sweep pays off.
- *(test)* `entropy_image_tile_bits_lands_in_swept_range_on_three_region_256`
  asserts the encoder picks one of `{3, 4, 5}` for `meta_bits` on the
  three-region fixture (gradient + bars + noise stacked vertically) and
  that the resulting bitstream round-trips through the in-crate decoder.
  `entropy_image_tile_bits_sweep_does_not_inflate_uniform_noise_64`
  asserts the sweep adds no bytes on uniform-noise 64×64 input where
  the single-group baseline always wins.

- *(vp8-enc)* psy-RDO source analysis + per-frame target-size rate
  control. Each `send_frame` on the non-explicit factories
  ([`make_encoder`] / [`make_encoder_with_quality`] /
  [`make_encoder_with_qindex`]) now runs a one-pass MAD analyser
  over the source luma plane (`encoder_vp8::compute_psy_stats`)
  and uses the resulting `PsyStats { mean_activity,
  high_variance_fraction, mb_count }` to bias both the per-segment
  quant deltas and the per-frequency AC/DC quant deltas before
  invoking the underlying VP8 encoder. CSF-style activity masking:
  frames with `mean_activity ≥ 16` (typical natural-image
  textures) get one step coarser high-freq AC bins (saves bits the
  eye won't notice on busy content); frames with `mean_activity
  < 6` (sky photos / flat plates) get one step finer to suppress
  visible banding on the rare edges. Variance-segment 3 delta also
  modulates: widens on segment-3-heavy frames (most MBs textured →
  recover bits there), narrows on segment-3-empty frames (rare
  textured MB shouldn't get hammered). Modulation strength scales
  with qindex so the qindex=0 endpoint reproduces the pre-psy
  bitstream byte-for-byte. New
  [`encoder_vp8::make_encoder_with_target_size`] factory hits a
  caller-supplied byte budget within ±10 % via a 5-iteration
  bisection over qindex (worst-case 6× single-shot encode cost,
  converges in 2-3 iterations on natural-image content because the
  size-vs-qindex curve is monotone). Measured win on the AC-rich
  noisy 128×128 fixture at qindex 64: −1.1 % bytes and +0.01 dB
  PSNR vs the no-psy baseline; both bitstreams cross-decode
  cleanly through libwebp's `dwebp`. Explicit `*_and_freq_deltas`
  factories continue to pass freq-deltas through verbatim and
  bypass the psy modulation, preserving the
  `Vp8FreqDeltas::default()` byte-identical guarantee for tuning
  callers.
- *(test)* `vp8_lossy_psy_rdo` integration suite (7 tests):
  `psy_stats_distinguish_smooth_vs_noisy` (asserts the analyser
  ranks the smooth fixture at activity 3.0 and the noisy fixture
  at 18.4 on the same 128×128 frame), `psy_stats_sub_mb_frame_returns_default`
  (8×8 frames return `mb_count=0` rather than panic),
  `psy_modulation_changes_bitstream_and_keeps_quality_on_noisy_source`
  (psy-on vs psy-off bytes / PSNR comparison + dwebp cross-decode),
  `psy_modulation_smooth_source_does_not_blow_up_bytes` (bytes
  growth ≤ 25 % on smooth content),
  `target_size_rate_control_hits_within_tolerance` (6 KB / 12 KB
  / 20 KB targets all land within ±15 %),
  `target_size_rate_control_handles_unreachable_target` (50-byte
  target on a 128×128 noisy fixture lands at the smallest
  achievable size without panicking),
  `psy_modulation_collapses_to_baseline_at_qindex_zero`
  (high-quality byte-identical guarantee).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).