### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/OxideAV/oxideav-webp/compare/v0.1.4...v0.1.5) - 2026-05-09
+
+### Added
+
+- *(anim-encoder)* real Gaussian downsample + auto-inner-threshold default flip
+- *(anim-encoder)* opt-in MS-SSIM-lite + slow-tests gated 320x240 fixture
+- *(anim-encoder)* opt-in SSIM-lite cost model + mid-density ramp validation
+- *(anim-encoder)* adaptive max_components + auto inner-encode for Delta mode
+- *(anim-encoder)* multi-rect ANMF for Delta mode (per-block decision)
+- *(anim-encoder)* AVIF-style perceptual delta-merge for animation
+- *(anim-decoder,demux)* zero-clone next_frame_borrowed + streaming Demuxer impl
+- *(anim-decoder)* seek_to_frame random-access + memory-tight streaming demux
+- *(anim-decoder,encoder-vp8l)* streaming WebpAnimDecoder + VP8L metadata factory
+
+### Other
+
+- *(anim-encoder)* downsize multi-rect Delta fixture from 320x240 to 160x120
+- doc the deferred dispose-to-background semantics
+- drop stale dead_code on LazyParsedContainer.total_duration_ms
+
 ### Added
 
 - *(anim-encoder)* **opt-in real Gaussian downsample kernel for the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/OxideAV/oxideav-webp/compare/v0.1.4...v0.1.5) - 2026-05-09

### Added

- *(anim-encoder)* real Gaussian downsample + auto-inner-threshold default flip
- *(anim-encoder)* opt-in MS-SSIM-lite + slow-tests gated 320x240 fixture
- *(anim-encoder)* opt-in SSIM-lite cost model + mid-density ramp validation
- *(anim-encoder)* adaptive max_components + auto inner-encode for Delta mode
- *(anim-encoder)* multi-rect ANMF for Delta mode (per-block decision)
- *(anim-encoder)* AVIF-style perceptual delta-merge for animation
- *(anim-decoder,demux)* zero-clone next_frame_borrowed + streaming Demuxer impl
- *(anim-decoder)* seek_to_frame random-access + memory-tight streaming demux
- *(anim-decoder,encoder-vp8l)* streaming WebpAnimDecoder + VP8L metadata factory

### Other

- *(anim-encoder)* downsize multi-rect Delta fixture from 320x240 to 160x120
- doc the deferred dispose-to-background semantics
- drop stale dead_code on LazyParsedContainer.total_duration_ms

### Added

- *(anim-encoder)* **opt-in real Gaussian downsample kernel for the
  3-scale MS-SSIM-lite cost path** — new
  `DeltaConfig::msssim_downsample_kernel: DownsampleKernel` field
  (default `DownsampleKernel::Box`, preserves existing box-average
  behaviour) selects the kernel used to reduce the scale-1 / scale-2
  extended regions before the contrast/structure components are
  computed. `DownsampleKernel::Gaussian` swaps in the canonical
  Wang/Bovik 2003 5-tap σ=0.8 kernel
  (`[0.054, 0.244, 0.404, 0.244, 0.054]`) applied separably (horizontal
  then vertical) followed by 2× decimation; the 4× scale cascades two
  blur+decimate passes for a true Gaussian pyramid. Closes a real
  perceptual undershoot the box pillbox over-smooths on smooth
  gradients (the box average is a degenerate σ ≈ ∞ pillbox filter).
  Builder method `DeltaConfig::msssim_downsample_kernel(kernel)` and
  the new `DownsampleKernel` enum are re-exported from the crate root.
  Test `msssim_gaussian_kernel_disagrees_with_box_on_smooth_gradient`
  pins that the two kernels report different MS-SSIM costs on a
  high-frequency checkerboard with a localised perturbation;
  `msssim_cost_block_identical_inputs_returns_zero` extended to cover
  both kernels.

- *(anim-encoder)* **opt-in 3-scale MS-SSIM-lite cost model for
  `AnimFrameMode::Delta`** — new `DeltaConfig::enable_msssim_cost: bool`
  (default `false`, preserves existing SAD/single-scale-SSIM behaviour)
  generalises the single-scale SSIM-lite cost to 3 spatial scales per
  Wang/Bovik 2003 ("Multi-scale structural similarity for image quality
  assessment"). Cost = `round((1.0 - MS-SSIM) * 10000)` where
  `MS-SSIM = SSIM_0^α · CS_1^β · CS_2^γ` with empirical exponents
  `α=0.2856, β=0.3001, γ=0.4143` (sum 1.0) derived by fusing the
  bottom-two scales of the canonical 5-scale series
  `{0.0448, 0.2856, 0.3001, 0.2363, 0.1333}` into γ. Scale 0 is the
  full SSIM (luminance × contrast × structure) at the native block
  resolution; scales 1 and 2 use 2× and 4× extended regions around
  the block, separable-Gaussian box-downsampled, computing only the
  contrast × structure components (luminance term carried solely by
  the native scale). Catches **low-frequency structural drift** that
  single-scale 8×8 SSIM misses — worked example: a centre 8×8 block
  whose pixels are bit-identical between prev/curr but whose
  surrounding context picks up a high-contrast stripe pattern. Single-
  scale SSIM scores 0 (identical centre); MS-SSIM scale-1 / scale-2
  CS terms collapse → cost > default `msssim_threshold` 50 → block
  flagged changed. Threshold lives on the new
  `DeltaConfig::msssim_threshold: u32` (same scale as `ssim_threshold`,
  default 50). MS-SSIM supersedes single-scale SSIM when both flags
  are on. Builder methods `DeltaConfig::enable_msssim_cost(bool)` /
  `msssim_threshold(u32)` mirror the field setters. Tests
  `msssim_cost_block_identical_inputs_returns_zero`,
  `msssim_cost_catches_low_freq_drift_single_scale_misses`, and
  `msssim_cost_threshold_dispatches_correctly_via_config` pin the
  per-block math + the dispatcher gate.

- *(tests)* **slow-tests Cargo feature gate for the original 320×240
  multi-rect Delta benchmark** — restores the pre-`d2501a1` 320×240
  scattered-stamps fixture as
  `tests/animated_delta_merge_320x240.rs`, gated behind the new
  default-off `slow-tests` feature so CI runtime stays ≤ 10 min on
  default builds. Run with
  `cargo test --features slow-tests --test animated_delta_merge_320x240
  -- --test-threads=1` to refresh the headline numbers (≈ 130 s on a
  release build). On the canonical 3-frame, 3-cluster fixture the
  pinned numbers are: full-frame lossless = 685,262 bytes, single-bbox
  Delta = 583,870 bytes (3 ANMFs), multi-rect Delta = 228,762 bytes
  (7 ANMFs) — multi-rect Delta saves **66.6%** vs full-frame lossless.
  Test `slow_delta_mode_320x240_multi_rect_pins_headline_byte_count`
  pins the wire-size headline; companion test
  `slow_delta_mode_320x240_multi_rect_round_trip_pixel_identical`
  verifies the larger-canvas multi-rect round-trip stays pixel-
  identical (the smaller default 160×120 round-trip test isn't a
  regression watchdog at 320×240 because the merge / sub-rect math
  scales with canvas size).

- *(anim-encoder)* **opt-in SSIM-lite cost model for
  `AnimFrameMode::Delta`** — new `DeltaConfig::enable_ssim_cost: bool`
  (default `false`, preserves existing SAD-based behaviour) swaps the
  default luminance-biased SAD per-block cost for a single-scale
  SSIM-lite cost (`(1 - SSIM) * 10000`) computed on the BT.601 luma
  channel. Skips the multi-scale Gaussian-pyramid for ≈ 4–10× lower
  per-block cost vs full MS-SSIM. The SSIM-lite cost path uses the
  separate `DeltaConfig::ssim_threshold: u32` (default 50, ≈ 0.005
  SSIM gap) so the SAD and SSIM defaults stay independent. Catches
  low-contrast structural changes that SAD's luma-weighted-pixel-diff
  underweights — worked example: an 8×8 block where 8 stripe pixels
  shift luma 130→128 against a uniform luma-128 background scores
  SAD 24 (≤ default threshold 32 → "unchanged") but SSIM cost 73 (>
  default `ssim_threshold` 50 → "changed"). Builder methods
  `DeltaConfig::enable_ssim_cost(bool)` and
  `DeltaConfig::ssim_threshold(u32)` mirror the field setters. Tests
  `ssim_cost_block_low_contrast_diff_picks_higher_cost_than_sad`,
  `ssim_cost_block_identical_inputs_returns_zero`, and
  `ssim_cost_threshold_dispatches_correctly_via_config` pin the
  per-block math + the dispatcher gate.

- *(anim-encoder, tests)* **mid-density adaptive budget validation** —
  closes a coverage gap where the adaptive `max_components` ramp's
  ≤ 5% (LO) and ≥ 30% (HI) extremes had integration-test fixtures but
  the 5–30% mid-band only had a unit-test pin (no end-to-end fixture).
  New integration test `delta_mode_mid_density_picks_adaptive_budget_8`
  uses a 4×4 grid of 16×16 stamps on a 160×120 canvas (cluster
  density ≈ 21.3% → budget = 8) and pins three independent properties:
  the new `debug_cluster_density` probe observes the expected density,
  the new `debug_adaptive_max_components` probe maps it to budget = 8,
  and the encoder's adaptive output matches an explicit
  `max_components_override(8)` byte-for-byte while differing from
  `Some(16)` (proving we're in the mid-band, not silently clipped).
  Companion test `delta_mode_mid_density_round_trip_pixel_identical`
  exercises the merge-to-budget step on the same fixture (8 of 16
  clusters merge into nearest neighbours) and verifies the round-trip
  reconstructs each input frame pixel-identically — the first test
  that catches a merge-step pixel-drop regression.

- *(anim-encoder)* **adaptive `max_components` budget for
  `AnimFrameMode::Delta`** — replaces the fixed `max_components: u32 = 8`
  field on `DeltaConfig` with `max_components_override: Option<u32>`
  (None = adaptive, the new default). The adaptive path computes a
  per-frame `cluster_density = sum(cluster_pixels) / canvas_pixels`
  and maps it to a content-aware sub-rect cap: density ≤ 5% → 16
  rects (scattered tiny clusters benefit from more rects), density ≥
  30% → 4 rects (one big cluster → small budget, super-rect collapse
  cheap), linear interpolation in between. Callers that need a fixed
  budget call the new `DeltaConfig::max_components_override(n)`
  builder-style setter (or set the field directly). The 3-cluster
  scattered-stamps fixture (cluster density ≈ 4%) keeps all 3 clusters
  separate with the new adaptive default — wire-size unchanged from
  the previous fixed-8 default. Test
  `delta_mode_adaptive_budget_keeps_low_density_clusters_separate`
  pins the behaviour; `adaptive_max_components_pins_documented_density_band`
  unit-tests the density → budget mapping.

- *(anim-encoder)* **auto inner-encode lossy fallback for Delta-mode
  sub-rect tiles** — new `DeltaConfig::auto_inner_threshold_bytes:
  Option<u32>` (default `None`) opts each Delta-mode sub-rect tile
  into a lossless-vs-lossy candidate race when the tile's lossless
  VP8L payload exceeds the threshold. Tiles below the cutoff stay
  lossless (no quality loss for the common-case small-tile path);
  tiles above the cutoff produce both a lossless and a lossy VP8 +
  ALPH (at the new `DeltaConfig::auto_inner_quality: f32` knob,
  default 75) candidate and the byte-smaller wins on disk. Full-
  canvas frames (the always-full first frame + cost-model bbox-too-
  large fallback) ignore the threshold and always stay lossless to
  preserve canvas-baseline round-trip semantics. Closes the "lossless
  for small tiles, lossy for large busy tiles" common-case wire-size
  win — on a 64×64 fixture with a noisy 32×32 delta sub-rect the
  file shrinks from 3328 B (lossless-only baseline) to 1244 B
  (auto-inner with threshold = 256 B) — ≈ 63% reduction. Tests
  `delta_mode_auto_inner_encode_picks_lossy_for_busy_tile` and
  `delta_mode_auto_inner_encode_keeps_small_tiles_lossless`.

- *(anim-encoder)* **multi-rect ANMF for `AnimFrameMode::Delta`** —
  the per-frame cost-model now runs a 4-connected-component pass on
  the changed-block grid and emits one ANMF sub-rect per disjoint
  cluster (instead of a single bounding box of all changes). Wins on
  scattered-change content like a UI with two independent spinners or
  a HUD with three separate counters where the single-bbox cover
  would span almost the full canvas. New `DeltaConfig::max_components`
  knob (default 8) caps the per-frame sub-rect count; when the
  cost-model finds more clusters than the budget, the smallest are
  iteratively merged with their nearest neighbour (axis-aligned
  inter-bbox squared-distance). Sub-rects within a logical input
  frame use `duration_ms = 0` for every tile except the last (which
  carries the input frame's duration), so total display time is
  preserved across the round-trip — decoded `WebpFrame` count exceeds
  the input frame count when multi-rect kicks in. On a 160×120
  3-cluster fixture (16×16 stamps at top-left/centre/bottom-right),
  file size drops from 98 532 B (single-bbox baseline) to 56 256 B
  (≈ 43 % saving).
  Single-cluster frames degrade gracefully to the historical single-
  bbox path. Set `max_components = 1` to force the historical
  behaviour.

- *(anim-encoder)* **`AnimFrameMode::Delta` AVIF-style perceptual
  frame-merge** — a new [`AnimFrameMode`] variant that opts each
  non-first frame into block-level dirty-rect detection. The encoder
  walks the canvas in `block_size × block_size` blocks (default 8×8)
  and computes a luminance-biased sum-of-absolute-differences cost
  per block (`|Δluma| + ¼·(|ΔR| + |ΔG| + |ΔB|) + |Δα|`, BT.601 luma).
  Blocks with cost > `threshold` (default 32) flag as changed; the
  encoder takes the bounding box of changed blocks, encodes only the
  sub-rectangle as a `VP8L` tile, and emits an ANMF with
  `blending_method = 1` (DoNotBlend — the decoder overwrites the
  prior-frame canvas region rather than alpha-blending). When the
  bbox covers more than `max_bbox_fraction` of the canvas (default
  0.8) the frame falls back to a full-canvas encode. Identical
  consecutive frames collapse to a 1×1 minimal-overwrite tile so the
  duration counter still ticks. The first frame is always full-canvas.
  On a 160×120 fixture with a 32×32 changing corner block (≈ 5% of
  canvas) the per-frame ANMF payload drops from ≈110 bytes (full-
  canvas Lossless baseline) to ≈44 bytes (≥ 80% wire-size reduction);
  the decoder reconstructs each frame's canvas pixel-identically with
  the source (Delta mode emits VP8L sub-rect tiles end-to-end).
  Caller constraints (validated at encode time): every frame must be
  canvas-sized, at origin (0, 0), with `blend = false` and
  `dispose_to_background = false` — the cost-model needs the prior
  frame's full canvas as the reference. New `DeltaConfig` struct
  exposes `block_size`, `threshold`, `max_bbox_fraction` knobs.

- *(anim-decoder)* **`WebpAnimDecoder::next_frame_borrowed()`
  zero-clone canvas view** — returns a `WebpAnimFrameRef<'_>` whose
  `rgba: &[u8]` borrows directly into the decoder's persistent canvas,
  saving the per-frame `canvas_w * canvas_h * 4` byte clone the owned
  `next_frame()` path makes. Same scalar metadata as `WebpAnimFrame`
  (`pts_ms` / `duration_ms` / `is_keyframe` / blend / dispose flags
  + frame bbox); `to_owned()` adapter promotes the borrow into a
  `WebpAnimFrame` for callers that want to retain a snapshot.
  Lifetime is clamped to `&mut self`, so the borrow-checker stops
  any later mutating call (`next_frame{,_borrowed}` / `seek_to_frame`
  / `reset`) from invalidating the view under the caller's feet.
  Disposal handling is consistent with `next_frame` — the previous
  frame's deferred `dispose_to_background` bbox is wiped at the start
  of the next pull, never under a live borrow.
  Useful for callers that just blit each frame to a sink and discard
  it (UI preview rendering, frame streaming over a socket, "convert
  animation to a sequence of PNGs", etc).
- *(demux)* **Streaming `Demuxer` impl** — the WebP container demuxer
  now emits packets one-at-a-time from `next_packet()` instead of
  pre-computing the full `Vec<Packet>` at `open` time. The lazy
  RIFF parser (`parse_webp_body_lazy`) walks the chunk tree once;
  per-packet OWEB payloads are materialised on demand from
  `(offset, length)` ranges into the owned body buffer via the new
  `encode_lazy_frame_payload` helper. Same wire format as before
  (the registry-side `WebpDecoder` reads OWEB without caring whether
  the producer was lazy or eager); same PTS/DTS/keyframe-flag
  arithmetic. Working set during demuxing drops from O(N×payload)
  to O(payload) for an N-frame animation. Pairs naturally with the
  streaming `WebpAnimDecoder` so end-to-end demux+decode works at
  one frame's-worth of memory.

- *(anim-decoder)* **`WebpAnimDecoder::seek_to_frame(idx)` random-
  access** — positions the decoder so the next `next_frame()` call
  returns frame `idx`. Animated WebP carries cross-frame state
  (each ANMF blends or overwrites onto a persistent canvas, with
  optional dispose-to-background after rendering), so the
  implementation rewinds to frame 0 and replays frames `0..idx`
  against the canvas. Same shape + semantics as libwebp's
  `WebPAnimDecoderReset` + N×`WebPAnimDecoderGetNext` sequence.
  `target == 0` is equivalent to `reset()`; `target == frame_count`
  lands at end-of-stream; `target > frame_count` is rejected.
  Backward seeks reset and replay; forward seeks from current
  position skip the rewind. The replay's intermediate frames are
  consumed internally without queueing — memory cost is one
  `WebpAnimFrame` worth + the persistent canvas at any moment.
  Ergonomic API for UI scrubbers and "skip to keyframe" tooling
  over animations whose loop count exceeds 1.
- *(anim-decoder)* **Memory-tight streaming demux** — the lazy
  parser (`crate::demux::parse_webp_body_lazy`) walks the RIFF
  chunk tree once and records per-frame VP8/VP8L/ALPH bitstreams
  as `(offset, length)` ranges into a single owned body buffer,
  instead of cloning each chunk into per-frame `Vec<u8>`. For a
  1000-frame animation the savings are ~1000 fewer allocations +
  the file size's worth of avoided memcpy traffic; the actual
  bitstream slice is handed to the codec (VP8 / VP8L / ALPH-VP8L)
  zero-copy until the per-frame decode runs. The eager
  `decode_webp` path keeps using the owned `parse_webp_body` so
  existing callers see no observable change. Internal:
  `LazyParsedContainer`, `LazyParsedFrame`, `LazyImageRef`,
  `LazyAlphRef`, `decode_lazy_frame_to_rgba`. The `ChunkRef`
  iterator now exposes `payload_offset` so both paths share the
  same chunk walker.

- *(anim-decoder)* **Streaming animated WebP decoder** —
  `WebpAnimDecoder::new(bytes)` builds a pull-driven decoder that
  yields one `WebpAnimFrame` per `next_frame()` call. Mirrors
  libwebp's `WebPAnimDecoder` shape: `info()` returns
  `WebpAnimInfo { canvas_width, canvas_height, frame_count,
  loop_count, background_rgba, metadata }` up front, `next_frame()`
  composites each ANMF tile against a persistent RGBA canvas
  (honouring blend / dispose flags + the ANIM-chunk BG colour),
  `reset()` rewinds to frame 0 (re-filling the canvas with the
  RFC 9649 §2.5 background), `done()` flags end-of-animation. Each
  emitted frame carries `pts_ms` (cumulative, with the spec-floored
  `1`-ms minimum), `duration_ms`, the canvas-state RGBA snapshot,
  the `is_keyframe` / `blend_with_previous` /
  `dispose_to_background` flags, and the on-disk frame bbox. Lets
  callers stop early (preview thumbnails, "show first 5 frames")
  without paying the full-decode cost of `decode_webp`. Simple-
  layout (non-animated) files surface as a 1-frame animation so
  consumers can use one code path for both flavours. New types
  re-exported at the crate root: `WebpAnimDecoder`, `WebpAnimFrame`,
  `WebpAnimInfo`. Implementation in `src/anim_decoder.rs` reuses the
  existing `parse_webp_body` + `decode_parsed_frame_to_rgba` +
  `composite` helpers — no duplication of the disposal/blend state
  machine.
- *(encoder-vp8l)* **EXIF / XMP / ICC chunk passthrough on the
  registry-side `Vp8lEncoder` adapter** — new
  `crate::encoder::make_encoder_with_metadata(&CodecParameters,
  WebpMetadataOwned)` factory mirrors the VP8 lossy
  `make_encoder_with_qindex_and_metadata` /
  `make_encoder_with_quality_and_metadata` factories on the
  lossless side. Until now only the standalone
  `encode_vp8l_argb_with_metadata` could attach metadata to a
  lossless WebP through the registry; the registry-side encoder
  hard-coded `WebpMetadata::default()` so callers going through
  `Box<dyn Encoder>` had no way to surface their colour profile.

### Changed

- *(anim-encoder)* **`DeltaConfig::auto_inner_threshold_bytes` default
  flipped from `None` to `Some(4096)`** — out-of-the-box Delta-mode
  encodes now run the per-sub-rect lossy/lossless race for any
  sub-rect tile whose lossless VP8L payload exceeds 4 KB. Real-world
  animations with noisy delta regions benefit (~63% reduction observed
  on a 128×128 fixture with a noisy 64×64 sub-rect: 12.5 KB → 4.6 KB).
  Pixel-identical round-trip semantics are preserved for sub-rect
  tiles that fit in 4 KB lossless. The builder
  `DeltaConfig::auto_inner_threshold_bytes(...)` now takes
  `Option<u32>` (was `u32` for "set to `Some(bytes)`"); pass `None` to
  opt out and force every sub-rect tile to stay lossless regardless of
  size (preserves the pre-default-change semantics for every tile).
  New test
  `delta_mode_default_auto_inner_threshold_beats_explicit_none_baseline_on_busy_tile`
  pins the wire-size win of the new default vs explicit `None`.

- *(anim-encoder)* **`DeltaConfig::max_components: u32` removed,
  replaced with `max_components_override: Option<u32>`**. Source-level
  break (no on-disk format change). Callers passing
  `max_components: 1` (force single-bbox) now write
  `DeltaConfig::default().max_components_override(1)`. Default
  behaviour switches from the previous fixed cap of 8 to the
  cluster-density-aware adaptive ramp described in the new
  "adaptive `max_components` budget" Added entry above.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).