### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 131 (2026-05-25).** Published §2.5 `VP8 ` (lossy)
+  **encoder API surface** — the `encode_vp8_lossy_rgba` /
+  `encode_vp8_lossy_rgb24` / `encode_vp8_lossy_yuv420p` /
+  `encode_vp8_lossy_yuva420p` free functions, the new `encoder_vp8`
+  module with `make_encoder_with_quality` / `_with_qindex` /
+  `_with_target_size` (and `_and_metadata` / `_and_freq_deltas`
+  variants), `Vp8FreqDeltas`, `Vp8PsyStats`, `compute_psy_stats`,
+  `freq_deltas_for_qindex`, `quality_to_qindex`,
+  `DEFAULT_QUALITY` / `QUALITY_MIN..=QUALITY_MAX` / `QINDEX_MIN..=QINDEX_MAX`,
+  and the registry-side `CODEC_ID_VP8 = "webp_vp8"` codec id with the
+  `WebpVp8LossyEncoder` `Encoder` trait impl + `make_vp8_lossy_encoder`
+  factory. **Status:** API-shape stubs. Every entry point validates
+  input dims / buffer length and then returns
+  `WebpError::Unsupported` (free functions) /
+  `oxideav_core::Error::Unsupported` (trait impl). The wiring to a
+  real VP8 lossy bitstream is blocked on the §13 / §14 pixel-driven
+  encode round on the `oxideav-vp8` sibling crate: the current
+  `oxideav-vp8 = "0.2"` encoder ships Phase 1
+  ([`oxideav_vp8::encode_silent_keyframe`]) which emits a structurally
+  valid VP8 keyframe but **ignores the caller's pixels** (every MB is
+  `mb_skip_coeff = 1` with `DC_PRED` → constant-grey picture). Wiring
+  that through to a WebP RIFF wrapper would produce garbage bytes —
+  the exact failure mode the round-131 directive forbids — so this
+  round lands the API shape only and reports the gap. The
+  `encoder_vp8` module-level doc-comment enumerates the precise
+  missing primitives on `oxideav-vp8` (forward WHT / forward DCT /
+  forward quantization / per-MB pixel-driven encode driver / top-level
+  I420 → keyframe driver). Once those land, the function bodies become
+  a thin call into the new vp8 encoder + the existing
+  `build::build_webp_file` RIFF wrapper — no API churn. 18 new
+  published-API tests + 4 new inline unit tests; total 380 (was 347).
+
 * **Clean-room round 130 (2026-05-25).** §5.2.2 **width-aware distance-code
   chooser** for the VP8L lossless encoder. Each backward reference now
   picks the smaller of the scan-line code (`D + 120`, the round-119

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 138 (2026-05-26).** **`build::build_webp_file_with_metadata`
+  — typed §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / §2.7.1.5 `XMP ` writer at
+  the container-builder layer.** The high-level
+  `encode_vp8l_argb_with_metadata` (round 115) already framed metadata
+  inline for the VP8L pixel path; round 138 lifts the same logic into
+  the standalone `build::` module so external encoders can wrap any
+  `VP8 ` / `VP8L` bitstream payload with the §2.7 metadata chunks
+  without re-implementing the chunk-ordering rule. A new
+  [`build::MetadataPayloads`] borrowed bag carries the three optional
+  payloads; the writer picks the simple §2.5 / §2.6 layout when the bag
+  is empty (byte-for-byte identical to `build::build_webp_file`) and
+  auto-promotes to the §2.7 extended layout when any kind is present.
+  The emitted chunk order matches RFC 9649 §2.7 verbatim: `VP8X` first,
+  `ICCP` before the bitstream, the `VP8 ` / `VP8L` bitstream, then
+  `EXIF` and `XMP ` after — and the §2.7.1 flag octet (`I` / `E` / `X`
+  bits) declares exactly the kinds that follow, never an extra
+  unconditional OR. Twelve new tests in `build::tests` cover: empty
+  metadata + simple kind = byte-for-byte equivalence to
+  `build_webp_file`; simple kind + metadata auto-promotes to extended
+  with the right flag set; all-three-set emits in §2.7 order; per-kind
+  isolation (each of ICC / Exif / XMP individually sets only its own
+  flag and emits only its own chunk); odd-length payloads trigger the
+  §2.3 pad byte; empty metadata payloads (zero-length) still emit the
+  chunk + set the flag; extended kind + empty metadata matches
+  `build_webp_file`; canvas-validation errors propagate. Five new
+  integration tests in `tests/published_encode_api.rs` cover the
+  per-kind isolation at the published-API level
+  (`encode_vp8l_argb_with_metadata` + `extract_metadata`) plus a
+  round-trip through `build::build_webp_file_with_metadata` with a real
+  VP8L bitstream.
+
 * **Clean-room round 137 (2026-05-26).** **Optimal length-limited Huffman
   via Package-Merge.** The round-136 encoder built canonical Huffman from
   histograms, then post-passed with a heuristic depth-limiter ("lengthen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 136 (2026-05-25).** §3.7.2.1.1 **simple code length
+  code** emission for the VP8L lossless encoder. The encoder previously
+  always wrote each of the five prefix codes' length tables with the
+  §3.7.2.1.2 *normal code length code* (a 19-symbol code-length-code plus
+  per-symbol lengths). It now dispatches to the cheaper §3.7.2.1.1
+  *simple* form whenever the length table describes 1 or 2 symbols at
+  code length 1, all in the `[0..255]` range the simple form admits —
+  exactly the form `build_code_lengths` produces for single-color
+  channels and the empty distance code. The simple form encodes the
+  whole table in 3–11 bits (`%b1` flag + 1-bit `num_symbols-1` + 1-bit
+  `is_first_8bits` + a 1- or 8-bit `symbol0` + an optional 8-bit
+  `symbol1`), versus the normal form's ≥18-bit header, and picks the
+  narrow 1-bit `symbol0` field for the very common single-symbol-0
+  (empty) distance code. Both forms describe the identical length table,
+  so per-symbol code emission and the decoder's reconstruction are
+  unaffected; the choice only shrinks the meta-block header. Bit-exact
+  round trip holds on every fixture. Headline measurement: re-encoding
+  the seven lossless fixtures totals **1634 B with the simple path vs
+  2658 B normal-only — a 1024 B (38.5 %) header reduction**, ranging
+  from −81.6 % on `lossless-1x1` (174 → 32 B) and −75.6 % on
+  `lossless-32x32-rgb` (328 → 80 B) down to −16.8 % on the natural
+  128×128 image (1038 → 864 B). Six new inline tests cover the
+  `simple_code_symbols` classifier (1-symbol / 2-symbol eligible;
+  length≠1, 3-symbol, symbol>255, all-zero ineligible), the 1- and
+  2-symbol round trips through the round-104 prefix reader, and the
+  measured byte win over the normal form for the empty distance code.
+
 * **Clean-room round 135 (2026-05-25).** §3.5.4 / §4.4 **color-indexing
   (palette) transform encoding** for the VP8L lossless encoder — the
   last unimplemented VP8L transform on the encode side. When the image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 139 (2026-05-26).** **VP8L lossless encoder
+  *near-lossless* preprocessing.** A new
+  [`near_lossless`](src/near_lossless.rs) module exposes the in-place
+  RGB-channel quantizer `near_lossless::apply(&mut [u32], quality)` plus
+  its out-of-place sibling `near_lossless::quantize`; both round each
+  color channel to the nearest multiple of `2^n` where
+  `n = bits_to_drop_for_quality(quality)` per the documented mapping
+  `n = clamp((100 - q + 19) / 20, 0, 5)` — `q = 100` → 0 (no-op),
+  `q ∈ 80..=99` → 1, `q ∈ 60..=79` → 2, `q ∈ 40..=59` → 3,
+  `q ∈ 20..=39` → 4, `q ∈ 0..=19` → 5. Alpha is preserved bit-exactly
+  (the preprocessing never touches it). The new public entry point
+  [`encode_vp8l_argb_with_near_lossless(argb, w, h, has_alpha, quality)`](src/lib.rs)
+  runs the preprocessing pass and hands the (quantized) pixels to the
+  existing VP8L encoder — no decoder-side change is needed, the result
+  is a perfectly normal `VP8L` chunk that decodes back through
+  [`decode_webp`](src/lib.rs) to the quantized pixels bit-exactly.
+  RFC 9649 does not normatively define the near-lossless formula
+  (it is an encoder choice); the chosen mapping + per-channel
+  round-half-up-with-clamp rounding rule is documented in the module-
+  level docstring so reproducibility is a property of *our* encoder
+  rather than a portable cross-encoder guarantee.
+
+  **Three round-139 guarantees** are pinned by integration tests in
+  [`tests/published_near_lossless_api.rs`](tests/published_near_lossless_api.rs):
+  (a) `quality = 100` is byte-exact-equal to the baseline encoder on
+  every tested fixture (1×1, 3×5, 7×4, 16×16, 64×64 natural-gradient,
+  96×96 noisy); the no-op fast path returns from
+  `encode_vp8l_argb_with` directly. (b) `quality = 60` produces a
+  strictly smaller bitstream than `quality = 100` on a deterministic
+  96×96 high-entropy fixture (27,770 B → 20,860 B, **−24.9 %**) with
+  PSNR 46.25 dB — well above the test's ≥ 40 dB floor. (c) Decoder
+  round-trip recovers the quantized ARGB exactly at q=60 and q=0; alpha
+  round-trips unchanged through the full encode-decode cycle at q=40 on
+  a non-opaque image. Quality table on the noisy fixture: q=100 →
+  27,770 B (identity); q=95 / q=80 → 24,327 B / 51.20 dB; q=60 →
+  20,860 B / 46.25 dB; q=40 → 17,394 B / 40.43 dB; q=20 → 13,916 B /
+  34.09 dB; q=0 → 10,451 B / 27.45 dB.
+
+  Twelve new inline tests cover: the `bits_to_drop_for_quality` bucket
+  table, monotonic non-decreasing behaviour as quality drops, the
+  `quantize_channel` identity at `n = 0`, round-to-nearest behaviour at
+  `n = 1` and `n = 2`, the `255 → largest multiple of step ≤ 255` clamp
+  rule (`n = 1` → 254, `n = 2` → 252, `n = 5` → 224), the documented
+  error bounds (`step - 1` worst case across the upper clamp window,
+  `step / 2` tighter bound outside it), and `result % step == 0` over
+  every byte value × `n` combination. ARGB-level tests cover the
+  byte-for-byte identity at `q = 100` and `q > 100`, alpha preservation
+  across every quality level, the `q = 60 → multiples of 4` invariant,
+  per-channel error bound across `[0..255]` for every quality, and
+  apply/quantize equivalence at every quality step. Nine integration
+  tests + 1 measurement helper exercise the three guarantees end-to-end
+  plus dimension-mismatch error propagation and the alpha-through-the-
+  full-decode-cycle case. Total: **453** tests green (+20 from round
+  138).
+
 * **Clean-room round 138 (2026-05-26).** **`build::build_webp_file_with_metadata`
   — typed §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / §2.7.1.5 `XMP ` writer at
   the container-builder layer.** The high-level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 137 (2026-05-26).** **Optimal length-limited Huffman
+  via Package-Merge.** The round-136 encoder built canonical Huffman from
+  histograms, then post-passed with a heuristic depth-limiter ("lengthen
+  the deepest leaf, shorten a short one to keep the Kraft sum at 1") when
+  the unconstrained tree depth exceeded the spec's 15-bit cap. On
+  cap-triggering histograms the heuristic is only *locally* optimal; the
+  globally-optimal length assignment under the depth cap is given by the
+  Package-Merge algorithm (Larmore–Hirschberg 1990) applied to the
+  coin-collector reformulation of length-limited Huffman. `build_code_lengths`
+  now invokes a from-scratch Package-Merge implementation when (and only
+  when) the unconstrained tree exceeds [`MAX_CODE_LENGTH`]; histograms whose
+  unconstrained tree already fits under the cap continue to use the
+  unconstrained build (which is itself optimal). The result is a
+  weakly-smaller bit cost ∑ freq[s]·len[s] on every input that triggers the
+  cap, and identical output on every input that does not — so the
+  round-trip stays bit-exact on every existing fixture (414/414 tests
+  green, including all seven lossless fixtures). Headline measurement on
+  a pathological Fibonacci(25) frequency vector (unconstrained tree depth
+  24, well past the 15-bit cap): **−759 bits (~95 bytes) vs the round-136
+  heuristic**, with both forms remaining complete (Kraft sum 1) and
+  cap-honouring. The earlier Fibonacci(20) case yields a smaller but real
+  −26-bit win. The heuristic limiter is retained as `#[cfg(test)]`-only
+  scaffolding so the comparison tests can demonstrate the strict-win
+  delta. Eight new inline tests cover: single-symbol / two-symbol
+  short-circuit, Kraft completeness over four histograms (uniform, mild
+  skew, ramp, Fibonacci), agreement with unconstrained Huffman when the
+  cap is not triggered, the strict-win pathological cases (Fibonacci(20)
+  and Fibonacci(25)), the `build_code_lengths` fallback dispatch, and a
+  bit-exact round trip through the round-104 prefix reader.
+
 * **Clean-room round 136 (2026-05-25).** §3.7.2.1.1 **simple code length
   code** emission for the VP8L lossless encoder. The encoder previously
   always wrote each of the five prefix codes' length tables with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 142 (2026-05-26).** **Chainable
+  `AnimFrame::with_blend(BlendingMethod)` and
+  `AnimFrame::with_dispose(DisposalMethod)` builders for the §2.7.1.1
+  `B` (blending) and `D` (disposal) info-byte bits.** The underlying
+  fields were already public on `AnimFrame` since round 118, but the
+  published-0.1.5 surface only exposed the literal-construction path;
+  the new helpers complete the chainable-builder pattern alongside
+  `with_near_lossless_quality` (r140) and the `AnimFrame::new(…)`
+  constructor. Both helpers consume the receiver and return `Self`, so
+  they compose with each other and with the existing builders in any
+  order. No new public fields; no behavioural change to existing
+  encoder output (the literal-construction path was already wired).
+
+  Six new integration tests in
+  [`tests/published_anim_blend_dispose_api.rs`](tests/published_anim_blend_dispose_api.rs)
+  pin the end-to-end semantics through `decode_webp`'s §2.7.1.1
+  compositor: (a) opaque-source alpha-blend short-circuits to byte-
+  exact round-trip; (b) a 2×2 translucent (alpha=128) BLUE sub-frame
+  over an 8×8 opaque RED keyframe blends to the spec-formula bit-
+  exact `(127, 0, 128, 255)`; (c) the same setup with Overwrite blits
+  the translucent source verbatim into the canvas; (d) a 2×2 GREEN
+  frame with dispose=Background between RED keyframe and 2×2 BLUE
+  frame produces a third-frame snapshot whose `(2..4, 2..4)` rect is
+  the ANIM bg, not GREEN; (e) the mirror case with dispose=None leaves
+  GREEN on the canvas under the next frame; (f) the integrated case
+  where AlphaBlend + Background dispose compose on the same frame
+  produces the blended pixels in the f1 snapshot and the bg-cleared
+  rect in the f2 snapshot.
+
+  Six new inline unit tests confirm the `new()` blend/dispose
+  defaults (`Overwrite` / `None`), the per-method builder round-trip
+  for each, the chaining behaviour against `with_near_lossless_quality`,
+  and the §2.7.1.1 Figure 9 info-byte emission for each `B` and `D`
+  bit. Total: **485** tests green (was 473: +12 from this round).
+  Default and `--no-default-features` builds both clippy + fmt clean.
+
 * **Clean-room round 141 (2026-05-26).** **Animation-wide near-lossless
   default in `AnimEncoderOptions`.** The new
   `AnimEncoderOptions::default_near_lossless_quality: Option<u8>` field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 134 (2026-05-25).** §4.2 **color (cross-channel
+  decorrelation) transform encoding** for the VP8L lossless encoder.
+  The encoder tiles the image into `1 << size_bits` square blocks
+  (`size_bits = 4`, 16×16) and, for each block, picks the three
+  signed-8-bit `ColorTransformElement` coefficients (`green_to_red` /
+  `green_to_blue` / `red_to_blue`) by a coordinate-descent search over
+  a coarse 3.5-fixed-point grid, scored with the same wrap-aware
+  sum-of-absolute-residuals proxy the predictor uses; the all-zero
+  (identity) element is always the search origin so a block with no
+  usable correlation keeps the no-transform residual. It writes the
+  §3.8.2 `color-tx` header (`%b1` present, transform type 1, 3-bit
+  `size_bits - 2`), the sub-resolution color image as an
+  `entropy-coded-image` (the §4.2 layout: alpha 255, red =
+  `red_to_blue`, green = `green_to_blue`, blue = `green_to_red`), then
+  the residual main image as a §3.8.3 `spatially-coded-image`. The
+  forward `ColorTransform` (subtract the three deltas, using the
+  *original* red for the `red_to_blue` term) is the exact inverse of
+  the decoder's `inverse_color`, which restores red before re-adding
+  the blue delta — bit-exact across the modulo-256 wrap. The color
+  path is a new candidate in `encode_argb_literals_with_width_selected`
+  alongside the round-133 predictor and round-132 subtract-green ×
+  cache cross-product; the chooser emits whichever candidate is
+  smallest and never regresses. Headline measurement: a 64×64 image
+  with high-entropy green and fractional-slope red/blue shrinks from
+  7904 B (best non-color path) to 7026 B (color) — an 11 % size
+  reduction. Five new inline tests cover the forward/inverse per-pixel
+  round trip (including the signed [128..255] coefficient range), the
+  sub-image layout, the correlated-image size win + round trip, a noisy
+  non-power-of-two round trip, and a no-regression check on
+  uncorrelated noise.
+
 * **Clean-room round 133 (2026-05-25).** §3.5.1 / §4.1 **predictor
   (spatial) transform encoding** for the VP8L lossless encoder. The
   encoder tiles the image into `1 << size_bits` square blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 141 (2026-05-26).** **Animation-wide near-lossless
+  default in `AnimEncoderOptions`.** The new
+  `AnimEncoderOptions::default_near_lossless_quality: Option<u8>` field
+  lets callers set the VP8L near-lossless preprocessing knob **once for
+  the whole animation** instead of repeating it on every
+  [`AnimFrame::near_lossless_quality`]. Resolution order at encode time:
+  per-frame `Some(q)` always wins; per-frame `None` falls back to the
+  options-level default; both `None` is the pre-round-140 baseline
+  (no quantization, byte-exact-equal to the baseline encoder, identical
+  to `Some(100)` in either slot). A builder helper
+  `AnimEncoderOptions::with_default_near_lossless_quality(Option<u8>) -> Self`
+  matches the rest of the chainable options surface.
+
+  The default is threaded through to *both* the full-keyframe
+  ([`AnimFrameMode::Lossless`]) and dirty-rect
+  ([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths
+  via a single `effective_quality = frame.q.or(opts.default_q)`
+  resolution in `build_animated_webp_with_options`'s per-frame loop, so
+  the round-140 per-frame-knob behaviour and the round-141
+  options-default behaviour share the exact same downstream quantization
+  call and produce bit-identical per-frame ANMFs given the same
+  effective quality.
+
+  **Measured deltas (3-frame 64×64 noisy fixture, deterministic
+  xorshift32 seeds 0/1/2):** baseline (default `None`) 37,364 B (ANMFs
+  ~12,432 each). Options default `Some(60)` with no per-frame
+  overrides: 28,180 B (**−24.58 %** overall), each ANMF ~9,368 B
+  (**−24.66 %** / **−24.58 %** / **−24.63 %**) — byte-for-byte
+  equivalent to the round-140 per-frame `Some(60)` output. Mixed
+  (default `Some(60)`, frame 1 overridden to `Some(100)`): 31,236 B
+  (**−16.40 %** overall); frames 0 and 2 shrink to 9,368 B each
+  (default applied), frame 1 stays at 12,432 B exactly (override wins,
+  matches baseline ANMF byte-for-byte). The per-frame chunk sizes are
+  cross-checked against the corresponding "all `Some(60)`" and "all
+  `Some(100)`" files inside the test.
+
+  Seven new integration tests in
+  [`tests/published_anim_default_near_lossless_api.rs`](tests/published_anim_default_near_lossless_api.rs)
+  cover (a) default-only equals per-frame-only byte-for-byte, (b)
+  default `None` equals the convenience baseline, (c) default `Some(255)`
+  clamps to the baseline no-op, (d) per-frame `Some(q)` overrides the
+  default in either direction, (e) decoder round-trip recovers
+  `near_lossless::quantize(src, q)` exactly when the default supplies
+  the quality, and (f) the default flows through to the Delta
+  dirty-rect path the same way the per-frame knob does. Two new inline
+  unit tests confirm the new field defaults to `None` and the
+  `with_default_near_lossless_quality` builder round-trips. Default +
+  `--no-default-features` builds clippy + fmt clean.
+
 * **Clean-room round 140 (2026-05-26).** **Per-frame near-lossless
   preprocessing in the animated-WebP encoder.** The round-139 still-image
   `near_lossless::apply` preprocessor is now wired into the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 143 (2026-05-26).** **Chainable
+  `AnimEncoderOptions::with_default_lossy_quality(Option<u8>) -> Self`
+  builder and matching `default_lossy_quality: Option<u8>` field,
+  symmetric to the round-141
+  `AnimEncoderOptions::with_default_near_lossless_quality` /
+  `default_near_lossless_quality` pair.** Lets callers configure their
+  full encoder shape (lossy + near-lossless animation-wide defaults)
+  through one chainable builder surface today, ahead of the VP8 lossy
+  encode body landing.
+
+  **API-shape stub.** The VP8 lossy encode path is blocked on the
+  `oxideav-vp8` per-MB driver (workspace task #1041); the existing
+  `AnimFrameMode::Lossless` / `Delta` / `Auto` emission paths are
+  lossless-only and ignore this field. The contract pinned by the new
+  tests: setting `default_lossy_quality` to any value (`Some(0)` …
+  `Some(255)` / `None`) produces output **byte-exact-equal** to the
+  baseline `None` bytes, on both the full-keyframe and dirty-rect
+  Delta paths, and does not perturb the round-141 near-lossless
+  default's existing behaviour when both knobs are set together.
+
+  Six new integration tests in
+  [`tests/published_anim_default_lossy_api.rs`](tests/published_anim_default_lossy_api.rs)
+  cover (a) field defaults to `None`, (b) builder round-trips
+  `Some(80)` / `None` and composes with `with_default_near_lossless_quality`
+  in either order, (c) the two defaults are stored in independent
+  fields (struct-literal + dual-builder equivalence), (d) lossy
+  default is byte-exact no-op on the Lossless keyframe path across
+  `Some(0)`/`50`/`75`/`100`/`255`/`None`, (e) byte-exact no-op on
+  the Delta dirty-rect path, (f) byte-exact no-op when overlaid on a
+  `default_near_lossless_quality = Some(60)` baseline. Four new inline
+  unit tests confirm the default, the builder round-trip, independence
+  from the near-lossless default (copy-paste-swap guard), and the
+  encoder no-op contract on a 4×4 fixture. Total: **495** tests green
+  (was 485: +10 from this round). Default and `--no-default-features`
+  builds both clippy + fmt clean.
+
 * **Clean-room round 142 (2026-05-26).** **Chainable
   `AnimFrame::with_blend(BlendingMethod)` and
   `AnimFrame::with_dispose(DisposalMethod)` builders for the §2.7.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 132 (2026-05-25).** §5.2.3 **color-cache
+  size-selection chooser** for the VP8L lossless encoder. The
+  round-121 chooser evaluated a single `code_bits = 8` candidate
+  alongside the no-cache path; the round-132 chooser evaluates a
+  five-size slate `{5, 7, 8, 9, 11}` (exposed as
+  `CANDIDATE_COLOR_CACHE_BITS`) cross-producted with the §3.8.2
+  subtract-green transform axis, and emits the smallest of the 2 × 6
+  = 12 candidates. The §5.2.3 GREEN alphabet width is `256 + 24 +
+  (1 << code_bits)`, so the prefix-code header overhead scales with
+  the chosen size — picking the smallest cache that captures the
+  image's color recurrence avoids paying for an over-sized cache.
+  New public entry point `encode_argb_literals_with_width_selected`
+  returns `(bytes, chosen_code_bits)`; the existing
+  `encode_argb_literals_with_width` keeps its `Vec<u8>` signature
+  (the `.webp` production path calls into the selected variant and
+  drops the chosen-size scalar). Headline measurement: 32×32
+  palette-heavy pseudo-random goes from 661 B (round-121, fixed
+  `code_bits=8`) to 645 B (round-132, chosen `code_bits=7`) — a
+  2.4 % saving on top of the round-121 cache writer. Noise /
+  row-correlated / solid fixtures match the round-121 size byte-for-
+  byte (the chooser correctly falls back to `code_bits=0`). The
+  §5.2.3 header read on the decoder side is unchanged (it already
+  accepted the full `[1, 11]` range per RFC 9649); round-trip stays
+  bit-exact through `decode_lossless_image`. 6 new inline tests
+  (slate-spec-legal, palette → non-zero, noise → zero, chosen-size-
+  in-slate, per-decision round-trip, never-regress vs round 121).
+  Total: 386 tests (was 380).
+
 * **Clean-room round 131 (2026-05-25).** Published §2.5 `VP8 ` (lossy)
   **encoder API surface** — the `encode_vp8_lossy_rgba` /
   `encode_vp8_lossy_rgb24` / `encode_vp8_lossy_yuv420p` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 133 (2026-05-25).** §3.5.1 / §4.1 **predictor
+  (spatial) transform encoding** for the VP8L lossless encoder. The
+  encoder tiles the image into `1 << size_bits` square blocks
+  (`size_bits = 4`, 16×16) and, for each block, scores all 14
+  prediction modes `[0..13]` by a per-channel sum-of-absolute-residuals
+  proxy (folding the modulo-256 wrap so small negative residuals score
+  low) and picks the cheapest. It writes the §3.8.2 `predictor-tx`
+  header (`%b1` present, transform type 0, 3-bit `size_bits - 2`), the
+  sub-resolution predictor image as an `entropy-coded-image` (mode in
+  the green channel, no meta-prefix per the §3.8.2 grammar), then the
+  residual main image as a §3.8.3 `spatially-coded-image`. The forward
+  predictor primitives (`Average2` / `Select` / `ClampAddSubtractFull`
+  / `ClampAddSubtractHalf` and the §4.1 left-topmost / top-row /
+  left-column / rightmost-column border rules) are bit-identical to the
+  decoder's `inverse_predictor`, so `residual = actual − pred` is the
+  exact inverse of the decoder's `final = residual + pred`. The
+  predictor path is a new candidate in
+  `encode_argb_literals_with_width_selected` alongside the round-132
+  subtract-green × cache cross-product; the chooser emits whichever
+  candidate is smallest and never regresses. Headline measurement:
+  64×64 smooth 2-D gradient goes from 10377 B (no-predictor) to 308 B
+  (predictor) — a 97 % size reduction. The residual main image and the
+  predictor sub-image each run their own §5.2.3 color-cache evaluation.
+  Round trip stays bit-exact through `decode_lossless_image`, validated
+  on smooth, noisy, and non-power-of-two (partial-block) fixtures. Four
+  new inline tests cover (a) `sub_pred`/`add_pred` inverse across the
+  wrap; (b) every selected mode ∈ `0..=13`; (c) the gradient shrinks
+  and round-trips; (d) the predictor path round-trips on noise +
+  non-power-of-two dimensions.
+
 * **Clean-room round 132 (2026-05-25).** §5.2.3 **color-cache
   size-selection chooser** for the VP8L lossless encoder. The
   round-121 chooser evaluated a single `code_bits = 8` candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-26
+
+### Other
+
+- canonical-inverse round-trip test for build/extract metadata (round 144)
+- AnimEncoderOptions::default_lossy_quality / with_default_lossy_quality (round 143)
+- AnimFrame::with_blend / with_dispose chainable builders (round 142)
+- animation-wide near-lossless default (round 141)
+- wire per-frame near-lossless preprocessing into build_animated_webp
+- add near-lossless encoder preprocessing pass
+- Round 138: build::build_webp_file_with_metadata (ICCP/EXIF/XMP)
+- optimal length-limited Huffman via Package-Merge
+- emit §3.7.2.1.1 simple code length code for 1-2 symbol codes
+- add §4.4 color-indexing (palette) transform encoding
+- add §4.2 color (cross-channel) transform encoding
+- round-133 §4.1 predictor (spatial) transform encoding
+- round-132 §5.2.3 color-cache size-selection chooser
+- published VP8 lossy encoder API surface (API-shape stub)
+- round 130 — §5.2.2 width-aware distance-code chooser
+- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
+- wire lossy decode against published DecodeError (not unpublished Vp8Error)
+- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
+- §5.2.1 / §5.2.3 color-cache writer (round 121)
+- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
+- §5.2.2 LZ77 backward-reference matching (round 119)
+- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
+- round 117 — restore published VP8L lossless-encode public names
+- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
+- add API-COMPAT.md — public API shape the rebuild must reproduce
+- round 115 — first VP8L lossless encoder (literal-only round trip)
+- register oxideav_core::Decoder into RuntimeContext (round 112)
+- wire top-level decode_webp to RGBA for VP8L (round 111)
+- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
+- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
+- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
+- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
+- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
+- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
+- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
+- round 7: typed §2.6 `VP8L` chunk routing handle
+- round 6: typed §2.5 `VP8 ` chunk routing handle
+- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
+- round 4: ANMF §2.7.1.1 typed per-frame header parse
+- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
+- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
+- in-crate copies of fixture inputs for standalone CI checkout
+- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
+- orphan rebuild: clean-room scaffold post 2026-05-20 audit
+
 ### Added
 
 * **Clean-room round 144 (2026-05-26).** **Canonical-inverse round-trip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 140 (2026-05-26).** **Per-frame near-lossless
+  preprocessing in the animated-WebP encoder.** The round-139 still-image
+  `near_lossless::apply` preprocessor is now wired into the
+  [`build_animated_webp`](src/anim_encode.rs) /
+  [`build_animated_webp_with_options`](src/anim_encode.rs) path via a new
+  optional `AnimFrame::near_lossless_quality: Option<u8>` field
+  (defaulting to `None`, the no-op identity). A builder helper
+  `AnimFrame::with_near_lossless_quality(Option<u8>) -> Self` matches the
+  rest of the per-frame chainable construction. The preprocessing is
+  applied identically to the full-keyframe
+  ([`AnimFrameMode::Lossless`]) and dirty-rect
+  ([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths —
+  each frame's quality knob feeds into its per-frame VP8L bitstream
+  independently, so an animation can mix lossless (`None` / `Some(100)`)
+  and near-lossless frames freely.
+
+  **Three round-140 guarantees** are pinned by integration tests in
+  [`tests/published_anim_near_lossless_api.rs`](tests/published_anim_near_lossless_api.rs):
+  (a) `None` (default) and `Some(100)` produce byte-exact-equal output
+  to the pre-round-140 baseline encoder on every tested fixture, so
+  existing animated-WebP test fixtures keep their bit pattern; the
+  `None | Some(q ≥ 100)` no-op short-circuit lives in
+  `apply_near_lossless_if_requested` and delegates to
+  `near_lossless::apply`. (b) `Some(60)` produces a strictly smaller
+  3-frame animated WebP than `Some(100)` on a deterministic 64×64
+  high-entropy fixture (37,364 B → 28,180 B, **−24.58 %**) with every
+  decoded per-frame PSNR ≥ 46.25 dB — well above the ≥ 40 dB floor the
+  test enforces. (c) The decoded RGBA matches the still-image
+  `near_lossless::quantize` of the source byte-for-byte (full-keyframe
+  path) and matches the f0-with-quantized-sub-rect composite for the
+  dirty-rect path; alpha round-trips unchanged at q=40 on a
+  non-opaque-alpha fixture. Per-frame chunk-size monotonicity at
+  q=80 < q=60 < q=40 < q=0 is verified on a single-frame 48×48 fixture.
+  Mixed-quality test confirms that a per-frame knob is honoured frame
+  by frame.
+
+  11 new integration tests + 1 inline builder-round-trip test. Default
+  + `--no-default-features` builds both clippy + fmt clean.
+
 * **Clean-room round 139 (2026-05-26).** **VP8L lossless encoder
   *near-lossless* preprocessing.** A new
   [`near_lossless`](src/near_lossless.rs) module exposes the in-place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 135 (2026-05-25).** §3.5.4 / §4.4 **color-indexing
+  (palette) transform encoding** for the VP8L lossless encoder — the
+  last unimplemented VP8L transform on the encode side. When the image
+  has ≤ 256 distinct ARGB colors, the encoder builds the palette (in
+  first-appearance order), writes the §3.8.2 `color-indexing-tx` header
+  (`%b1` present, transform type 3, 8-bit `color_table_size - 1`), the
+  palette as a `color_table_size × 1` `entropy-coded-image` that is
+  per-channel subtraction-coded (the exact inverse of the decoder's
+  `inverse_color_table`), then replaces every pixel with its palette
+  index packed into the green channel and emits that index image as a
+  §3.8.3 `spatially-coded-image` at the subsampled width. For palettes
+  ≤ 16 colors it applies the spec's §4.4 pixel-bundling per Table 3 —
+  bundling 2 / 4 / 8 indices LSB-first into one green byte at
+  `width_bits` 1 / 2 / 3 (palette ≤ 16 / ≤ 4 / ≤ 2), subsampling the
+  main-image width by `DIV_ROUND_UP(width, 1 << width_bits)`. The
+  forward bundling field layout is bit-identical to the decoder's
+  `inverse_color_indexing` un-bundler, and the trailing partial bundle
+  on non-multiple widths round-trips exactly. The color-indexing path
+  is a new candidate in `encode_argb_literals_with_width_selected`
+  alongside the round-134 color, round-133 predictor, and round-132
+  subtract-green × cache cross-product; it returns `None` (and the
+  chooser skips it) on images with > 256 distinct colors, and only
+  wins on low-color images where the single-index-byte representation
+  beats the literal/LZ77 paths. Headline measurement: a 64×64
+  8-color image (`width_bits = 1`, two indices per byte) shrinks from
+  1982 B (best non-palette path) to 1858 B (palette) — a 6.3 % size
+  reduction; spatially-coherent palette art shrinks far more. Five
+  new inline tests cover the Table-3 `width_bits` mapping, the palette
+  build + > 256-color rejection, the forward/inverse subtraction-coding
+  round trip, the bundled size win + chooser selection + bit-exact
+  round trip, an unbundled (17..256-color) round trip, the partial-row
+  bundle on non-power-of-two widths, and the > 256-color rejection
+  through the production chooser.
+
 * **Clean-room round 134 (2026-05-25).** §4.2 **color (cross-channel
   decorrelation) transform encoding** for the VP8L lossless encoder.
   The encoder tiles the image into `1 << size_bits` square blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 144 (2026-05-26).** **Canonical-inverse round-trip
+  tests pinning `build_webp_file_with_metadata` as the byte-exact left
+  inverse of `extract_metadata` over the §2.7 metadata chunks.** §2.7's
+  "may appear out of order" carve-out for `EXIF` / `XMP ` is collapsed by
+  the writer to a single canonical `EXIF` → `XMP ` order, the §2.3 pad
+  bytes are always zero, and the §2.7.1 flag octet is recomputed from
+  the input's `Some`-ness. These three deterministic-emission properties
+  together make the round trip
+  `build(payload, meta) == build(payload, extract(build(payload, meta)))`
+  byte-identical. The new tests pin that identity so any future change
+  to the writer's emission order, pad handling, or flag-octet
+  computation surfaces as a byte-diff in CI.
+
+  No new public API. Four new integration tests in
+  [`tests/published_encode_api.rs`](tests/published_encode_api.rs) cover
+  (a) the all-three-set case, (b) every single-kind and pair-kind
+  subset (six combinations) under one parametric harness, (c) the
+  odd-length-payload case (every metadata chunk gets a §2.3 pad byte
+  that must be regenerated identically on re-build), and (d) the
+  `ImageKind::ExtendedLossy` bitstream-FourCC variant. One new inline
+  unit test in [`src/build.rs`](src/build.rs) anchors the same
+  property at the writer level via the `container::parse` walker
+  (i.e. without depending on the `extract_metadata` public path).
+
+  Total: **500** tests green (was 495: +5 from this round). Default and
+  `--no-default-features` builds both clippy + fmt clean.
+
 * **Clean-room round 143 (2026-05-26).** **Chainable
   `AnimEncoderOptions::with_default_lossy_quality(Option<u8>) -> Self`
   builder and matching `default_lossy_quality: Option<u8>` field,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,58 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 142)
+
+**Round 142 added chainable `AnimFrame::with_blend(BlendingMethod)` and
+`AnimFrame::with_dispose(DisposalMethod)` builders for the per-frame
+§2.7.1.1 `B` and `D` info-byte bits**, and pinned the end-to-end
+round-trip semantics of both with six new integration tests. The
+underlying `blend: BlendingMethod` and `dispose: DisposalMethod` fields
+were already public on [`AnimFrame`](src/anim_encode.rs) since round
+118, but the published-0.1.5 surface only exposed the literal-
+construction path; the new
+[`with_blend`](src/anim_encode.rs) / [`with_dispose`](src/anim_encode.rs)
+helpers complete the chainable-builder pattern alongside
+`with_near_lossless_quality` (r140) and the
+`AnimFrame::new(…)` constructor. Both helpers consume the receiver and
+return `Self`, so they compose with each other and with the existing
+builders in any order.
+
+**Three round-142 guarantees** are pinned by integration tests in
+[`tests/published_anim_blend_dispose_api.rs`](tests/published_anim_blend_dispose_api.rs):
+(a) the chosen `B` / `D` bit round-trips byte-exactly through the §2.7.1.1
+Figure 9 ANMF info byte — the encoder emits the bit a reader can
+re-parse via [`crate::anmf::AnmfHeader::parse`] (inline tests). (b) The
+§2.7.1.1 **alpha-blending formula** `blend.A = src.A + dst.A * (1 −
+src.A / 255)`, `blend.RGB = (src.RGB * src.A + dst.RGB * dst.A * (1 −
+src.A / 255)) / blend.A` (8-bit integer approximation, sRGB space)
+applies bit-exactly on a 2×2 translucent (`src.A = 128`) sub-frame over
+an opaque keyframe: red `(255, 0, 0, 255)` under blue `(0, 0, 255,
+128)` blends to **`(127, 0, 128, 255)`** — the precise spec-formula
+value. The opaque (`src.A = 255`) case still decodes to the source
+verbatim, since the formula short-circuits to overwrite at full alpha.
+(c) The §2.7.1.1 **disposal rule** "before rendering each frame, the
+previous frame's Disposal method is applied" clears a
+`DisposalMethod::Background` frame's sub-rect to the ANIM background
+colour before the next frame is composited — a 2×2 GREEN frame with
+dispose=Background between an 8×8 RED keyframe and a 2×2 BLUE frame
+produces a third-frame snapshot whose `(2..4, 2..4)` rect is the ANIM
+bg `(10, 20, 30, 255)`, not GREEN. The mirror case with
+`DisposalMethod::None` leaves GREEN on the canvas under the next
+frame. The integrated case where AlphaBlend + Background dispose
+compose on the same frame produces the blended pixels in the f1
+snapshot and the bg-cleared rect in the f2 snapshot.
+
+What landed: two 22-line builders on
+[`AnimFrame`](src/anim_encode.rs), six new integration tests, and six
+new inline unit tests (the `new()` defaults for blend/dispose, the
+builder round-trip for each method, a chaining test against the other
+builders, and the info-byte emission for each method). No new public
+fields; no behavioural change to existing encoder output (the
+literal-construction path was already wired). Total: **485** tests
+green (was 473: +12 from this round). Default and
+`--no-default-features` builds both clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 141)
 
 **Round 141 hoisted the round-140 per-frame near-lossless knob to an

--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 143)
+
+**Round 143 added the chainable
+`AnimEncoderOptions::with_default_lossy_quality(Option<u8>)` builder and
+the matching `default_lossy_quality: Option<u8>` field** on
+[`AnimEncoderOptions`](src/anim_encode.rs), symmetric to the round-141
+`with_default_near_lossless_quality` / `default_near_lossless_quality`
+pair. The new field lets callers shape their full encoder configuration
+(lossy + near-lossless animation-wide defaults) through one chainable
+builder surface today, ahead of the VP8 lossy encode body landing.
+
+**API-shape stub.** The VP8 lossy encode path is blocked on the
+`oxideav-vp8` per-MB driver (workspace task #1041); the existing
+`AnimFrameMode::Lossless` / `Delta` / `Auto` emission paths are
+lossless-only and ignore this field. The contract pinned by the new
+round-143 tests: setting `default_lossy_quality` to any value (`Some(0)`
+… `Some(255)` / `None`) produces output **byte-exact-equal** to the
+baseline `None` bytes, on both the full-keyframe and dirty-rect Delta
+paths, and does not perturb the round-141 near-lossless default's
+existing behaviour when both knobs are set together. Once the lossy
+emission body lands, the no-op contract here becomes the behavioural
+hook the lossy path consumes.
+
+What landed: one 11-line builder + one new field on
+[`AnimEncoderOptions`](src/anim_encode.rs), six new integration tests in
+[`tests/published_anim_default_lossy_api.rs`](tests/published_anim_default_lossy_api.rs)
+(field default, builder round-trip, dual-field independence, lossless
+keyframe no-op across six quality values, Delta dirty-rect no-op,
+near-lossless overlay no-op), and four new inline unit tests (default,
+builder round-trip, copy-paste-swap independence guard, and the
+encoder-no-op contract on a 4×4 fixture). Total: **495** tests green
+(was 485: +10 from this round). Default and `--no-default-features`
+builds both clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 142)
 
 **Round 142 added chainable `AnimFrame::with_blend(BlendingMethod)` and

--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-25 (clean-room round 132)
+
+**Round 132 widened the VP8L §5.2.3 color-cache chooser from a single
+`code_bits = 8` candidate (round 121) to a five-size slate.** The
+encoder now evaluates `code_bits ∈ {5, 7, 8, 9, 11}` alongside the
+no-cache option, cross-products with the §3.8.2 subtract-green
+transform axis, and emits the smallest of the 2 × 6 = 12 candidates.
+The §5.2.3 GREEN alphabet width is `256 + 24 + (1 << code_bits)`, so
+the prefix-code header overhead scales with the chosen size — picking
+the smallest cache that captures the image's color recurrence avoids
+paying for an over-sized cache. The new public entry point is
+[`encode_argb_literals_with_width_selected`](src/vp8l_encode.rs),
+which returns `(bytes, chosen_code_bits)`; the existing width-aware
+helper [`encode_argb_literals_with_width`](src/vp8l_encode.rs) (the
+one `encode_vp8l_payload` calls into) keeps its `Vec<u8>` signature
+unchanged. The candidate slate is exported as
+[`CANDIDATE_COLOR_CACHE_BITS`](src/vp8l_encode.rs).
+
+Headline measurement on a 32×32 palette-heavy pseudo-random fixture:
+**645 B (round-132, chosen code_bits=7) vs 661 B (round-121, fixed
+code_bits=8) — a 2.4 % saving on top of the round-121 cache writer**.
+Noise / row-correlated / solid fixtures match the round-121 size
+byte-for-byte (the chooser falls back to `code_bits=0`). The §5.2.3
+header read on the decoder side is unchanged (it already accepted
+the full `[1, 11]` range per RFC 9649); round-trip stays bit-exact
+through [`decode_lossless_image`](src/lib.rs).
+
+Six new inline tests cover (a) the candidate slate being spec-legal +
+monotone + containing the round-121 default; (b) palette-heavy input
+selects a non-zero size; (c) noise selects size 0; (d) the chosen size
+is always in `{0} ∪ CANDIDATE_COLOR_CACHE_BITS`; (e) the chosen byte
+stream round-trips bit-exactly for each cache decision (palette /
+noise / solid); and (f) the round-132 chooser never regresses against
+the round-121 single-size chooser on any tested fixture. Total: **386**
+tests (was 380).
+
 ## Status — 2026-05-25 (clean-room round 131)
 
 **Round 131 landed the published §2.5 `VP8 ` (lossy) encoder API

--- a/README.md
+++ b/README.md
@@ -2,7 +2,41 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-25 (clean-room round 136)
+## Status — 2026-05-26 (clean-room round 137)
+
+**Round 137 replaced the encoder's heuristic length-limited Huffman
+post-pass with a from-scratch *Package-Merge* (Larmore–Hirschberg 1990)
+implementation — the textbook *optimal* length-limited Huffman algorithm
+under the spec's §3.7.2 15-bit cap.** Round 136 built canonical Huffman
+from histograms and post-passed with a local "lengthen the deepest leaf,
+shorten a short one to keep the Kraft sum at 1" greedy. The greedy is
+correct (it always returns a complete depth-≤ 15 code), but only
+*locally* optimal: on histograms whose unconstrained Huffman tree
+exceeds the cap, a globally smaller ∑ freq[s]·len[s] is achievable.
+Package-Merge, applied to the coin-collector reformulation, returns that
+globally-optimal assignment. The encoder's
+[`build_code_lengths`](src/vp8l_encode.rs) now invokes Package-Merge on
+the fallback path whenever (and only when) the unconstrained tree
+exceeds [`MAX_CODE_LENGTH`]; histograms that already fit the cap keep
+the unconstrained build (itself optimal). Result: weakly-smaller bit
+cost on every cap-triggered input, identical output otherwise — so
+round-trip is bit-exact on every existing fixture (414/414 tests green,
+all seven lossless fixtures round-trip unchanged). The heuristic limiter
+is retained as `#[cfg(test)]`-only scaffolding so a comparison test can
+demonstrate the strict-win delta. Headline measurement on a pathological
+Fibonacci(25) frequency vector (unconstrained tree depth 24, well past
+the 15-bit cap): **−759 bits (~95 bytes) vs the round-136 heuristic**,
+with both forms remaining complete (Kraft sum 1) and cap-honouring; the
+shallower Fibonacci(20) case yields a smaller but real −26-bit win.
+Eight new inline tests cover single-symbol / two-symbol short-circuit,
+Kraft completeness over four histogram shapes (uniform, mild skew, ramp,
+Fibonacci), agreement with unconstrained Huffman when the cap is not
+triggered, the strict-win pathological cases (Fibonacci(20) and
+Fibonacci(25)), the `build_code_lengths` fallback dispatch, and a
+bit-exact round trip through the round-104 prefix reader. The natural
+test fixtures (predictor / cache / palette / color-decorrelated images)
+do not exercise the depth cap, so their byte counts are unchanged from
+round 136.
 
 **Round 136 added the VP8L §3.7.2.1.1 simple code length code to the
 encoder's prefix-code emission.** Each of the five prefix codes was

--- a/README.md
+++ b/README.md
@@ -2,6 +2,59 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 139)
+
+**Round 139 added the VP8L lossless encoder's *near-lossless*
+preprocessing pass — the encoder-side pixel-quantization step the cwebp
+`-near_lossless` knob controls.** A new
+[`near_lossless`](src/near_lossless.rs) module exposes
+[`apply(&mut [u32], quality)`](src/near_lossless.rs) — an in-place RGB
+quantizer that rounds each color channel to the nearest multiple of
+`2^n` where `n = bits_to_drop_for_quality(quality)` (the spec text does
+not normatively define the formula; round 139 documents the chosen
+mapping `n = clamp((100 - q + 19) / 20, 0, 5)` explicitly so
+reproducibility is a property of *our* encoder). Alpha is preserved
+exactly. The new public entry point
+[`encode_vp8l_argb_with_near_lossless(argb, w, h, has_alpha, quality)`](src/lib.rs)
+runs the preprocessing then hands the (quantized) pixels to the
+existing VP8L pipeline — no decoder change is needed, the result is a
+perfectly normal `VP8L` chunk that round-trips bit-exactly through
+[`decode_webp`](src/lib.rs) to the *quantized* pixels.
+
+**Three round-139 guarantees** are pinned by integration tests in
+[`tests/published_near_lossless_api.rs`](tests/published_near_lossless_api.rs):
+(a) **`quality = 100` is byte-exact-equal to the baseline encoder** on
+every fixture tested (1×1, 3×5, 7×4, 16×16, 64×64 natural-gradient,
+96×96 noisy) — the no-op fast path returns from
+`encode_vp8l_argb_with` directly without allocating a quantized copy;
+(b) **`quality = 60` produces a smaller bitstream than `quality = 100`**
+on a deterministic 96×96 high-entropy fixture (27,770 B → 20,860 B, a
+**−24.9 % size reduction**), with PSNR 46.25 dB — well above the
+≥ 40 dB floor the test pins (typical-case worst error is `step/2 = 2`
+at `n = 2`, putting the floor at ~42 dB);
+(c) **decoder round-trip recovers the quantized ARGB exactly** at every
+quality level (q=60 and q=0 are explicit fixtures), and **alpha
+round-trips unchanged** through encode-quantize-decode at q=40 on a
+non-opaque image. Full quality table on the same noisy fixture: q=100
+27,770 B (no-op identity), q=95 / q=80 24,327 B / 51.20 dB,
+**q=60 20,860 B / 46.25 dB**, q=40 17,394 B / 40.43 dB, q=20 13,916 B /
+34.09 dB, q=0 10,451 B / 27.45 dB.
+
+What landed: a new 350-line `near_lossless` module with the
+`bits_to_drop_for_quality` mapping, the `quantize_channel` per-byte
+round-half-up-with-clamp primitive, `apply` (in-place) +
+`quantize` (out-of-place), and 12 inline tests covering the bucket
+mapping, monotonicity, clamp behaviour, error bounds (`step - 1` worst
+case, `step / 2` typical), alpha preservation across every quality
+level, and apply/quantize equivalence. A new `lib.rs` entry point
+`encode_vp8l_argb_with_near_lossless` provides the wrapper; 9
+integration tests + 1 measurement helper cover the three guarantees
+above plus dimension-mismatch error propagation, `quality > 100`
+clamping, the q=0 maximum-quantization round-trip, and the alpha
+preservation through full encode+decode. Total: **453** tests green
+(was 433: +20 from this round). Both `default` and
+`--no-default-features` builds pass clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 138)
 
 **Round 138 lifted the §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / §2.7.1.5

--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 140)
+
+**Round 140 wired the round-139 VP8L *near-lossless* preprocessing pass
+into the animated-WebP encoder path.** The still-image entry point
+`encode_vp8l_argb_with_near_lossless` was already in place; round 140
+extends the per-frame surface so `build_animated_webp` /
+`build_animated_webp_with_options` honour the same `[0..=100]` knob
+*per frame*. The change is API-additive — a new optional
+[`AnimFrame::near_lossless_quality: Option<u8>`](src/anim_encode.rs)
+field plus a chainable
+[`with_near_lossless_quality(Option<u8>)`](src/anim_encode.rs) builder —
+and defaults to `None`, the no-op identity, so every existing
+animated-WebP test fixture continues to produce its pre-round-140 bit
+pattern. The preprocessing is applied identically across the
+full-keyframe ([`AnimFrameMode::Lossless`]) and dirty-rect
+([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths;
+each frame's knob feeds into its per-frame `VP8L` bitstream
+independently, so an animation can mix lossless and near-lossless
+frames freely.
+
+**Three round-140 guarantees** are pinned by integration tests in
+[`tests/published_anim_near_lossless_api.rs`](tests/published_anim_near_lossless_api.rs):
+(a) **`None` (default) and `Some(100)` are byte-exact-equal to the
+pre-round-140 baseline** on every fixture tested — the no-op
+short-circuit (`if let Some(q) = quality { near_lossless::apply(...) }`)
+guarantees byte-exact equivalence whenever the knob is left at the
+default or explicitly at 100. (b) **`Some(60)` shrinks a 3-frame
+animated WebP** on a deterministic 64×64 noisy fixture (37,364 B →
+**28,180 B**, a **−24.58 % reduction**) with every decoded per-frame
+PSNR at **46.25 dB** — well above the ≥ 40 dB floor the test enforces.
+(c) **Decoder round-trip recovers the quantized pixels exactly**: the
+full-keyframe path matches the still-image `near_lossless::quantize` of
+the source byte-for-byte; the dirty-rect path matches an `f0`-with-
+quantized-sub-rect composite; alpha round-trips unchanged at q=40 on a
+non-opaque-alpha fixture. Per-frame monotonicity q=80 < q=60 < q=40 <
+q=0 holds on a single-frame 48×48 fixture (32,888 / 28,180 / 23,548 /
+14,280 bytes respectively, vs. 37,364 B baseline — −12 % / −25 % /
+−37 % / −62 %; PSNR per the still-image quality table).
+
+What landed: a 30-line `apply_near_lossless_if_requested` helper +
+two-line call-sites in `emit_full_anmf` and `emit_dirty_anmf`; the
+public `AnimFrame` struct gains one field and one builder; the
+`AnimFrame::new` default leaves it `None`; the literal-construction
+test fixture (`tests/published_anim_api.rs::frame_blend_dispose_and_offset_fields_are_carried`)
+updated to spell out the new field. 11 new integration tests +
+1 inline builder-round-trip test. Total: **464** tests green (was 453:
++11 from this round). Both default and `--no-default-features` builds
+pass clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 139)
 
 **Round 139 added the VP8L lossless encoder's *near-lossless*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,45 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-25 (clean-room round 133)
+## Status — 2026-05-25 (clean-room round 134)
+
+**Round 134 added the VP8L §4.2 color (cross-channel decorrelation)
+transform to the encoder.** The encoder tiles the image into the spec's
+`1 << size_bits` square blocks (`size_bits = 4`, i.e. 16×16) and, for
+each block, picks the three signed-8-bit `ColorTransformElement`
+coefficients (`green_to_red` / `green_to_blue` / `red_to_blue`) by a
+cheap coordinate-descent search over a coarse 3.5-fixed-point grid,
+scoring candidates with the same wrap-aware sum-of-absolute-residuals
+proxy the predictor uses. The all-zero (identity) element is always the
+search origin, so a block with no usable correlation keeps the
+no-transform residual. It emits the §3.8.2 `color-tx` header (`%b1` +
+type 1 + 3-bit `size_bits - 2`), the sub-resolution color image as an
+`entropy-coded-image` (the §4.2 layout: alpha 255, red = `red_to_blue`,
+green = `green_to_blue`, blue = `green_to_red`), then the residual main
+image as a §3.8.3 `spatially-coded-image`. The forward
+`ColorTransform` (subtract deltas, using the *original* red for the
+`red_to_blue` term) is the exact inverse of the decoder's
+[`inverse_color`](src/vp8l_transform.rs), which restores red before
+re-adding the blue delta — so the pair is bit-exact across the
+modulo-256 wrap. The color path is a new candidate in
+[`encode_argb_literals_with_width_selected`](src/vp8l_encode.rs)
+alongside the round-133 predictor and round-132 subtract-green × cache
+cross-product; the chooser still emits whichever is smallest, so it
+never regresses.
+
+Headline measurement on a 64×64 image with high-entropy green and
+fractional-slope red/blue (the §4.2 sweet spot the predictor and
+subtract-green cannot capture): **7026 B (color) vs 7904 B (best
+non-color path) — an 11 % size reduction**. Round trip stays bit-exact
+through [`decode_lossless_image`](src/lib.rs), validated on the
+correlated fixture plus a noisy non-power-of-two (partial-block)
+fixture. Five new inline tests cover (a) the forward per-pixel
+transform being the exact inverse of the decoder's add-back across the
+wrap and the signed [128..255]→negative coefficient range; (b) every
+selected element's sub-image layout/opacity; (c) the correlated image
+shrinks vs the best non-color path and round-trips; (d) the color path
+round-trips on noise + non-power-of-two dimensions; (e) the production
+chooser never regresses on uncorrelated noise.
 
 **Round 133 added the VP8L §3.5.1 / §4.1 predictor (spatial) transform
 to the encoder.** The encoder now tiles the image into the spec's

--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 141)
+
+**Round 141 hoisted the round-140 per-frame near-lossless knob to an
+animation-wide default** on
+[`AnimEncoderOptions`](src/anim_encode.rs). A new optional
+[`AnimEncoderOptions::default_near_lossless_quality: Option<u8>`](src/anim_encode.rs)
+field — paired with the chainable
+[`with_default_near_lossless_quality(Option<u8>)`](src/anim_encode.rs)
+builder — lets callers set the VP8L near-lossless preprocessing quality
+**once for the whole animation** instead of repeating it on every
+[`AnimFrame`]. Resolution order at encode time: a per-frame
+`Some(q)` always wins; a per-frame `None` falls back to the
+options-level default; both `None` is the baseline (no quantization,
+byte-exact-equal to the pre-round-140 output, equivalent to `Some(100)`
+in either slot). The default is threaded through to *both* the
+full-keyframe ([`AnimFrameMode::Lossless`]) and dirty-rect
+([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths via
+a single `effective_quality = frame.q.or(opts.default_q)` resolution in
+`build_animated_webp_with_options`'s per-frame loop, so the round-140
+per-frame-knob behaviour and the round-141 options-default behaviour
+share the exact same downstream quantization call and produce
+bit-identical per-frame ANMFs given the same effective quality.
+
+**Measured deltas** (3-frame 64×64 deterministic xorshift32-noise
+fixture, seeds 0/1/2): the round-140 baseline (no near-lossless) is
+**37,364 B** (ANMFs ~12,432 each). Round-141 options default
+`Some(60)` with no per-frame overrides: **28,180 B (−24.58 %)** with
+per-frame ANMFs of 9,368 / 9,376 / 9,368 — **byte-for-byte equivalent
+to the round-140 per-frame `Some(60)` file**. Mixed (default `Some(60)`,
+frame 1 overridden to `Some(100)`): **31,236 B (−16.40 %)**; frames 0
+and 2 each shrink to 9,368 B (default applied, −24.66 % / −24.63 %),
+frame 1 stays at exactly 12,432 B (override wins, matches baseline
+ANMF byte-for-byte).
+
+Seven new integration tests in
+[`tests/published_anim_default_near_lossless_api.rs`](tests/published_anim_default_near_lossless_api.rs)
+cover (a) default-only equals per-frame-only byte-for-byte, (b) default
+`None` equals the convenience baseline, (c) default `Some(255)` clamps
+to the baseline no-op, (d) per-frame `Some(q)` overrides the default in
+either direction (including the central "mixed sequence" case that
+checks per-frame ANMF sizes against the all-60 / all-100 reference
+files), (e) decoder round-trip recovers `near_lossless::quantize(src, q)`
+exactly when the default supplies the quality, and (f) the default
+flows through to the Delta dirty-rect path the same way the per-frame
+knob does. Two new inline unit tests confirm the new field defaults to
+`None` and the `with_default_near_lossless_quality` builder
+round-trips. Total: **473** tests green (was 464: +9 from this round).
+Default + `--no-default-features` builds clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 140)
 
 **Round 140 wired the round-139 VP8L *near-lossless* preprocessing pass

--- a/README.md
+++ b/README.md
@@ -2,6 +2,68 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-25 (clean-room round 131)
+
+**Round 131 landed the published §2.5 `VP8 ` (lossy) encoder API
+surface** — every function name, type, constant, and registry entry the
+published-0.1.5 release exposed per [`API-COMPAT.md`](API-COMPAT.md), so
+downstream consumers compile and a future round wires the encoder body
+in without API churn.
+
+**Status: API-shape stub.** The wiring to a real VP8 lossy bitstream
+is blocked on `oxideav-vp8 = "0.2"`'s encoder, which today ships only
+**Phase 1**: [`oxideav_vp8::encode_silent_keyframe`](https://docs.rs/oxideav-vp8/0.2.0/oxideav_vp8/fn.encode_silent_keyframe.html)
+emits a structurally valid VP8 keyframe but **ignores the caller's
+pixels entirely** (every MB carries `mb_skip_coeff = 1` with
+`DC_PRED` → constant-grey picture). Wiring that through a WebP RIFF
+wrapper would produce garbage bytes — the exact failure mode the
+round-131 directive forbids — so this round lands the API shape only:
+each entry point validates input dims / buffer length then returns
+[`WebpError::Unsupported`](src/lib.rs) (free functions) or
+[`oxideav_core::Error::Unsupported`] (trait impl). No call ever
+returns `Ok(bytes)`.
+
+What landed:
+
+* Standalone free functions —
+  [`encode_vp8_lossy_rgba`](src/lib.rs),
+  [`encode_vp8_lossy_rgb24`](src/lib.rs),
+  [`encode_vp8_lossy_yuv420p`](src/lib.rs),
+  [`encode_vp8_lossy_yuva420p`](src/lib.rs).
+* New module [`encoder_vp8`](src/encoder_vp8.rs) carrying the direct
+  factory family — `make_encoder_with_quality` / `_with_qindex` /
+  `_with_target_size` (and `_and_metadata` / `_and_freq_deltas`
+  variants) — plus
+  [`Vp8FreqDeltas`](src/encoder_vp8.rs),
+  [`Vp8PsyStats`](src/encoder_vp8.rs),
+  [`compute_psy_stats`](src/encoder_vp8.rs),
+  [`freq_deltas_for_qindex`](src/encoder_vp8.rs),
+  [`quality_to_qindex`](src/encoder_vp8.rs), and the
+  `QUALITY_*` / `QINDEX_*` / `DEFAULT_QUALITY` constants.
+* Registry side — `CODEC_ID_VP8 = "webp_vp8"`,
+  [`WebpVp8LossyEncoder`](src/registry.rs) `Encoder` trait impl,
+  [`make_vp8_lossy_encoder`](src/registry.rs) factory; the codec is
+  registered alongside `webp_vp8l` so a `first_encoder` lookup against
+  the lossy id works.
+* The [`encoder_vp8`](src/encoder_vp8.rs) module-level doc-comment
+  enumerates the **precise** missing primitives on the
+  `oxideav-vp8` side that block real wiring: forward §14.3 WHT /
+  §14.4 DCT, forward §14.1 quantization, a pixel-driven §12
+  intra-prediction search, a per-MB encode driver consuming a
+  16×16 luma + 8×8 chroma block, and a top-level
+  "encode I420 → VP8 keyframe" entry. Once those land, the bodies
+  of the published entries above become a thin call into the new
+  vp8 encoder + the existing [`build::build_webp_file`](src/build.rs)
+  RIFF wrapper.
+
+18 new published-API tests + 4 inline `encoder_vp8` unit tests cover
+buffer-length validation, the quality/qindex mapping, the
+`Vp8FreqDeltas` / `Vp8PsyStats` stub semantics, and the registry-side
+construction + `send_frame` → `Unsupported` contract. The day
+`oxideav-vp8`'s pixel encoder lands, the
+`*_validates_then_unsupported` tests start failing — a deliberate
+change-detector. Total: **380** tests (was 347).
+
 ## Status — 2026-05-25 (clean-room round 130)
 
 **Round 130 added a §5.2.2 width-aware distance-code chooser to the VP8L

--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-26 (clean-room round 137)
+## Status — 2026-05-26 (clean-room round 138)
+
+**Round 138 lifted the §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / §2.7.1.5
+`XMP ` metadata writer up to the container-builder layer.** The
+high-level `encode_vp8l_argb_with_metadata` (round 115) already emitted
+the three metadata chunks for the VP8L pixel path, but the standalone
+`build::` module — the byte-pushing builders external encoders use to
+frame their own payloads — had no equivalent. Round 138 adds
+[`build::build_webp_file_with_metadata`](src/build.rs) +
+[`build::MetadataPayloads`](src/build.rs): a borrowed three-`Option<&[u8]>`
+bag plus a writer that picks the simple §2.5 / §2.6 layout when the bag
+is empty (byte-for-byte identical to `build::build_webp_file`) and the
+§2.7 extended layout when any kind is set, emitting chunks in the spec's
+order — `VP8X` first, `ICCP` before the bitstream, the `VP8 ` / `VP8L`
+bitstream, then `EXIF` and `XMP ` after — with the §2.7.1 flag octet
+(`I` / `E` / `X`) declaring exactly the kinds present. Twelve new tests
+in `build::tests` cover the per-kind isolation (each of ICC / Exif / XMP
+on its own sets only its own flag and emits only its own chunk),
+odd-length pad-byte behaviour, empty-payload edge case, and equivalence
+with `build_webp_file` on the no-metadata fast path; five new
+integration tests in `tests/published_encode_api.rs` exercise the
+per-kind isolation through `encode_vp8l_argb_with_metadata` +
+`extract_metadata` and round-trip a real VP8L bitstream through
+`build_webp_file_with_metadata`. All 428 tests green
+(337 lib + 50 + 8 + 4 + 11 + 18 + 0 integration). The build module's
+docstring now reflects that the metadata-chunk gap is closed.
 
 **Round 137 replaced the encoder's heuristic length-limited Huffman
 post-pass with a from-scratch *Package-Merge* (Larmore–Hirschberg 1990)
@@ -655,6 +680,16 @@ validated bit-exact (all 16384 bytes) against `dwebp -alpha` on the
     (one `VP8 ` / `VP8L` chunk); the `Extended*` variants emit `VP8X`
     + bitstream per §2.7's chunk-ordering rule. The §2.4 `File Size`
     field is computed as `4 + body.len()` per the RFC.
+  * [`build::build_webp_file_with_metadata(payload, image_kind, w, h, meta)`](src/build.rs)
+    (round 138) — §2.4 file writer extended with the §2.7.1.4 `ICCP`
+    and §2.7.1.5 `EXIF` / `XMP ` metadata chunks. Takes a
+    [`build::MetadataPayloads`](src/build.rs) borrowed bag of three
+    optional payloads; auto-promotes a simple `ImageKind` to the
+    extended `VP8X` layout whenever any metadata kind is set; emits
+    chunks in the §2.7 order (`VP8X` → `ICCP` → bitstream → `EXIF` →
+    `XMP `) and sets exactly the §2.7.1 `I` / `E` / `X` flag bits the
+    payloads imply. Byte-for-byte equivalent to `build_webp_file` on
+    the empty-metadata fast path.
   * Canvas-dim validation matches the parser's MUSTs symmetrically
     (zero / above 2^24 / product cap > 2^32 - 1).
   * Standalone-friendly: every public function compiles cleanly
@@ -1009,12 +1044,13 @@ validated bit-exact (all 16384 bytes) against `dwebp -alpha` on the
 | §2.7.1.1 `ANMF` Frame Data    | not yet — sub-RIFF bytes after 16-byte header opaque |
 | §2.7.1.2 `ALPH` info byte     | done (Rsv/P/F/C 2-bit decompose, typed enums)       |
 | §2.7.1.2 `ALPH` bitstream     | done — raw + headerless VP8L (green channel) + 4 inverse filters |
-| §2.7.1.4 `ICCP`               | surfaced as opaque chunk                            |
-| §2.7.1.5 `EXIF` / `XMP `      | surfaced as opaque chunks                           |
+| §2.7.1.4 `ICCP`               | read + **write** (r138 `build_webp_file_with_metadata`) |
+| §2.7.1.5 `EXIF` / `XMP `      | read + **write** (r138 `build_webp_file_with_metadata`) |
 | §2.7.1.6 unknown chunks       | surfaced (no special handling required by §2.7.1.6) |
 | §2.3 `build_chunk` writer     | done — generic FourCC+Size+payload+odd-pad emit     |
 | §2.7.1 `build_vp8x_chunk`     | done — typed flag-byte + 24-bit LE × 2 emit         |
 | §2.4 `build_webp_file`        | done — simple + extended `RIFF/WEBP` envelope       |
+| §2.4 `build_webp_file_with_metadata` | done (r138) — emits `VP8X` + optional `ICCP` / `EXIF` / `XMP ` in §2.7 order |
 | VP8L bitstream decode         | done — `decode_webp` / `decode_lossless_image` → RGBA |
 | `oxideav_core::Decoder` registration | done (r112) — `register()` installs the `webp` decoder factory |
 | VP8 lossy bitstream decode    | done (r124) — routed through `oxideav-vp8` → BT.601 RGBA |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,31 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-25 (clean-room round 135)
+## Status — 2026-05-25 (clean-room round 136)
+
+**Round 136 added the VP8L §3.7.2.1.1 simple code length code to the
+encoder's prefix-code emission.** Each of the five prefix codes was
+previously written with the §3.7.2.1.2 *normal code length code* (a
+19-symbol code-length-code header plus per-symbol lengths). The encoder
+now picks the cheaper §3.7.2.1.1 *simple* form whenever a code's length
+table is 1 or 2 length-1 symbols in `[0..255]` — the form
+[`build_code_lengths`](src/vp8l_encode.rs) yields for single-color
+channels and the empty distance code — encoding the whole table in 3–11
+bits (`%b1` flag + `num_symbols-1` + `is_first_8bits` + a 1/8-bit
+`symbol0` + optional 8-bit `symbol1`) vs the normal form's ≥18-bit
+header. The narrow 1-bit `symbol0` field is used for the common
+single-symbol-0 (empty) distance code. Both forms describe the identical
+length table, so symbol emission and the decoder's reconstruction are
+unchanged ([`simple_code_symbols`](src/vp8l_encode.rs) /
+[`write_simple_code_lengths`](src/vp8l_encode.rs) mirror the decoder's
+`read_simple_code_lengths`). Headline measurement: re-encoding the seven
+lossless fixtures totals **1634 B with the simple path vs 2658 B
+normal-only — a 1024 B (38.5 %) header reduction**, from −81.6 % on
+`lossless-1x1` (174 → 32 B) and −75.6 % on `lossless-32x32-rgb`
+(328 → 80 B) to −16.8 % on the natural 128×128 image (1038 → 864 B).
+Six new inline tests cover the classifier, the 1- and 2-symbol round
+trips through the prefix reader, and the measured win over the normal
+form. Round trip stays bit-exact on every fixture.
 
 **Round 135 added the VP8L §3.5.4 / §4.4 color-indexing (palette)
 transform to the encoder — the last unimplemented VP8L transform on the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,39 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-25 (clean-room round 132)
+## Status — 2026-05-25 (clean-room round 133)
+
+**Round 133 added the VP8L §3.5.1 / §4.1 predictor (spatial) transform
+to the encoder.** The encoder now tiles the image into the spec's
+`1 << size_bits` square blocks (`size_bits = 4`, i.e. 16×16) and, for
+each block, scores all 14 prediction modes `[0..13]` by a per-channel
+sum-of-absolute-residuals proxy (folding the modulo-256 wrap so small
+negative residuals score low), picking the cheapest mode. It emits the
+§3.8.2 `predictor-tx` header (`%b1` + type 0 + 3-bit `size_bits - 2`),
+the sub-resolution predictor image as an `entropy-coded-image` (mode in
+the green channel, no meta-prefix per the §3.8.2 grammar), then the
+residual main image as a §3.8.3 `spatially-coded-image`. The forward
+predictor primitives (`Average2` / `Select` / `ClampAddSubtractFull` /
+`ClampAddSubtractHalf` and the §4.1 border rules) are bit-identical to
+the decoder's [`inverse_predictor`](src/vp8l_transform.rs), so
+`residual = actual − pred` is the exact inverse of the decoder's
+`final = residual + pred`. The predictor path is a new candidate in
+[`encode_argb_literals_with_width_selected`](src/vp8l_encode.rs)
+alongside the round-132 subtract-green × cache cross-product; the
+chooser still emits whichever candidate is smallest, so it never
+regresses.
+
+Headline measurement on a 64×64 smooth 2-D gradient: **308 B
+(predictor) vs 10377 B (no-predictor) — a 97 % size reduction**, the
+gradient picking gradient-style predictors as expected. The residual
+main image and the predictor sub-image each run their own §5.2.3
+color-cache evaluation. Round trip stays bit-exact through
+[`decode_lossless_image`](src/lib.rs), validated on smooth, noisy, and
+non-power-of-two (partial-block) fixtures. Four new inline tests cover
+(a) `sub_pred` being the exact inverse of `add_pred` across the wrap;
+(b) every selected mode ∈ `0..=13`; (c) the gradient shrinks vs.
+no-predictor and round-trips; (d) the predictor path round-trips on
+noise + non-power-of-two dimensions.
 
 **Round 132 widened the VP8L §5.2.3 color-cache chooser from a single
 `code_bits = 8` candidate (round 121) to a five-size slate.** The
@@ -146,9 +178,9 @@ near-row distances compounds the per-emission saving via the §5.2.2
 distance-prefix Huffman tree (more frequent low-prefix codes amortise
 the table overhead). Round trip is bit-exact across every fixture above
 through [`decode_webp`](src/lib.rs) / [`decode_lossless_image`](src/lib.rs).
-Still lacks: §3.8.2 predictor / color / color-indexing transform
-encoding (subtract-green is the only transform the encoder applies),
-and VP8 lossy encode.
+Still lacks (as of this round): §3.8.2 color / color-indexing transform
+encoding (subtract-green and — as of round 133 — the §4.1 predictor
+transform are the transforms the encoder applies), and VP8 lossy encode.
 
 ## Status — 2026-05-25 (clean-room round 127)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,37 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
-## Status — 2026-05-25 (clean-room round 134)
+## Status — 2026-05-25 (clean-room round 135)
+
+**Round 135 added the VP8L §3.5.4 / §4.4 color-indexing (palette)
+transform to the encoder — the last unimplemented VP8L transform on the
+encode side.** When the image has ≤ 256 distinct ARGB colors, the encoder
+builds the palette (first-appearance order), emits the §3.8.2
+`color-indexing-tx` header (`%b1` + type 3 + 8-bit `color_table_size - 1`),
+the palette as a `color_table_size × 1` `entropy-coded-image` that is
+per-channel subtraction-coded (the exact inverse of the decoder's
+[`inverse_color_table`](src/vp8l_transform.rs)), then replaces every pixel
+with its palette index in the green channel and emits that index image as a
+§3.8.3 `spatially-coded-image`. For palettes ≤ 16 colors it applies the
+spec's §4.4 pixel-bundling per Table 3 — packing 2 / 4 / 8 indices
+LSB-first into one green byte at `width_bits` 1 / 2 / 3, subsampling the
+main-image width by `DIV_ROUND_UP(width, 1 << width_bits)`. The forward
+field layout is bit-identical to the decoder's
+[`inverse_color_indexing`](src/vp8l_transform.rs) un-bundler, so the stream
+round-trips bit-exact (including the trailing partial bundle on
+non-multiple widths). The palette path is a new candidate in
+[`encode_argb_literals_with_width_selected`](src/vp8l_encode.rs) alongside
+the round-134 color, round-133 predictor, and round-132 subtract-green ×
+cache cross-product; it returns `None` on > 256-color images (so the
+chooser skips it) and only wins on low-color images. Headline measurement:
+a 64×64 8-color image (`width_bits = 1`, two indices per byte) shrinks from
+1982 B (best non-palette path) to 1858 B (palette) — a 6.3 % reduction;
+spatially-coherent palette art shrinks far more. Five new inline tests
+cover the Table-3 `width_bits` mapping + palette build/rejection, the
+subtraction-coding round trip, the bundled size win + chooser selection +
+bit-exact round trip, an unbundled (17..256-color) round trip, the
+partial-row bundle on odd widths, and the > 256-color rejection through the
+production chooser.
 
 **Round 134 added the VP8L §4.2 color (cross-channel decorrelation)
 transform to the encoder.** The encoder tiles the image into the spec's
@@ -216,9 +246,9 @@ near-row distances compounds the per-emission saving via the §5.2.2
 distance-prefix Huffman tree (more frequent low-prefix codes amortise
 the table overhead). Round trip is bit-exact across every fixture above
 through [`decode_webp`](src/lib.rs) / [`decode_lossless_image`](src/lib.rs).
-Still lacks (as of this round): §3.8.2 color / color-indexing transform
-encoding (subtract-green and — as of round 133 — the §4.1 predictor
-transform are the transforms the encoder applies), and VP8 lossy encode.
+Still lacks (as of this round): VP8 lossy encode. (All four VP8L §3.8.2
+transforms now have encode support — subtract-green, §4.1 predictor
+[r133], §4.2 color [r134], and §4.4 color-indexing [r135].)
 
 ## Status — 2026-05-25 (clean-room round 127)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 144)
+
+**Round 144 pinned `build_webp_file_with_metadata` as the byte-exact left
+inverse of `extract_metadata` over the §2.7 metadata chunks.** §2.7's
+"may appear out of order" carve-out for `EXIF` / `XMP ` is collapsed by
+the writer to a single canonical `EXIF` → `XMP ` order, the §2.3 pad
+bytes are always zero, and the §2.7.1 flag octet is recomputed from the
+input's `Some`-ness. These three deterministic-emission properties make
+the round trip
+`build(payload, meta) == build(payload, extract(build(payload, meta)))`
+byte-identical: re-feeding the extracted metadata payloads back into the
+writer produces the same container bytes. The new tests pin that
+identity so any future change to the writer's emission order, pad
+handling, or flag-octet computation surfaces as a byte-diff in CI.
+
+No new public API. Four new integration tests in
+[`tests/published_encode_api.rs`](tests/published_encode_api.rs) cover
+(a) the all-three-set canonical-inverse case, (b) every single-kind and
+pair-kind subset (six combinations: `icc-only` / `exif-only` /
+`xmp-only` / `icc+exif` / `icc+xmp` / `exif+xmp`) under one parametric
+harness, (c) the odd-length-payload case (every metadata chunk gets a
+§2.3 pad byte that must be regenerated identically on re-build), and
+(d) the `ImageKind::ExtendedLossy` bitstream-FourCC variant. One new
+inline unit test in [`src/build.rs`](src/build.rs) anchors the same
+property at the writer level via the `container::parse` walker without
+depending on the `extract_metadata` public path.
+
+Total: **500** tests green (was 495: +5 from this round). Default and
+`--no-default-features` builds both clippy + fmt clean.
+
 ## Status — 2026-05-26 (clean-room round 143)
 
 **Round 143 added the chainable

--- a/src/anim_encode.rs
+++ b/src/anim_encode.rs
@@ -286,6 +286,14 @@ impl DeltaConfig {
 /// VP8L bitstreams are byte-exact-equal to the baseline encoder
 /// (equivalent to `Some(100)` in either slot). See
 /// [`crate::near_lossless`] for the quality scale and step table.
+///
+/// `default_lossy_quality` is the symmetric animation-wide fallback for
+/// the (still blocked on `oxideav-vp8` per-MB driver) VP8 lossy encode
+/// path. It is **no-op API surface today**: the lossless emission paths
+/// ignore it entirely and the field is wired only so callers can begin
+/// shaping their encoder configuration alongside the lossless knobs
+/// without code churn once the lossy path lands. See the module-level
+/// "Lossy quality" note for the resolution semantics.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AnimEncoderOptions<'a> {
     /// §2.7.1.1 `ANIM` loop count. `0` means "loop infinitely".
@@ -305,6 +313,22 @@ pub struct AnimEncoderOptions<'a> {
     /// identical to the baseline encoder, `0` is maximum RGB-channel
     /// quantization.
     pub default_near_lossless_quality: Option<u8>,
+    /// Animation-wide default **lossy** (VP8) quality used for every
+    /// frame whose own (future) per-frame lossy-quality field is `None`.
+    /// Resolution semantics mirror
+    /// [`AnimEncoderOptions::default_near_lossless_quality`]: per-frame
+    /// `Some(q)` always wins; per-frame `None` falls back to this
+    /// options-level default; both `None` is the lossless-only baseline.
+    ///
+    /// **API-shape stub today.** The VP8 lossy encode body is blocked
+    /// on the `oxideav-vp8` per-MB driver (workspace task #1041); the
+    /// existing `AnimFrameMode::Lossless` / `Delta` / `Auto` emission
+    /// paths are lossless-only and ignore this field. Storing it here
+    /// today lets callers wire their full encoder configuration without
+    /// code churn once the lossy path lands. The value uses the same
+    /// `[0..=100]` scale as the rest of this crate's encoder quality
+    /// knobs (`100` = highest quality, `0` = lowest).
+    pub default_lossy_quality: Option<u8>,
 }
 
 impl<'a> AnimEncoderOptions<'a> {
@@ -316,6 +340,22 @@ impl<'a> AnimEncoderOptions<'a> {
     /// [`AnimFrame::near_lossless_quality`].
     pub fn with_default_near_lossless_quality(mut self, quality: Option<u8>) -> Self {
         self.default_near_lossless_quality = quality;
+        self
+    }
+
+    /// Builder helper: set the animation-wide
+    /// [`AnimEncoderOptions::default_lossy_quality`] fallback in-place
+    /// and return `self`. Symmetric to
+    /// [`Self::with_default_near_lossless_quality`].
+    ///
+    /// **API-shape stub today.** Stored verbatim on the options struct
+    /// and ignored by the current lossless-only encoder; the value will
+    /// drive the per-MB quantiser ladder once the VP8 lossy encode body
+    /// is wired (workspace task #1041). Setting it today is harmless —
+    /// the current emission paths produce the same bytes regardless of
+    /// what is stored here.
+    pub fn with_default_lossy_quality(mut self, quality: Option<u8>) -> Self {
+        self.default_lossy_quality = quality;
         self
     }
 }
@@ -1121,6 +1161,64 @@ mod tests {
         assert_eq!(opts.default_near_lossless_quality, Some(60));
         let opts2 = AnimEncoderOptions::default().with_default_near_lossless_quality(None);
         assert_eq!(opts2.default_near_lossless_quality, None);
+    }
+
+    #[test]
+    fn anim_encoder_options_default_lossy_quality_default_is_none() {
+        let opts = AnimEncoderOptions::default();
+        assert_eq!(
+            opts.default_lossy_quality, None,
+            "default lossy fallback must be None (API-shape stub awaiting VP8 lossy encode)"
+        );
+    }
+
+    #[test]
+    fn with_default_lossy_quality_builder_round_trips_field() {
+        let opts = AnimEncoderOptions::default().with_default_lossy_quality(Some(75));
+        assert_eq!(opts.default_lossy_quality, Some(75));
+        let opts2 = AnimEncoderOptions::default().with_default_lossy_quality(None);
+        assert_eq!(opts2.default_lossy_quality, None);
+    }
+
+    #[test]
+    fn with_default_lossy_quality_is_independent_of_near_lossless_default() {
+        // Setting one must not perturb the other; this guards against a
+        // copy-paste swap on the builder body.
+        let opts = AnimEncoderOptions::default()
+            .with_default_near_lossless_quality(Some(60))
+            .with_default_lossy_quality(Some(80));
+        assert_eq!(opts.default_near_lossless_quality, Some(60));
+        assert_eq!(opts.default_lossy_quality, Some(80));
+
+        let opts2 = AnimEncoderOptions::default()
+            .with_default_lossy_quality(Some(80))
+            .with_default_near_lossless_quality(Some(60));
+        assert_eq!(opts2.default_near_lossless_quality, Some(60));
+        assert_eq!(opts2.default_lossy_quality, Some(80));
+    }
+
+    #[test]
+    fn with_default_lossy_quality_is_lossless_encode_no_op_today() {
+        // API-shape stub contract: the lossless emission paths must
+        // produce the same bytes regardless of what is stored in
+        // `default_lossy_quality`. Otherwise the field would not be a
+        // pure stub and consumers wiring it today would see a quiet
+        // bitstream change.
+        let f = AnimFrame::new(4, 4, solid_rgba(4, 4, [10, 20, 30, 255]), 80);
+        let baseline = build_animated_webp_with_options(
+            std::slice::from_ref(&f),
+            &AnimEncoderOptions::default(),
+        )
+        .expect("baseline");
+        for q in [Some(0u8), Some(50), Some(75), Some(100), Some(255), None] {
+            let opts = AnimEncoderOptions::default().with_default_lossy_quality(q);
+            let bytes = build_animated_webp_with_options(std::slice::from_ref(&f), &opts)
+                .expect("lossy default build");
+            assert_eq!(
+                bytes, baseline,
+                "default_lossy_quality = {q:?} must be a no-op on the current lossless encoder paths"
+            );
+        }
     }
 
     #[test]

--- a/src/anim_encode.rs
+++ b/src/anim_encode.rs
@@ -163,6 +163,52 @@ impl AnimFrame {
         self.near_lossless_quality = quality;
         self
     }
+
+    /// Builder helper: set the §2.7.1.1 `B` (blending) bit on this frame
+    /// and return `self`.
+    ///
+    /// * [`BlendingMethod::Overwrite`] (§2.7.1.1 `B = 1`) — the
+    ///   [`AnimFrame::new`] default — copies the frame's sub-rect pixels
+    ///   over the previous canvas byte-for-byte, ignoring the source's
+    ///   alpha. Use this when the frame is a full opaque keyframe.
+    /// * [`BlendingMethod::AlphaBlend`] (§2.7.1.1 `B = 0`) runs the
+    ///   per-pixel formula `blend.A = src.A + dst.A * (1 - src.A / 255)`
+    ///   then `blend.RGB = (src.RGB * src.A + dst.RGB * dst.A * (1 -
+    ///   src.A / 255)) / blend.A` (8-bit integer approximation, sRGB
+    ///   space). Translucent pixels (`src.A < 255`) preserve the
+    ///   previous canvas underneath; fully-opaque pixels still overwrite.
+    ///
+    /// The chosen method is emitted into the §2.7.1.1 Figure 9 info byte
+    /// of the ANMF header and consumed by [`crate::decode_webp`]'s
+    /// canvas compositor. Round-trip is bit-exact regardless of which
+    /// method is chosen, given equivalent source pixels.
+    pub fn with_blend(mut self, blend: BlendingMethod) -> Self {
+        self.blend = blend;
+        self
+    }
+
+    /// Builder helper: set the §2.7.1.1 `D` (disposal) bit on this frame
+    /// and return `self`.
+    ///
+    /// * [`DisposalMethod::None`] (§2.7.1.1 `D = 0`) — the
+    ///   [`AnimFrame::new`] default — leaves this frame's sub-rect on
+    ///   the canvas after display, so the next frame composites over
+    ///   the result.
+    /// * [`DisposalMethod::Background`] (§2.7.1.1 `D = 1`) clears this
+    ///   frame's sub-rect to the §2.7.1.1 ANIM background colour
+    ///   *before* the next frame's blending step. The encoder mirrors
+    ///   that behaviour in its internal canvas tracker so the
+    ///   dirty-rect diff used by [`AnimFrameMode::Auto`] /
+    ///   [`AnimFrameMode::Delta`] is computed against the post-dispose
+    ///   canvas — the same reference state the decoder sees.
+    ///
+    /// The chosen method is emitted into the §2.7.1.1 Figure 9 info byte
+    /// of the ANMF header. Round-trip is bit-exact through
+    /// [`crate::decode_webp`] for both methods.
+    pub fn with_dispose(mut self, dispose: DisposalMethod) -> Self {
+        self.dispose = dispose;
+        self
+    }
 }
 
 /// Multi-scale SSIM downsample kernel selector for the (blocked) delta path.
@@ -1075,5 +1121,110 @@ mod tests {
         assert_eq!(opts.default_near_lossless_quality, Some(60));
         let opts2 = AnimEncoderOptions::default().with_default_near_lossless_quality(None);
         assert_eq!(opts2.default_near_lossless_quality, None);
+    }
+
+    #[test]
+    fn anim_frame_new_defaults_blend_and_dispose_to_overwrite_and_none() {
+        let f = AnimFrame::new(4, 4, solid_rgba(4, 4, [0, 0, 0, 255]), 50);
+        assert_eq!(
+            f.blend,
+            BlendingMethod::Overwrite,
+            "new() blend default must be Overwrite (§2.7.1.1 B = 1)"
+        );
+        assert_eq!(
+            f.dispose,
+            DisposalMethod::None,
+            "new() dispose default must be None (§2.7.1.1 D = 0)"
+        );
+    }
+
+    #[test]
+    fn with_blend_builder_round_trips_both_methods() {
+        let base = AnimFrame::new(4, 4, solid_rgba(4, 4, [1, 2, 3, 255]), 50);
+        let alpha = base.clone().with_blend(BlendingMethod::AlphaBlend);
+        assert_eq!(alpha.blend, BlendingMethod::AlphaBlend);
+        let over = base.with_blend(BlendingMethod::Overwrite);
+        assert_eq!(over.blend, BlendingMethod::Overwrite);
+    }
+
+    #[test]
+    fn with_dispose_builder_round_trips_both_methods() {
+        let base = AnimFrame::new(4, 4, solid_rgba(4, 4, [1, 2, 3, 255]), 50);
+        let bg = base.clone().with_dispose(DisposalMethod::Background);
+        assert_eq!(bg.dispose, DisposalMethod::Background);
+        let none = base.with_dispose(DisposalMethod::None);
+        assert_eq!(none.dispose, DisposalMethod::None);
+    }
+
+    #[test]
+    fn with_blend_and_with_dispose_chain_with_other_builders() {
+        // The chainable forms compose with the existing
+        // `with_near_lossless_quality` builder and don't disturb its
+        // independent field.
+        let f = AnimFrame::new(4, 4, solid_rgba(4, 4, [9, 9, 9, 255]), 25)
+            .with_blend(BlendingMethod::AlphaBlend)
+            .with_dispose(DisposalMethod::Background)
+            .with_near_lossless_quality(Some(60));
+        assert_eq!(f.blend, BlendingMethod::AlphaBlend);
+        assert_eq!(f.dispose, DisposalMethod::Background);
+        assert_eq!(f.near_lossless_quality, Some(60));
+        assert_eq!(f.duration, 25);
+        assert_eq!(f.width, 4);
+        assert_eq!(f.height, 4);
+    }
+
+    #[test]
+    fn with_blend_emits_correct_info_byte_in_anmf_header() {
+        // Build a one-frame animation per builder method and re-parse
+        // the ANMF header to confirm the §2.7.1.1 Figure 9 info byte
+        // carries the requested `B` bit.
+        for (blend, expected_b) in [
+            (BlendingMethod::Overwrite, 1u8),
+            (BlendingMethod::AlphaBlend, 0u8),
+        ] {
+            let f = AnimFrame::new(4, 4, solid_rgba(4, 4, [10, 20, 30, 255]), 80).with_blend(blend);
+            let file = build_animated_webp(&[f]).expect("build");
+            let c = crate::container::parse(&file).expect("container");
+            let anmf = c
+                .first_chunk_with_fourcc(fourcc::ANMF)
+                .expect("ANMF present");
+            let header = crate::anmf::AnmfHeader::parse(anmf.payload(&file)).expect("ANMF parse");
+            assert_eq!(
+                header.blend, blend,
+                "blend round-trips through the ANMF info byte"
+            );
+            // Sanity: the §2.7.1.1 Figure 9 info byte's B bit equals
+            // the expected value (bit 1).
+            assert_eq!(
+                (header.info_byte >> 1) & 1,
+                expected_b,
+                "info byte B bit = {expected_b}"
+            );
+        }
+    }
+
+    #[test]
+    fn with_dispose_emits_correct_info_byte_in_anmf_header() {
+        // Build a one-frame animation per builder method and re-parse
+        // the ANMF header to confirm the §2.7.1.1 Figure 9 info byte
+        // carries the requested `D` bit.
+        for (dispose, expected_d) in [
+            (DisposalMethod::None, 0u8),
+            (DisposalMethod::Background, 1u8),
+        ] {
+            let f =
+                AnimFrame::new(4, 4, solid_rgba(4, 4, [10, 20, 30, 255]), 80).with_dispose(dispose);
+            let file = build_animated_webp(&[f]).expect("build");
+            let c = crate::container::parse(&file).expect("container");
+            let anmf = c
+                .first_chunk_with_fourcc(fourcc::ANMF)
+                .expect("ANMF present");
+            let header = crate::anmf::AnmfHeader::parse(anmf.payload(&file)).expect("ANMF parse");
+            assert_eq!(
+                header.dispose, dispose,
+                "dispose round-trips through the ANMF info byte"
+            );
+            assert_eq!(header.info_byte & 1, expected_d, "info byte D bit");
+        }
     }
 }

--- a/src/anim_encode.rs
+++ b/src/anim_encode.rs
@@ -45,6 +45,7 @@
 use crate::anmf::{BlendingMethod, DisposalMethod};
 use crate::build::{self, Vp8xFlags};
 use crate::container::fourcc;
+use crate::near_lossless;
 use crate::vp8l_encode;
 use crate::{Error, WebpError, WebpMetadata};
 
@@ -107,6 +108,26 @@ pub struct AnimFrame {
     pub dispose: DisposalMethod,
     /// Per-frame compression mode.
     pub mode: AnimFrameMode,
+    /// Per-frame VP8L **near-lossless** preprocessing quality, on the
+    /// same `[0..=100]` scale documented in [`crate::near_lossless`]:
+    /// `100` (or any value ≥ 100) is a no-op identical to the baseline
+    /// encoder, `0` is maximum RGB-channel quantization. `None` (the
+    /// default) is equivalent to `Some(100)` — no quantization is
+    /// applied, and the per-frame VP8L bitstream is byte-exact-equal to
+    /// the pre-round-140 baseline.
+    ///
+    /// The preprocessing rounds each frame's R, G, B channels to the
+    /// nearest multiple of `2^n` (where
+    /// `n = near_lossless::bits_to_drop_for_quality(quality)`) *before*
+    /// the VP8L encode runs. Alpha is preserved bit-exactly. The
+    /// resulting `VP8L` chunk decodes back to the **quantized** pixels
+    /// through [`crate::decode_webp`] — no decoder change is needed.
+    ///
+    /// Applied identically to the full-keyframe ([`AnimFrameMode::Lossless`])
+    /// and dirty-rect ([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`])
+    /// emission paths; the [`AnimFrameMode::Auto`] size comparison is made
+    /// between the two *quantized* candidates.
+    pub near_lossless_quality: Option<u8>,
 }
 
 impl AnimFrame {
@@ -130,7 +151,17 @@ impl AnimFrame {
             blend: BlendingMethod::Overwrite,
             dispose: DisposalMethod::None,
             mode: AnimFrameMode::Lossless,
+            near_lossless_quality: None,
         }
+    }
+
+    /// Builder helper: set the per-frame near-lossless quality knob
+    /// in-place and return `self`. Equivalent to assigning
+    /// [`AnimFrame::near_lossless_quality`] directly; `None` (or
+    /// `Some(100)`) is the no-op baseline.
+    pub fn with_near_lossless_quality(mut self, quality: Option<u8>) -> Self {
+        self.near_lossless_quality = quality;
+        self
     }
 }
 
@@ -663,8 +694,11 @@ fn emit_full_anmf(
     h: u32,
     pixels: &[u8],
 ) -> Result<Vec<u8>, WebpError> {
-    let argb = rgba_to_argb(pixels);
+    let mut argb = rgba_to_argb(pixels);
     let has_alpha = pixels.chunks_exact(4).any(|px| px[3] != 0xff);
+    // Per-frame near-lossless preprocessing — no-op when the knob is
+    // `None` (default) or `Some(q)` with `q ≥ 100`. See `AnimFrame::near_lossless_quality`.
+    apply_near_lossless_if_requested(&mut argb, f.near_lossless_quality);
     let bitstream = vp8l_encode::encode_vp8l_argb_with(&argb, w, h, has_alpha)
         .map_err(Error::from)
         .map_err(WebpError::from)?;
@@ -687,8 +721,14 @@ fn emit_full_anmf(
 /// The caller's `dispose` is overridden to `None` regardless of what they
 /// passed — preserving it would corrupt the next frame's reference state.
 fn emit_dirty_anmf(f: &AnimFrame, rect: DirtyRect, sub_rgba: &[u8]) -> Result<Vec<u8>, WebpError> {
-    let argb = rgba_to_argb(sub_rgba);
+    let mut argb = rgba_to_argb(sub_rgba);
     let has_alpha = sub_rgba.chunks_exact(4).any(|px| px[3] != 0xff);
+    // Per-frame near-lossless preprocessing — applied identically to the
+    // dirty-rect sub-frame so an `AnimFrameMode::Delta` / `::Auto` frame
+    // with the knob set quantizes the *changed* sub-rectangle in the
+    // same way a full keyframe would. No-op when the knob is `None`
+    // (default) or `Some(q)` with `q ≥ 100`.
+    apply_near_lossless_if_requested(&mut argb, f.near_lossless_quality);
     let bitstream = vp8l_encode::encode_vp8l_argb_with(&argb, rect.w, rect.h, has_alpha)
         .map_err(Error::from)
         .map_err(WebpError::from)?;
@@ -742,6 +782,24 @@ fn push_u24_le(out: &mut Vec<u8>, v: u32) {
     out.push((v & 0xFF) as u8);
     out.push(((v >> 8) & 0xFF) as u8);
     out.push(((v >> 16) & 0xFF) as u8);
+}
+
+/// Run the VP8L near-lossless preprocessing pass on a packed-ARGB buffer
+/// when the per-frame knob is set to a value below 100. `None` and
+/// `Some(q)` with `q ≥ 100` are no-ops — the buffer is left untouched,
+/// guaranteeing byte-exact equivalence to the pre-round-140 baseline for
+/// the default `AnimFrame::new` construction.
+///
+/// Delegates to [`near_lossless::apply`] for the actual per-channel
+/// quantization; this helper exists only to centralise the
+/// `None | Some(100)` fast-path check across the full-keyframe and
+/// dirty-rect emission paths.
+fn apply_near_lossless_if_requested(argb: &mut [u32], quality: Option<u8>) {
+    if let Some(q) = quality {
+        // `near_lossless::apply` already short-circuits on `n == 0`, so
+        // we don't need a second check here.
+        near_lossless::apply(argb, q);
+    }
 }
 
 /// Repack interleaved `[R, G, B, A]` bytes into packed ARGB

--- a/src/anim_encode.rs
+++ b/src/anim_encode.rs
@@ -231,6 +231,15 @@ impl DeltaConfig {
 /// `background_rgba` is the `ANIM` background colour as `[R, G, B, A]`. The
 /// borrowed [`WebpMetadata`] carries optional ICC / Exif / XMP payloads to
 /// embed in the §2.7 chunk order. `delta` tunes the (blocked) delta path.
+///
+/// `default_near_lossless_quality` is the animation-wide fallback for the
+/// VP8L near-lossless preprocessing knob. It is consulted **only** when a
+/// frame's own [`AnimFrame::near_lossless_quality`] is `None`; a per-frame
+/// `Some(q)` always overrides the default. When both are absent — the
+/// pre-round-140 baseline — no quantization is applied and the per-frame
+/// VP8L bitstreams are byte-exact-equal to the baseline encoder
+/// (equivalent to `Some(100)` in either slot). See
+/// [`crate::near_lossless`] for the quality scale and step table.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AnimEncoderOptions<'a> {
     /// §2.7.1.1 `ANIM` loop count. `0` means "loop infinitely".
@@ -241,6 +250,28 @@ pub struct AnimEncoderOptions<'a> {
     pub metadata: WebpMetadata<'a>,
     /// Tuning for the (blocked) inter-frame delta path.
     pub delta: DeltaConfig,
+    /// Animation-wide default near-lossless quality used for every frame
+    /// whose own [`AnimFrame::near_lossless_quality`] is `None`. A
+    /// per-frame `Some(q)` always wins. `None` (the default) preserves
+    /// the pre-round-140 baseline behaviour — no quantization is applied.
+    /// The value uses the same `[0..=100]` scale documented in
+    /// [`crate::near_lossless`]: `100` (or any value ≥ 100) is a no-op
+    /// identical to the baseline encoder, `0` is maximum RGB-channel
+    /// quantization.
+    pub default_near_lossless_quality: Option<u8>,
+}
+
+impl<'a> AnimEncoderOptions<'a> {
+    /// Builder helper: set the animation-wide
+    /// [`AnimEncoderOptions::default_near_lossless_quality`] fallback
+    /// in-place and return `self`. `None` preserves the baseline (no
+    /// quantization); `Some(q)` applies the same `[0..=100]` knob to
+    /// every frame that did not set its own per-frame
+    /// [`AnimFrame::near_lossless_quality`].
+    pub fn with_default_near_lossless_quality(mut self, quality: Option<u8>) -> Self {
+        self.default_near_lossless_quality = quality;
+        self
+    }
 }
 
 /// Build an animated `.webp` from `frames`, defaulting all encoder options
@@ -358,8 +389,23 @@ pub fn build_animated_webp_with_options(
         if let Some((px, py, pw, ph, DisposalMethod::Background)) = prev_disposal {
             fill_canvas_rect_in_place(&mut prev_canvas, canvas_width, px, py, pw, ph, bg_rgba);
         }
-        let anmf_payload =
-            build_anmf_payload_with_prev(f, canvas_width, canvas_height, &prev_canvas, idx == 0)?;
+        // Resolve the effective near-lossless quality for this frame:
+        // a per-frame `Some(q)` always wins; a per-frame `None` falls back
+        // to the animation-wide
+        // [`AnimEncoderOptions::default_near_lossless_quality`]; when both
+        // are `None` the result is `None` (no quantization, baseline
+        // bitstream).
+        let effective_quality = f
+            .near_lossless_quality
+            .or(opts.default_near_lossless_quality);
+        let anmf_payload = build_anmf_payload_with_prev(
+            f,
+            canvas_width,
+            canvas_height,
+            &prev_canvas,
+            idx == 0,
+            effective_quality,
+        )?;
         push(fourcc::ANMF, &anmf_payload)?;
         // Update the canvas tracker with this frame's drawn pixels
         // (matching the decoder's blend method).
@@ -612,18 +658,27 @@ fn build_anim_payload(opts: &AnimEncoderOptions<'_>) -> Vec<u8> {
 ///
 /// For [`AnimFrameMode::Auto`], both candidates are encoded and the
 /// smaller VP8L bitstream wins.
+///
+/// `effective_quality` is the already-resolved near-lossless preprocessing
+/// knob for this frame: the per-frame
+/// [`AnimFrame::near_lossless_quality`] when set, else the animation-wide
+/// [`AnimEncoderOptions::default_near_lossless_quality`] fallback, else
+/// `None`. `None` and `Some(q ≥ 100)` are no-ops at the per-pixel level.
 fn build_anmf_payload_with_prev(
     f: &AnimFrame,
     canvas_w: u32,
     canvas_h: u32,
     prev: &[u8],
     is_first_frame: bool,
+    effective_quality: Option<u8>,
 ) -> Result<Vec<u8>, WebpError> {
     match f.mode {
-        AnimFrameMode::Lossless => emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels),
+        AnimFrameMode::Lossless => {
+            emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels, effective_quality)
+        }
         AnimFrameMode::Delta => {
             if is_first_frame {
-                emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels)
+                emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels, effective_quality)
             } else {
                 let rect =
                     dirty_rect_canvas_coords(f, canvas_w, canvas_h, prev).unwrap_or(DirtyRect {
@@ -639,13 +694,14 @@ fn build_anmf_payload_with_prev(
                         h: 2.min(f.height),
                     });
                 let sub_rgba = extract_subrect_from_frame(f, rect);
-                emit_dirty_anmf(f, rect, &sub_rgba)
+                emit_dirty_anmf(f, rect, &sub_rgba, effective_quality)
             }
         }
         AnimFrameMode::Auto => {
             // Always evaluate the full-frame candidate (and use it for the
             // first frame regardless).
-            let full = emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels)?;
+            let full =
+                emit_full_anmf(f, f.x, f.y, f.width, f.height, &f.pixels, effective_quality)?;
             if is_first_frame {
                 return Ok(full);
             }
@@ -659,7 +715,7 @@ fn build_anmf_payload_with_prev(
                     h: 2.min(f.height),
                 };
                 let sub_rgba = extract_subrect_from_frame(f, degen_rect);
-                let delta = emit_dirty_anmf(f, degen_rect, &sub_rgba)?;
+                let delta = emit_dirty_anmf(f, degen_rect, &sub_rgba, effective_quality)?;
                 return Ok(if delta.len() < full.len() {
                     delta
                 } else {
@@ -672,7 +728,7 @@ fn build_anmf_payload_with_prev(
                 return Ok(full);
             }
             let sub_rgba = extract_subrect_from_frame(f, rect);
-            let delta = emit_dirty_anmf(f, rect, &sub_rgba)?;
+            let delta = emit_dirty_anmf(f, rect, &sub_rgba, effective_quality)?;
             Ok(if delta.len() < full.len() {
                 delta
             } else {
@@ -686,6 +742,12 @@ fn build_anmf_payload_with_prev(
 /// the §2.7.1.1 Figure 9 16-byte ANMF header at `(x, y, w, h)` with the
 /// caller's blend/dispose/duration. Used by both the full-keyframe and
 /// dirty-rect emission paths.
+///
+/// `effective_quality` is the already-resolved near-lossless preprocessing
+/// knob the caller decided on (per-frame override, else the
+/// animation-wide [`AnimEncoderOptions::default_near_lossless_quality`]
+/// fallback, else `None`). `None` / `Some(q ≥ 100)` is the baseline.
+#[allow(clippy::too_many_arguments)]
 fn emit_full_anmf(
     f: &AnimFrame,
     x: u32,
@@ -693,12 +755,15 @@ fn emit_full_anmf(
     w: u32,
     h: u32,
     pixels: &[u8],
+    effective_quality: Option<u8>,
 ) -> Result<Vec<u8>, WebpError> {
     let mut argb = rgba_to_argb(pixels);
     let has_alpha = pixels.chunks_exact(4).any(|px| px[3] != 0xff);
-    // Per-frame near-lossless preprocessing — no-op when the knob is
-    // `None` (default) or `Some(q)` with `q ≥ 100`. See `AnimFrame::near_lossless_quality`.
-    apply_near_lossless_if_requested(&mut argb, f.near_lossless_quality);
+    // Near-lossless preprocessing — no-op when the resolved knob is
+    // `None` (default) or `Some(q)` with `q ≥ 100`. See
+    // `AnimFrame::near_lossless_quality` and
+    // `AnimEncoderOptions::default_near_lossless_quality`.
+    apply_near_lossless_if_requested(&mut argb, effective_quality);
     let bitstream = vp8l_encode::encode_vp8l_argb_with(&argb, w, h, has_alpha)
         .map_err(Error::from)
         .map_err(WebpError::from)?;
@@ -720,15 +785,21 @@ fn emit_full_anmf(
 /// compositor reconstructs the caller's full-canvas frame bit-exactly.
 /// The caller's `dispose` is overridden to `None` regardless of what they
 /// passed — preserving it would corrupt the next frame's reference state.
-fn emit_dirty_anmf(f: &AnimFrame, rect: DirtyRect, sub_rgba: &[u8]) -> Result<Vec<u8>, WebpError> {
+///
+/// `effective_quality` is the already-resolved near-lossless preprocessing
+/// knob for this frame; applied identically to the dirty-rect sub-frame
+/// so a [`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`] frame with the
+/// knob set quantizes the changed sub-rectangle the same way a full
+/// keyframe would.
+fn emit_dirty_anmf(
+    f: &AnimFrame,
+    rect: DirtyRect,
+    sub_rgba: &[u8],
+    effective_quality: Option<u8>,
+) -> Result<Vec<u8>, WebpError> {
     let mut argb = rgba_to_argb(sub_rgba);
     let has_alpha = sub_rgba.chunks_exact(4).any(|px| px[3] != 0xff);
-    // Per-frame near-lossless preprocessing — applied identically to the
-    // dirty-rect sub-frame so an `AnimFrameMode::Delta` / `::Auto` frame
-    // with the knob set quantizes the *changed* sub-rectangle in the
-    // same way a full keyframe would. No-op when the knob is `None`
-    // (default) or `Some(q)` with `q ≥ 100`.
-    apply_near_lossless_if_requested(&mut argb, f.near_lossless_quality);
+    apply_near_lossless_if_requested(&mut argb, effective_quality);
     let bitstream = vp8l_encode::encode_vp8l_argb_with(&argb, rect.w, rect.h, has_alpha)
         .map_err(Error::from)
         .map_err(WebpError::from)?;
@@ -987,5 +1058,22 @@ mod tests {
         assert_eq!(cfg.max_components, 3);
         assert_eq!(cfg.auto_inner_threshold_bytes, Some(512));
         assert_eq!(cfg.msssim_downsample_kernel, DownsampleKernel::Gaussian);
+    }
+
+    #[test]
+    fn anim_encoder_options_default_near_lossless_quality_default_is_none() {
+        let opts = AnimEncoderOptions::default();
+        assert_eq!(
+            opts.default_near_lossless_quality, None,
+            "default fallback must be None for byte-exact baseline"
+        );
+    }
+
+    #[test]
+    fn with_default_near_lossless_quality_builder_round_trips_field() {
+        let opts = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+        assert_eq!(opts.default_near_lossless_quality, Some(60));
+        let opts2 = AnimEncoderOptions::default().with_default_near_lossless_quality(None);
+        assert_eq!(opts2.default_near_lossless_quality, None);
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1198,4 +1198,71 @@ mod tests {
         }
         .is_empty());
     }
+
+    /// Canonical-inverse round trip at the writer level: build a file
+    /// with metadata, read the metadata chunks back out via the
+    /// container walker, then re-build with those bytes. The two files
+    /// must be byte-identical. Pins the writer's canonical §2.7 chunk
+    /// order and §2.3 pad-byte handling against any future drift.
+    #[test]
+    fn metadata_writer_canonical_inverse_round_trip_is_byte_identical() {
+        let payload = vec![0xC3u8; 11]; // odd-length bitstream → §2.3 pad
+        let icc = b"canonical-icc-payload".to_vec();
+        let exif = b"canonical-exif".to_vec(); // odd length too
+        let xmp = b"canonical-xmp-payload".to_vec();
+
+        let first = build_webp_file_with_metadata(
+            &payload,
+            ImageKind::ExtendedLossless,
+            32,
+            32,
+            MetadataPayloads {
+                icc: Some(&icc),
+                exif: Some(&exif),
+                xmp: Some(&xmp),
+            },
+        )
+        .unwrap();
+
+        // Recover the §2.7 metadata payloads through the container walker
+        // (the §2.3 pads are dropped on extract; only the declared
+        // payload bytes come back).
+        let c = parse(&first).expect("file parses");
+        let icc_back = c
+            .first_chunk_with_fourcc(fourcc::ICCP)
+            .map(|ch| ch.payload(&first).to_vec())
+            .expect("ICCP present");
+        let exif_back = c
+            .first_chunk_with_fourcc(fourcc::EXIF)
+            .map(|ch| ch.payload(&first).to_vec())
+            .expect("EXIF present");
+        let xmp_back = c
+            .first_chunk_with_fourcc(fourcc::XMP)
+            .map(|ch| ch.payload(&first).to_vec())
+            .expect("XMP present");
+
+        // Re-build with the round-tripped payloads. Canonical-inverse
+        // identity: the writer regenerates the same §2.7 chunk order,
+        // the same flag-octet, and the same §2.3 pad bytes, so the
+        // bytes must equal `first` exactly.
+        let second = build_webp_file_with_metadata(
+            &payload,
+            ImageKind::ExtendedLossless,
+            32,
+            32,
+            MetadataPayloads {
+                icc: Some(&icc_back),
+                exif: Some(&exif_back),
+                xmp: Some(&xmp_back),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            first, second,
+            "build_webp_file_with_metadata is the canonical inverse of \
+             the container walker on metadata chunks: re-building with \
+             the extracted payloads must produce byte-identical bytes"
+        );
+    }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -38,13 +38,25 @@
 //!   the body is a §2.7.1 `VP8X` chunk followed by the `VP8 ` / `VP8L`
 //!   chunk per §2.7's chunk-ordering rule.
 //!
+//! * [`build_webp_file_with_metadata`] — the §2.4 file writer extended
+//!   with the §2.7.1.4 `ICCP` and §2.7.1.5 `EXIF` / `XMP ` metadata
+//!   chunks. Given a single bitstream payload + image kind + canvas
+//!   dimensions + a [`MetadataPayloads`] bag, it picks the simple or
+//!   extended layout (auto-promoting whenever any metadata field is
+//!   set) and emits the chunks in the §2.7 order: `VP8X` first, then
+//!   `ICCP`, then the bitstream (`VP8 ` / `VP8L`), then `EXIF`, then
+//!   `XMP `. The §2.7.1 flag octet of the emitted `VP8X` declares
+//!   exactly which of the three metadata kinds are present.
+//!
 //! ## What is intentionally *not* here
 //!
-//! * No `ICCP` / `EXIF` / `XMP ` / `ANIM` / `ANMF` / `ALPH` writers —
-//!   round-5 wires only the still-image fast path. Once a `VP8L`
-//!   encoder lands, follow-up rounds can add metadata-chunk writers
-//!   plus a multi-frame `build_animated_webp_file` that walks an
-//!   ordered chunk list.
+//! * No `ANIM` / `ANMF` / `ALPH` writers in the still-image fast path
+//!   covered by this module. `ANIM` / `ANMF` framing lives in
+//!   [`crate::anim_encode`]; `ALPH` is emitted by the lossy /
+//!   alpha-encode path. Round 138 closed the metadata-chunk gap; the
+//!   `ICCP` / `EXIF` / `XMP ` writers below are spec-conformant with
+//!   §2.7's chunk-ordering rule and round-trip through
+//!   [`crate::container::parse`] + [`crate::extract_metadata`].
 //! * No payload validation. `build_webp_file` does not parse the bytes
 //!   the caller hands it as `payload`. A nonsense payload still
 //!   produces a structurally-valid RIFF — the responsibility for the
@@ -419,6 +431,163 @@ pub fn build_webp_file(
     Ok(out)
 }
 
+/// Borrowed payload bytes for the §2.7.1.4 `ICCP` and §2.7.1.5
+/// `EXIF` / `XMP ` metadata chunks the §2.7 extended layout can
+/// carry.
+///
+/// Each field is `None` to omit the corresponding chunk and `Some`
+/// to embed it. `Default` is all-`None`, matching the simple-layout
+/// fast path. The bytes are not copied — the writer frames them in
+/// place when [`build_webp_file_with_metadata`] runs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MetadataPayloads<'a> {
+    /// §2.7.1.4 `ICCP` ICC color-profile payload to embed, if any.
+    /// Setting this sets the §2.7.1 `I` bit in the emitted `VP8X`.
+    pub icc: Option<&'a [u8]>,
+    /// §2.7.1.5 `EXIF` Exif payload to embed, if any. Setting this
+    /// sets the §2.7.1 `E` bit in the emitted `VP8X`.
+    pub exif: Option<&'a [u8]>,
+    /// §2.7.1.5 `XMP ` XMP payload to embed, if any. Setting this
+    /// sets the §2.7.1 `X` bit in the emitted `VP8X`.
+    pub xmp: Option<&'a [u8]>,
+}
+
+impl<'a> MetadataPayloads<'a> {
+    /// True if every metadata field is `None`. When this is true and
+    /// the caller asks for a non-extended [`ImageKind`] and there is
+    /// no alpha to declare, [`build_webp_file_with_metadata`] can
+    /// stay on the simple §2.5 / §2.6 layout.
+    pub fn is_empty(&self) -> bool {
+        self.icc.is_none() && self.exif.is_none() && self.xmp.is_none()
+    }
+}
+
+/// Build a `RIFF/WEBP` file around a single bitstream payload **with
+/// optional file-level metadata**, per RFC 9649 §2.4 + §2.5 / §2.6 /
+/// §2.7.
+///
+/// Arguments mirror [`build_webp_file`] plus a [`MetadataPayloads`]
+/// bag. The writer makes the layout decision automatically:
+///
+/// * **Simple §2.5 / §2.6 layout** when `image_kind` is
+///   [`ImageKind::Lossy`] / [`ImageKind::Lossless`] *and* `metadata`
+///   is empty. The output is the single `VP8 ` / `VP8L` chunk wrapped
+///   in the §2.4 file header — same bytes [`build_webp_file`] would
+///   produce. The `metadata` argument MUST be empty when the caller
+///   asks for a simple kind, otherwise the writer would have to emit
+///   a `VP8X` (a structural change the caller didn't ask for); the
+///   writer therefore promotes to extended automatically when needed.
+///
+/// * **Extended §2.7 layout** when `image_kind` is
+///   [`ImageKind::ExtendedLossy`] / [`ImageKind::ExtendedLossless`],
+///   *or* whenever any metadata field is set (in which case a
+///   simple-kind input is promoted to its extended counterpart). The
+///   chunks emitted, in §2.7's documented order:
+///
+///   1. `VP8X` — flag octet declares exactly the metadata chunks
+///      that follow (`I` if `icc` is set, `E` if `exif`, `X` if
+///      `xmp`). `L` / `A` are left clear by this writer — alpha and
+///      animation declarations belong to layers that *also* emit the
+///      bitstream chunks they imply.
+///   2. `ICCP` — only when `metadata.icc` is `Some`.
+///   3. The bitstream chunk — `VP8 ` for the lossy kinds, `VP8L`
+///      for the lossless kinds.
+///   4. `EXIF` — only when `metadata.exif` is `Some`.
+///   5. `XMP ` — only when `metadata.xmp` is `Some`.
+///
+/// §2.7 explicitly permits `EXIF` / `XMP ` to appear in either order
+/// or anywhere after the bitstream chunk (they fall in the §2.7.1.5
+/// "may appear out of order" carve-out); this writer picks the
+/// `EXIF` → `XMP ` order to match the order [`crate::extract_metadata`]
+/// is most efficient at recovering and to keep the on-disk byte
+/// sequence deterministic for a given input.
+///
+/// Returns the complete on-disk byte stream including the §2.4 file
+/// header and any §2.3 pad bytes the chunks required.
+pub fn build_webp_file_with_metadata(
+    payload: &[u8],
+    image_kind: ImageKind,
+    canvas_width: u32,
+    canvas_height: u32,
+    metadata: MetadataPayloads<'_>,
+) -> Result<Vec<u8>, BuildError> {
+    // Fast path: simple kind + no metadata → identical to
+    // build_webp_file. Keep the byte-for-byte equivalence so callers
+    // that don't need metadata can switch between the two without a
+    // disk-image change.
+    if !image_kind.is_extended() && metadata.is_empty() {
+        return build_webp_file(payload, image_kind, canvas_width, canvas_height);
+    }
+
+    if payload.len() as u64 > MAX_CHUNK_PAYLOAD as u64 {
+        return Err(BuildError::PayloadTooLargeForChunk { got: payload.len() });
+    }
+
+    // Either the caller asked for an extended layout, or metadata is
+    // present and forces one. Promote simple kinds to their extended
+    // counterparts so the resulting file carries a VP8X declaring the
+    // metadata flags.
+    let bitstream_fourcc = image_kind.bitstream_fourcc();
+    let flags = Vp8xFlags {
+        has_iccp: metadata.icc.is_some(),
+        has_alpha: false,
+        has_exif: metadata.exif.is_some(),
+        has_xmp: metadata.xmp.is_some(),
+        has_animation: false,
+    };
+
+    let vp8x_payload = build_vp8x_chunk(canvas_width, canvas_height, flags)?;
+    let vp8x_chunk = build_chunk(fourcc::VP8X, &vp8x_payload)?;
+    let bitstream_chunk = build_chunk(bitstream_fourcc, payload)?;
+
+    let mut body: Vec<u8> = Vec::with_capacity(
+        vp8x_chunk.len()
+            + bitstream_chunk.len()
+            + metadata
+                .icc
+                .map(|b| 8 + b.len() + (b.len() & 1))
+                .unwrap_or(0)
+            + metadata
+                .exif
+                .map(|b| 8 + b.len() + (b.len() & 1))
+                .unwrap_or(0)
+            + metadata
+                .xmp
+                .map(|b| 8 + b.len() + (b.len() & 1))
+                .unwrap_or(0),
+    );
+
+    // §2.7 order: VP8X first.
+    body.extend_from_slice(&vp8x_chunk);
+    // §2.7.1.4: ICCP appears before the bitstream chunk(s).
+    if let Some(icc) = metadata.icc {
+        body.extend_from_slice(&build_chunk(fourcc::ICCP, icc)?);
+    }
+    // §2.5 / §2.6 bitstream chunk.
+    body.extend_from_slice(&bitstream_chunk);
+    // §2.7.1.5 EXIF / XMP appear after the bitstream chunk.
+    if let Some(exif) = metadata.exif {
+        body.extend_from_slice(&build_chunk(fourcc::EXIF, exif)?);
+    }
+    if let Some(xmp) = metadata.xmp {
+        body.extend_from_slice(&build_chunk(fourcc::XMP, xmp)?);
+    }
+
+    // §2.4: File Size = 4 ('WEBP' FourCC) + body length.
+    let file_size = (body.len() as u64) + 4;
+    if file_size > u64::from(u32::MAX) {
+        return Err(BuildError::PayloadTooLargeForChunk { got: payload.len() });
+    }
+    let file_size = file_size as u32;
+
+    let mut out = Vec::with_capacity(12 + body.len());
+    out.extend_from_slice(&fourcc::RIFF);
+    out.extend_from_slice(&file_size.to_le_bytes());
+    out.extend_from_slice(&fourcc::WEBP);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -754,5 +923,279 @@ mod tests {
             Err(ContainerError::ChunkPayloadOverflowsRiff { .. }) => {}
             other => panic!("expected ChunkPayloadOverflowsRiff, got {other:?}"),
         }
+    }
+
+    // ───────── build_webp_file_with_metadata (round 138) ─────────
+
+    /// Simple kind + empty metadata → byte-for-byte identical to
+    /// [`build_webp_file`]. The metadata writer collapses to the
+    /// no-metadata fast path so a caller that has no ICC / Exif /
+    /// XMP doesn't pay for a VP8X they didn't ask for.
+    #[test]
+    fn metadata_writer_no_metadata_matches_build_webp_file_byte_for_byte() {
+        let payload = b"\xDE\xAD\xBE\xEF\x01\x02\x03"; // 7 bytes, odd
+        for kind in [ImageKind::Lossy, ImageKind::Lossless] {
+            let baseline = build_webp_file(payload, kind, 0, 0).unwrap();
+            let with_meta =
+                build_webp_file_with_metadata(payload, kind, 0, 0, MetadataPayloads::default())
+                    .unwrap();
+            assert_eq!(
+                baseline, with_meta,
+                "simple {kind:?} with empty metadata diverged from build_webp_file"
+            );
+        }
+    }
+
+    /// Metadata present on a simple-kind input auto-promotes to the
+    /// extended layout — the §2.7 chunk-ordering rule forbids a
+    /// `VP8 ` / `VP8L`-only file from carrying `ICCP` / `EXIF` /
+    /// `XMP `. The flag octet declares exactly the kinds present.
+    #[test]
+    fn metadata_writer_simple_kind_with_metadata_promotes_to_extended() {
+        let payload = vec![0u8; 6];
+        let icc = b"icc-bytes".to_vec();
+        let meta = MetadataPayloads {
+            icc: Some(&icc),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 8, 8, meta).unwrap();
+        let c = parse(&bytes).expect("file parses");
+        // VP8X first, then ICCP, then VP8L.
+        let order: Vec<_> = c.chunks.iter().map(|c| c.fourcc).collect();
+        assert_eq!(order, vec![fourcc::VP8X, fourcc::ICCP, fourcc::VP8L]);
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(vp8x.has_iccp, "I bit must be set when ICCP is emitted");
+        assert!(!vp8x.has_exif);
+        assert!(!vp8x.has_xmp);
+        assert!(!vp8x.has_alpha);
+        assert!(!vp8x.has_animation);
+        // Payload recovered byte-for-byte from the ICCP chunk.
+        let iccp = c.first_chunk_with_fourcc(fourcc::ICCP).unwrap();
+        assert_eq!(iccp.payload(&bytes), &icc[..]);
+        // Bitstream payload survives intact.
+        let vp8l = c.first_chunk_with_fourcc(fourcc::VP8L).unwrap();
+        assert_eq!(vp8l.payload(&bytes), &payload[..]);
+    }
+
+    /// All three metadata kinds together — verifies the §2.7 chunk
+    /// order (VP8X → ICCP → bitstream → EXIF → XMP) and that each
+    /// payload survives the round trip byte-for-byte.
+    #[test]
+    fn metadata_writer_emits_all_three_kinds_in_spec_order() {
+        let payload = vec![0xAAu8; 5]; // odd → pad byte exercises §2.3
+        let icc = b"ICC color profile bytes".to_vec();
+        let exif = b"Exif\x00\x00MM\x00*\x00\x00\x00\x08".to_vec();
+        let xmp = b"<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>".to_vec();
+        let meta = MetadataPayloads {
+            icc: Some(&icc),
+            exif: Some(&exif),
+            xmp: Some(&xmp),
+        };
+        let bytes = build_webp_file_with_metadata(&payload, ImageKind::ExtendedLossy, 16, 16, meta)
+            .unwrap();
+        let c = parse(&bytes).expect("file parses");
+        let order: Vec<_> = c.chunks.iter().map(|c| c.fourcc).collect();
+        assert_eq!(
+            order,
+            vec![
+                fourcc::VP8X,
+                fourcc::ICCP,
+                fourcc::VP8,
+                fourcc::EXIF,
+                fourcc::XMP,
+            ],
+            "RFC 9649 §2.7 chunk order: VP8X → ICCP → bitstream → EXIF → XMP"
+        );
+        // VP8X flag bits declare all three kinds.
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(vp8x.has_iccp);
+        assert!(vp8x.has_exif);
+        assert!(vp8x.has_xmp);
+        assert_eq!(vp8x.canvas_width, 16);
+        assert_eq!(vp8x.canvas_height, 16);
+        // Every metadata payload survives byte-for-byte.
+        assert_eq!(
+            c.first_chunk_with_fourcc(fourcc::ICCP)
+                .unwrap()
+                .payload(&bytes),
+            &icc[..]
+        );
+        assert_eq!(
+            c.first_chunk_with_fourcc(fourcc::EXIF)
+                .unwrap()
+                .payload(&bytes),
+            &exif[..]
+        );
+        assert_eq!(
+            c.first_chunk_with_fourcc(fourcc::XMP)
+                .unwrap()
+                .payload(&bytes),
+            &xmp[..]
+        );
+    }
+
+    /// Per-kind isolation: each of ICCP / EXIF / XMP, on its own,
+    /// sets only its own flag bit and emits only its own chunk.
+    /// Guards against accidentally OR-ing flag bits that the caller
+    /// did not request, and against accidentally emitting a chunk
+    /// for a `None` field.
+    #[test]
+    fn metadata_writer_each_kind_in_isolation_sets_only_its_flag() {
+        let payload = vec![0u8; 4];
+        let blob = b"per-kind-test-payload".to_vec();
+
+        // ICCP only.
+        let meta = MetadataPayloads {
+            icc: Some(&blob),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 2, 2, meta).unwrap();
+        let c = parse(&bytes).unwrap();
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(vp8x.has_iccp);
+        assert!(!vp8x.has_exif);
+        assert!(!vp8x.has_xmp);
+        assert_eq!(c.chunks_with_fourcc(fourcc::ICCP).count(), 1);
+        assert_eq!(c.chunks_with_fourcc(fourcc::EXIF).count(), 0);
+        assert_eq!(c.chunks_with_fourcc(fourcc::XMP).count(), 0);
+
+        // EXIF only.
+        let meta = MetadataPayloads {
+            exif: Some(&blob),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 2, 2, meta).unwrap();
+        let c = parse(&bytes).unwrap();
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(!vp8x.has_iccp);
+        assert!(vp8x.has_exif);
+        assert!(!vp8x.has_xmp);
+        assert_eq!(c.chunks_with_fourcc(fourcc::ICCP).count(), 0);
+        assert_eq!(c.chunks_with_fourcc(fourcc::EXIF).count(), 1);
+        assert_eq!(c.chunks_with_fourcc(fourcc::XMP).count(), 0);
+
+        // XMP only.
+        let meta = MetadataPayloads {
+            xmp: Some(&blob),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 2, 2, meta).unwrap();
+        let c = parse(&bytes).unwrap();
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(!vp8x.has_iccp);
+        assert!(!vp8x.has_exif);
+        assert!(vp8x.has_xmp);
+        assert_eq!(c.chunks_with_fourcc(fourcc::ICCP).count(), 0);
+        assert_eq!(c.chunks_with_fourcc(fourcc::EXIF).count(), 0);
+        assert_eq!(c.chunks_with_fourcc(fourcc::XMP).count(), 1);
+    }
+
+    /// Odd-length metadata payloads trigger the §2.3 pad byte. The
+    /// parser sees the pad byte and the declared `Size` matches the
+    /// (un-padded) payload length, so the round trip recovers the
+    /// original bytes without the pad leaking into the payload slice.
+    #[test]
+    fn metadata_writer_pads_odd_length_payloads_per_section_2_3() {
+        let payload = vec![0u8; 4]; // even
+        let exif = vec![0xEFu8; 7]; // odd → pad needed
+        let meta = MetadataPayloads {
+            exif: Some(&exif),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 1, 1, meta).unwrap();
+        let c = parse(&bytes).expect("padded file parses");
+        let chunk = c.first_chunk_with_fourcc(fourcc::EXIF).unwrap();
+        assert_eq!(chunk.size, 7, "Size field excludes the §2.3 pad byte");
+        assert_eq!(
+            chunk.payload(&bytes),
+            &exif[..],
+            "payload slice excludes the §2.3 pad byte"
+        );
+        // The pad byte sits in the on-disk stream past `payload_end`.
+        assert_eq!(bytes[chunk.payload_end], 0u8);
+    }
+
+    /// Empty metadata strings (zero-length payloads) are allowed —
+    /// the chunk is still emitted (with `Size = 0` and no pad byte)
+    /// and the flag bit is still set.
+    #[test]
+    fn metadata_writer_accepts_empty_metadata_payloads() {
+        let payload = vec![0u8; 4];
+        let empty: &[u8] = &[];
+        let meta = MetadataPayloads {
+            xmp: Some(empty),
+            ..Default::default()
+        };
+        let bytes =
+            build_webp_file_with_metadata(&payload, ImageKind::Lossless, 1, 1, meta).unwrap();
+        let c = parse(&bytes).unwrap();
+        let xmp = c.first_chunk_with_fourcc(fourcc::XMP).unwrap();
+        assert_eq!(xmp.size, 0);
+        assert!(xmp.payload(&bytes).is_empty());
+        let vp8x = Vp8xHeader::parse(c.chunks[0].payload(&bytes)).unwrap();
+        assert!(vp8x.has_xmp);
+    }
+
+    /// Extended-kind input + empty metadata = the same VP8X-fronted
+    /// layout the existing `build_webp_file` would produce, with no
+    /// metadata-flag bits set.
+    #[test]
+    fn metadata_writer_extended_kind_with_no_metadata_matches_build_webp_file() {
+        let payload = vec![0u8; 8];
+        let baseline = build_webp_file(&payload, ImageKind::ExtendedLossy, 100, 100).unwrap();
+        let with_meta = build_webp_file_with_metadata(
+            &payload,
+            ImageKind::ExtendedLossy,
+            100,
+            100,
+            MetadataPayloads::default(),
+        )
+        .unwrap();
+        assert_eq!(baseline, with_meta);
+    }
+
+    /// Canvas-validation errors propagate out of the metadata writer
+    /// whenever the extended layout is exercised (either via an
+    /// explicit extended kind or via metadata-driven promotion).
+    #[test]
+    fn metadata_writer_propagates_canvas_validation_errors() {
+        let icc = b"x".to_vec();
+        let meta = MetadataPayloads {
+            icc: Some(&icc),
+            ..Default::default()
+        };
+        // 0 width forces a CanvasDimZero from build_vp8x_chunk.
+        assert_eq!(
+            build_webp_file_with_metadata(&[0u8; 4], ImageKind::Lossless, 0, 1, meta).unwrap_err(),
+            BuildError::CanvasDimZero { which: "width" }
+        );
+    }
+
+    /// `MetadataPayloads::is_empty` matches what the writer uses
+    /// internally to choose the fast path.
+    #[test]
+    fn metadata_payloads_is_empty_matches_writer_fast_path_predicate() {
+        assert!(MetadataPayloads::default().is_empty());
+        let blob: &[u8] = b"x";
+        assert!(!MetadataPayloads {
+            icc: Some(blob),
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!MetadataPayloads {
+            exif: Some(blob),
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!MetadataPayloads {
+            xmp: Some(blob),
+            ..Default::default()
+        }
+        .is_empty());
     }
 }

--- a/src/encoder_vp8.rs
+++ b/src/encoder_vp8.rs
@@ -1,0 +1,406 @@
+//! Published §2.5 `VP8 ` (lossy) **encoder** surface — API-shape stubs.
+//!
+//! ## Status: API-only stub, no pixel encode (round 131)
+//!
+//! The published-0.1.5 `oxideav-webp` crate exposed a family of VP8
+//! lossy encode entry points (`encode_vp8_lossy_rgba`,
+//! `encode_vp8_lossy_yuv420p`, `encoder_vp8::make_encoder_with_quality`,
+//! …) — see `API-COMPAT.md` for the full list. The current sibling
+//! crate `oxideav-vp8 = "0.2"` ships only **Phase 1** of the encoder:
+//!
+//! * a working §7.3 boolean-range entropy *encoder* primitive;
+//! * the §9.1 / §9.3 / §9.4 / §9.5 / §9.6 / §9.9 / §9.10 / §9.11
+//!   frame-header writer subroutines;
+//! * [`oxideav_vp8::encode_silent_keyframe`] — a top-level driver
+//!   that emits a *structurally valid VP8 key frame* in which every
+//!   macroblock carries `mb_skip_coeff = 1` with `DC_PRED` luma +
+//!   chroma. The encoder **ignores its pixel input entirely** — the
+//!   produced frame is a constant-grey picture regardless of what
+//!   `rgba` the caller passes; and
+//! * the §13 [`oxideav_vp8::TokenEncoder`] primitive (Phase 2,
+//!   per-block), which can encode pre-computed `[i16; 16]`
+//!   coefficient blocks but is **not** driven from pixels yet.
+//!
+//! Specifically, `oxideav-vp8 = "0.2"` does **not** expose:
+//!
+//! 1. A forward DCT (§14.4) / forward WHT (§14.3) on a 4×4 / Y2 block.
+//! 2. A pixel-driven §12 intra-prediction search or per-MB residual
+//!    computation.
+//! 3. §14.1 quantization (the encoder side, with its `ac_qlookup` /
+//!    `dc_qlookup` rounding rules).
+//! 4. A per-MB encode driver that consumes a 16×16 luma + 8×8 chroma
+//!    block and emits the §11 mode records plus §13 token stream that
+//!    [`TokenEncoder`] would consume.
+//! 5. A top-level "encode RGBA → VP8 keyframe" function.
+//!
+//! Without (1)–(5), threading a real RGBA picture through
+//! `encode_silent_keyframe` would produce a constant-grey VP8 stream
+//! that the WebP RIFF wrapper would dutifully package — i.e. **garbage
+//! bytes**, the exact failure mode the round-131 directive explicitly
+//! forbids ("DO NOT pretend to wire it … what's NOT valid is producing
+//! a 'VP8 lossy' function that returns garbage bytes").
+//!
+//! This module therefore lands the **API surface** required by
+//! `API-COMPAT.md` — the function names, types, constants, and registry
+//! entry — so downstream consumers compile and so a future round can
+//! drop a working encoder in without an API churn. Every entry point
+//! returns a clean
+//! [`crate::WebpError::Unsupported`] / `oxideav_core::Error::Unsupported`
+//! at call time; no encoded bytes are produced unless and until the
+//! upstream §13 / §14 encode round on `oxideav-vp8` lands the pixel
+//! path.
+//!
+//! ## Gap report (for the parent's round-131 ledger)
+//!
+//! The work that must land on `oxideav-vp8` to unblock real wiring
+//! here:
+//!
+//! * **§14.3 forward WHT** + **§14.4 forward 4×4 DCT** — inverse
+//!   primitives already exist on the decode side; the forward
+//!   primitives are pure numeric kernels.
+//! * **§14.1 forward quantization** — multiply / round-to-nearest
+//!   against `ac_qlookup` / `dc_qlookup`, mirroring
+//!   [`oxideav_vp8::MbDequantFactors`].
+//! * **§12 pixel-driven intra-mode search** — pick `DC_PRED` /
+//!   `V_PRED` / `H_PRED` / `TM_PRED` (or `B_PRED`) per MB; for a v0
+//!   encoder, a fixed `DC_PRED` choice that *honours the predicted
+//!   pixels* is sufficient.
+//! * **Per-MB encode driver** consuming a 16×16 luma + two 8×8 chroma
+//!   block, emitting (a) the §11 mode record, (b) the dequantized
+//!   reference reconstruction (for the §15 loop filter's neighbour
+//!   reads), and (c) the §13 token-stream bytes [`TokenEncoder`]
+//!   already wraps.
+//! * **Top-level "encode I420 → VP8 keyframe"** driver — this is the
+//!   one this module would call. Inputs: planar I420 + dimensions +
+//!   `qindex`; output: a complete VP8 keyframe bitstream the existing
+//!   [`oxideav_vp8::decode_vp8`] decodes back.
+//!
+//! Once that lands, the bodies of
+//! [`crate::encode_vp8_lossy_yuv420p`] / [`crate::encode_vp8_lossy_rgba`]
+//! / [`make_encoder_with_quality`] become a thin call into the new
+//! `oxideav_vp8` entry plus the existing
+//! [`crate::build::build_webp_file`] RIFF wrapper.
+
+use crate::WebpError;
+#[cfg(feature = "registry")]
+use crate::WebpMetadataOwned;
+
+/// `qindex` band for [`make_encoder_with_qindex`] — RFC 6386 §9.6
+/// `y_ac_qi` baseline (0..=127, lower = better quality, higher = more
+/// compression). Mirrors `oxideav-vp8`'s
+/// [`oxideav_vp8::SilentKeyframeParams::y_ac_qi`] field.
+pub const QINDEX_MIN: u8 = 0;
+/// Upper bound on the §9.6 `y_ac_qi` baseline (RFC 6386 — 7-bit
+/// quantiser index).
+pub const QINDEX_MAX: u8 = 127;
+
+/// libwebp-style quality scale used by [`make_encoder_with_quality`].
+///
+/// The mapping is `qindex = round((100 - quality) * 127 / 100)`,
+/// i.e. `quality = 100` → `qindex = 0` (best quality, biggest file),
+/// `quality = 0` → `qindex = 127` (worst quality, smallest file).
+pub const QUALITY_MIN: f32 = 0.0;
+/// Upper bound on the libwebp-style quality scale.
+pub const QUALITY_MAX: f32 = 100.0;
+/// Default quality libwebp's `cwebp` uses when no `-q` flag is supplied —
+/// preserved as the default for [`make_encoder_with_quality`] omissions.
+pub const DEFAULT_QUALITY: f32 = 75.0;
+
+/// Map a libwebp-style 0..=100 quality value to the RFC 6386 §9.6
+/// 0..=127 `y_ac_qi` baseline.
+///
+/// Out-of-range values clamp; NaN folds to [`DEFAULT_QUALITY`]'s mapping.
+/// This is a public utility so callers can mix-and-match the two scales
+/// freely.
+pub fn quality_to_qindex(quality: f32) -> u8 {
+    let q = if quality.is_nan() {
+        DEFAULT_QUALITY
+    } else {
+        quality.clamp(QUALITY_MIN, QUALITY_MAX)
+    };
+    let qi = ((QUALITY_MAX - q) * (QINDEX_MAX as f32) / QUALITY_MAX).round();
+    qi.clamp(QINDEX_MIN as f32, QINDEX_MAX as f32) as u8
+}
+
+/// Frequency-band delta knobs the published-0.1.5 API surfaced for the
+/// VP8 lossy encoder's perceptual-RDO ladder.
+///
+/// **API-shape stub.** The published crate carried these so a caller
+/// could fine-tune the quantiser deltas applied per AC-frequency band
+/// (low / mid / high luma + chroma) without dropping out to a custom
+/// `qindex`. The current rebuild stores the fields verbatim so the type
+/// round-trips through `params.extradata`, but they have **no effect**
+/// on the encoder output yet — the encoder itself is not pixel-driven
+/// (see the module-level note).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Vp8FreqDeltas {
+    /// Quantiser delta applied to the luma DC coefficient (low band).
+    pub luma_dc: i8,
+    /// Quantiser delta applied to the luma low-frequency AC band.
+    pub luma_low_ac: i8,
+    /// Quantiser delta applied to the luma high-frequency AC band.
+    pub luma_high_ac: i8,
+    /// Quantiser delta applied to the chroma DC coefficient.
+    pub chroma_dc: i8,
+    /// Quantiser delta applied to the chroma AC coefficients.
+    pub chroma_ac: i8,
+}
+
+impl Vp8FreqDeltas {
+    /// All-zero deltas — the baseline a stub encoder would emit even if
+    /// it were pixel-driven.
+    pub const fn zero() -> Self {
+        Self {
+            luma_dc: 0,
+            luma_low_ac: 0,
+            luma_high_ac: 0,
+            chroma_dc: 0,
+            chroma_ac: 0,
+        }
+    }
+}
+
+/// Per-image psy-visual statistics the published-0.1.5
+/// [`compute_psy_stats`] surface returned.
+///
+/// **API-shape stub.** A future round will populate this from the
+/// caller's RGBA / YUV input (band energy, edge density, …). Today,
+/// [`compute_psy_stats`] returns the all-zero default so downstream
+/// consumers that pipe it back into
+/// [`make_encoder_with_quality_and_freq_deltas`] / similar
+/// see the same value they'd see from a no-op.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Vp8PsyStats {
+    /// Mean per-pixel luma activity. Placeholder; not yet computed.
+    pub luma_activity: f32,
+    /// Mean per-pixel chroma activity. Placeholder; not yet computed.
+    pub chroma_activity: f32,
+}
+
+/// Compute the [`Vp8PsyStats`] for an RGBA input — published-API
+/// shape; **returns all-zero** until the VP8 lossy encoder is
+/// pixel-driven.
+///
+/// Length validation is still enforced (`rgba.len() ==
+/// width * height * 4`) so callers see the same error they would
+/// from a real implementation.
+pub fn compute_psy_stats(width: u32, height: u32, rgba: &[u8]) -> Result<Vp8PsyStats, WebpError> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(WebpError::InvalidData)?;
+    if rgba.len() != expected {
+        return Err(WebpError::InvalidData);
+    }
+    Ok(Vp8PsyStats::default())
+}
+
+/// Derive the per-band `Vp8FreqDeltas` an encoder would apply for the
+/// given baseline `qindex` — published-API shape; **returns
+/// `Vp8FreqDeltas::zero()`** until the VP8 lossy encoder is
+/// pixel-driven.
+pub fn freq_deltas_for_qindex(qindex: u8) -> Vp8FreqDeltas {
+    debug_assert!(qindex <= QINDEX_MAX);
+    Vp8FreqDeltas::zero()
+}
+
+// ───────────────────────── Encoder factories (registry-side) ─────────────────────────
+//
+// API-COMPAT.md spells out the published direct-factory family
+// (`make_encoder_with_quality`, `make_encoder_with_qindex`,
+// `make_encoder_with_target_size`, and the
+// `_and_metadata` / `_and_freq_deltas` variants). The registry-feature
+// gate matches `oxideav-core`'s — when `default-features = false` is
+// set on this crate the framework dep drops, so the trait-object
+// factories below drop with it.
+
+#[cfg(feature = "registry")]
+mod factories {
+    use super::*;
+    use crate::registry::{Vp8LossyEncoderConfig, WebpVp8LossyEncoder};
+    use oxideav_core::{CodecId, CodecParameters, Encoder, Error as CoreError, MediaType};
+
+    /// Build a configured VP8 lossy encoder from a baseline
+    /// libwebp-style `quality` value (0..=100, default 75).
+    ///
+    /// **Stub.** The encoder builds and registers fine; the first
+    /// `send_frame` will fail with [`oxideav_core::Error::Unsupported`]
+    /// per the module-level gap note. The published surface keeps the
+    /// factory signature so callers compile; once `oxideav-vp8` lands
+    /// the §13/§14 encode round the same construction starts emitting
+    /// real bytes.
+    pub fn make_encoder_with_quality(
+        params: &CodecParameters,
+        quality: f32,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex(params, quality_to_qindex(quality))
+    }
+
+    /// Build a configured VP8 lossy encoder from a baseline `qindex`
+    /// (RFC 6386 §9.6 `y_ac_qi`, 0..=127 — lower = better quality).
+    ///
+    /// **Stub.** See [`make_encoder_with_quality`].
+    pub fn make_encoder_with_qindex(
+        params: &CodecParameters,
+        qindex: u8,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex_and_metadata(params, qindex, WebpMetadataOwned::default())
+    }
+
+    /// Build a configured VP8 lossy encoder driven by a target output
+    /// size in bytes — the published "size-pass" mode.
+    ///
+    /// **Stub.** Currently maps to a deterministic
+    /// `qindex` chosen by [`quality_to_qindex`] for the libwebp default
+    /// quality; the real size search is part of the deferred
+    /// pixel-encode round.
+    pub fn make_encoder_with_target_size(
+        params: &CodecParameters,
+        _target_bytes: usize,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex(params, quality_to_qindex(DEFAULT_QUALITY))
+    }
+
+    /// Build a configured VP8 lossy encoder from a baseline `qindex`
+    /// and embed the supplied file-level metadata into every encoded
+    /// `.webp`.
+    pub fn make_encoder_with_qindex_and_metadata(
+        params: &CodecParameters,
+        qindex: u8,
+        metadata: WebpMetadataOwned,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex_and_freq_deltas(params, qindex, Vp8FreqDeltas::zero(), metadata)
+    }
+
+    /// Build a configured VP8 lossy encoder from a baseline `quality`
+    /// and embed the supplied file-level metadata.
+    pub fn make_encoder_with_quality_and_metadata(
+        params: &CodecParameters,
+        quality: f32,
+        metadata: WebpMetadataOwned,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex_and_metadata(params, quality_to_qindex(quality), metadata)
+    }
+
+    /// Build a configured VP8 lossy encoder with explicit per-band
+    /// quantiser deltas on top of a baseline `qindex`.
+    pub fn make_encoder_with_qindex_and_freq_deltas(
+        params: &CodecParameters,
+        qindex: u8,
+        freq_deltas: Vp8FreqDeltas,
+        metadata: WebpMetadataOwned,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        if qindex > QINDEX_MAX {
+            return Err(CoreError::invalid(format!(
+                "webp_vp8 encoder: qindex {qindex} exceeds the §9.6 0..=127 range"
+            )));
+        }
+        let width = params
+            .width
+            .ok_or_else(|| CoreError::invalid("webp_vp8 encoder: missing width"))?;
+        let height = params
+            .height
+            .ok_or_else(|| CoreError::invalid("webp_vp8 encoder: missing height"))?;
+
+        let mut output_params = params.clone();
+        output_params.media_type = MediaType::Video;
+        output_params.codec_id = CodecId::new(crate::CODEC_ID_VP8);
+
+        Ok(Box::new(WebpVp8LossyEncoder::new(
+            output_params,
+            Vp8LossyEncoderConfig {
+                width,
+                height,
+                pix: params.pixel_format,
+                qindex,
+                freq_deltas,
+                metadata,
+            },
+        )))
+    }
+
+    /// Build a configured VP8 lossy encoder with explicit per-band
+    /// quantiser deltas on top of a baseline `quality`.
+    pub fn make_encoder_with_quality_and_freq_deltas(
+        params: &CodecParameters,
+        quality: f32,
+        freq_deltas: Vp8FreqDeltas,
+        metadata: WebpMetadataOwned,
+    ) -> oxideav_core::Result<Box<dyn Encoder>> {
+        make_encoder_with_qindex_and_freq_deltas(
+            params,
+            quality_to_qindex(quality),
+            freq_deltas,
+            metadata,
+        )
+    }
+}
+
+#[cfg(feature = "registry")]
+pub use factories::{
+    make_encoder_with_qindex, make_encoder_with_qindex_and_freq_deltas,
+    make_encoder_with_qindex_and_metadata, make_encoder_with_quality,
+    make_encoder_with_quality_and_freq_deltas, make_encoder_with_quality_and_metadata,
+    make_encoder_with_target_size,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_to_qindex_endpoints_round_correctly() {
+        // libwebp convention: quality=100 → qindex=0; quality=0 → qindex=127.
+        assert_eq!(quality_to_qindex(100.0), 0);
+        assert_eq!(quality_to_qindex(0.0), 127);
+        // Default sits roughly in the middle of the band.
+        let qi = quality_to_qindex(DEFAULT_QUALITY);
+        assert!(qi > 0 && qi < QINDEX_MAX, "qindex {qi} should be mid-band");
+    }
+
+    #[test]
+    fn quality_to_qindex_clamps_out_of_range() {
+        assert_eq!(quality_to_qindex(-10.0), QINDEX_MAX);
+        assert_eq!(quality_to_qindex(200.0), QINDEX_MIN);
+        // NaN folds to the default quality's qindex.
+        assert_eq!(
+            quality_to_qindex(f32::NAN),
+            quality_to_qindex(DEFAULT_QUALITY)
+        );
+    }
+
+    #[test]
+    fn freq_deltas_default_is_zero() {
+        let d = Vp8FreqDeltas::default();
+        assert_eq!(d, Vp8FreqDeltas::zero());
+    }
+
+    #[test]
+    fn freq_deltas_for_qindex_is_zero_stub() {
+        // Stub: every qindex returns zero deltas today.
+        for qi in 0u8..=QINDEX_MAX {
+            assert_eq!(freq_deltas_for_qindex(qi), Vp8FreqDeltas::zero());
+        }
+    }
+
+    #[test]
+    fn compute_psy_stats_validates_buffer_length() {
+        // 2×2 image → 16 RGBA bytes.
+        assert!(compute_psy_stats(2, 2, &[0u8; 16]).is_ok());
+        // Wrong length — caller bug, not a pixel-encoder bug.
+        assert_eq!(
+            compute_psy_stats(2, 2, &[0u8; 15]),
+            Err(WebpError::InvalidData)
+        );
+        assert_eq!(
+            compute_psy_stats(2, 2, &[0u8; 17]),
+            Err(WebpError::InvalidData)
+        );
+    }
+
+    #[test]
+    fn compute_psy_stats_returns_default_stub() {
+        let s = compute_psy_stats(1, 1, &[0u8; 4]).unwrap();
+        assert_eq!(s, Vp8PsyStats::default());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub mod anim_encode;
 pub mod anmf;
 pub mod build;
 pub mod container;
+pub mod encoder_vp8;
 pub mod meta_prefix;
 #[cfg(feature = "registry")]
 pub mod registry;
@@ -1418,6 +1419,156 @@ pub fn encode_vp8l_argb_with_metadata(
     out.extend_from_slice(&container::fourcc::WEBP);
     out.extend_from_slice(&body);
     Ok(out)
+}
+
+// ─────────────────────── Published-shape VP8 (lossy) encode API ───────────────────────
+//
+// The published-0.1.5 `encode_vp8_lossy_*` surface from `API-COMPAT.md`,
+// rebuilt as **API-shape stubs**: every entry point returns
+// `WebpError::Unsupported` because the sibling `oxideav-vp8 = "0.2"` crate's
+// encoder is currently mid-Phase 2 — `encode_silent_keyframe` ships, but it
+// ignores the caller's pixels and emits a constant-grey frame. Wiring those
+// pixels through to a constant-grey VP8 stream wrapped in WebP RIFF would
+// produce *garbage bytes that decode to the wrong picture*, exactly the
+// failure mode the round-131 directive explicitly forbids.
+//
+// Once `oxideav-vp8` lands the §13 / §14 pixel-driven encode round (see the
+// `encoder_vp8` module-level gap report for the exact missing primitives),
+// the function bodies below become a thin pair of calls: convert the input
+// to I420, hand it to the new vp8 encoder for a real bitstream, then wrap
+// with `build::build_webp_file` (already implemented). The function
+// signatures are stable now so downstream consumers compile against the
+// final shape and the encode-side wiring lands without an API churn.
+
+/// Stable codec identifier the VP8 lossy encoder registers under in the
+/// codec registry — the published `"webp_vp8"` name. The matching VP8L
+/// (lossless) constant is [`CODEC_ID_VP8L`].
+pub const CODEC_ID_VP8: &str = "webp_vp8";
+
+/// Encode a planar I420 (YUV 4:2:0) picture to a complete §2.5 simple-lossy
+/// `.webp` file.
+///
+/// **Stub — returns [`WebpError::Unsupported`].** The wiring to
+/// `oxideav-vp8`'s encoder is blocked on the §13 / §14 pixel-driven encode
+/// round (see [`encoder_vp8`] module-level note); the function signature is
+/// the published-0.1.5 shape so callers compile against the final API.
+///
+/// `y` is the `width * height` luma plane; `u` / `v` are
+/// `((width+1)/2) * ((height+1)/2)` chroma planes. `meta` is embedded into
+/// the file's optional `VP8X` / `ICCP` / `EXIF` / `XMP ` chunks per the
+/// published convention.
+pub fn encode_vp8_lossy_yuv420p(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+    _meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    validate_yuv420_lengths(width, height, y, u, v)?;
+    Err(WebpError::Unsupported)
+}
+
+/// Encode a planar YUVA420P (I420 luma+chroma + a full-resolution alpha
+/// plane) picture to a complete §2.7 extended-lossy `.webp` file
+/// (`VP8X` + `VP8 ` + `ALPH`).
+///
+/// **Stub — returns [`WebpError::Unsupported`].** See
+/// [`encode_vp8_lossy_yuv420p`].
+pub fn encode_vp8_lossy_yuva420p(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+    a: &[u8],
+    _meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    validate_yuv420_lengths(width, height, y, u, v)?;
+    let alpha_expected = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or(WebpError::InvalidData)?;
+    if a.len() != alpha_expected {
+        return Err(WebpError::InvalidData);
+    }
+    Err(WebpError::Unsupported)
+}
+
+/// Encode an interleaved 8-bit RGBA image to a complete §2.5 / §2.7 lossy
+/// `.webp` file.
+///
+/// **Stub — returns [`WebpError::Unsupported`].** See
+/// [`encode_vp8_lossy_yuv420p`].
+///
+/// `rgba` is `width * height * 4` bytes in scan-line (top-to-bottom,
+/// left-to-right) order, each pixel `[R, G, B, A]` — the same layout
+/// [`WebpFrame::rgba`] uses. `quality` is the libwebp-style 0..=100 scale
+/// ([`encoder_vp8::DEFAULT_QUALITY`] is 75.0). When the wiring lands, an
+/// image whose alpha channel is not all-`0xff` auto-promotes to the §2.7
+/// `VP8X` + `VP8 ` + `ALPH` extended-lossy layout; opaque images emit the
+/// simple `VP8 ` layout.
+pub fn encode_vp8_lossy_rgba(
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+    _quality: f32,
+    _meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(WebpError::InvalidData)?;
+    if rgba.len() != expected {
+        return Err(WebpError::InvalidData);
+    }
+    Err(WebpError::Unsupported)
+}
+
+/// Encode an interleaved 8-bit RGB24 image to a complete §2.5 simple-lossy
+/// `.webp` file (every pixel treated as fully opaque).
+///
+/// **Stub — returns [`WebpError::Unsupported`].** See
+/// [`encode_vp8_lossy_yuv420p`]. The published-0.1.5 convention requires
+/// this path to **stream** the RGB→internal conversion without
+/// materialising an intermediate RGBA buffer — that constraint will be
+/// enforced once the real wiring lands.
+pub fn encode_vp8_lossy_rgb24(
+    width: u32,
+    height: u32,
+    rgb: &[u8],
+    _quality: f32,
+    _meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(3))
+        .ok_or(WebpError::InvalidData)?;
+    if rgb.len() != expected {
+        return Err(WebpError::InvalidData);
+    }
+    Err(WebpError::Unsupported)
+}
+
+/// Common length validator for the YUV 4:2:0 inputs of the lossy encoder
+/// family. Surfaces the published [`WebpError::InvalidData`] on any
+/// dimension / buffer mismatch.
+fn validate_yuv420_lengths(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+) -> Result<(), WebpError> {
+    let w = width as usize;
+    let h = height as usize;
+    let luma = w.checked_mul(h).ok_or(WebpError::InvalidData)?;
+    let cw = w.div_ceil(2);
+    let ch = h.div_ceil(2);
+    let chroma = cw.checked_mul(ch).ok_or(WebpError::InvalidData)?;
+    if y.len() != luma || u.len() != chroma || v.len() != chroma {
+        return Err(WebpError::InvalidData);
+    }
+    Ok(())
 }
 
 // ─────────────────────── Published-shape animation encode API ───────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ pub mod build;
 pub mod container;
 pub mod encoder_vp8;
 pub mod meta_prefix;
+pub mod near_lossless;
 #[cfg(feature = "registry")]
 pub mod registry;
 pub mod vp8_chunk;
@@ -1337,6 +1338,46 @@ pub fn encode_vp8l_argb_with(
     vp8l_encode::encode_vp8l_argb_with(argb, width, height, has_alpha)
         .map_err(Error::from)
         .map_err(WebpError::from)
+}
+
+/// Encode an ARGB image to a bare §2.6 / §3.4 `VP8L` bitstream after an
+/// optional **near-lossless** preprocessing pass — the encoder-side
+/// pixel-quantization step the cwebp `-near_lossless` flag controls.
+///
+/// `near_lossless_quality` is the same `[0..=100]` knob documented in
+/// [`near_lossless`]: **100 = lossless (no-op)** and **0 = maximum
+/// quantization**. The preprocessing rounds R, G, B to multiples of
+/// `2^n` (where `n = near_lossless::bits_to_drop_for_quality(quality)`)
+/// before the standard VP8L encode pipeline runs; alpha is left
+/// untouched. The output is a perfectly normal `VP8L` chunk payload that
+/// decodes back to the **quantized** ARGB values bit-exactly through
+/// [`decode_webp`] — no decoder change is needed.
+///
+/// At `quality = 100` (or any value ≥ 100) the preprocessing is a no-op
+/// and this function is byte-exact-equivalent to
+/// [`encode_vp8l_argb_with`] for the same `has_alpha` setting.
+///
+/// The compression win comes from the entropy stages (LZ77 / color-cache /
+/// Huffman) seeing fewer distinct colors and longer runs once low-order
+/// bits have been zeroed — a typical win on natural-image content at
+/// `quality = 60` is around 5–15 % at a PSNR floor that the
+/// [`near_lossless`] module-level documentation pins above 40 dB even at
+/// the worst-case rounding.
+pub fn encode_vp8l_argb_with_near_lossless(
+    argb: &[u32],
+    width: u32,
+    height: u32,
+    has_alpha: bool,
+    near_lossless_quality: u8,
+) -> Result<Vec<u8>, WebpError> {
+    let n = near_lossless::bits_to_drop_for_quality(near_lossless_quality);
+    if n == 0 {
+        // No-op fast path — guarantees byte-exact equivalence to the
+        // baseline encoder without allocating a quantized copy.
+        return encode_vp8l_argb_with(argb, width, height, has_alpha);
+    }
+    let quantized = near_lossless::quantize(argb, near_lossless_quality);
+    encode_vp8l_argb_with(&quantized, width, height, has_alpha)
 }
 
 /// Encode an ARGB image to a complete `.webp` file carrying a §2.6 `VP8L`

--- a/src/near_lossless.rs
+++ b/src/near_lossless.rs
@@ -1,0 +1,407 @@
+//! VP8L (WebP-Lossless) **near-lossless** encoder preprocessing.
+//!
+//! Near-lossless is an *encoder-side* preprocessing step: the input ARGB
+//! pixels are quantized to a coarser color precision **before** they are
+//! handed to the existing VP8L pipeline ([`crate::vp8l_encode`]). The
+//! bitstream itself is unchanged — a near-lossless `.webp` decodes through
+//! the exact same §3.4 + §3.8 lossless path, producing the (quantized)
+//! ARGB values bit-exactly. The compression win comes from the §5.2.2
+//! LZ77 / §5.2.3 color-cache stages, which see fewer distinct colors and
+//! longer repeats once low-order bits have been zeroed.
+//!
+//! ## Why this lives in the encoder, not the spec
+//!
+//! RFC 9649 standardises only the *bitstream*; the only mention of
+//! near-lossless in the WebP container/lossless specifications is the file
+//! it produces being a perfectly normal `VP8L` chunk. The specific
+//! quantization formula — how many low bits to drop per channel for a
+//! given quality level, the rounding direction, whether neighbouring
+//! pixels influence the decision — is left entirely to the encoder. This
+//! module therefore documents the chosen formula explicitly so that
+//! reproducibility is a property of *our* encoder, not a portable
+//! cross-encoder guarantee.
+//!
+//! ## Quality knob and quantization step
+//!
+//! The convention matches the cwebp `-near_lossless` flag: a `u8` in
+//! `[0..=100]` where **100 = lossless (no-op)** and **0 = maximum
+//! quantization**.
+//!
+//! The encoder maps `quality` to a *bits-to-drop* count
+//! `n ∈ [0..=5]` per the table below; that becomes the precision of each
+//! RGB channel (8 − n bits). Alpha is **never** quantized — its bit
+//! pattern is preserved exactly.
+//!
+//! | quality range | `n` (bits dropped) | retained precision | step |
+//! |---------------|--------------------|--------------------|------|
+//! | 100           | 0                  | 8 bits             |  1   |
+//! | 80..=99       | 1                  | 7 bits             |  2   |
+//! | 60..=79       | 2                  | 6 bits             |  4   |
+//! | 40..=59       | 3                  | 5 bits             |  8   |
+//! | 20..=39       | 4                  | 4 bits             | 16   |
+//! | 0..=19        | 5                  | 3 bits             | 32   |
+//!
+//! The mapping is `n = clamp((100 - q + 19) / 20, 0, 5)` — a 20-point
+//! window per step, biased so `q = 100` cleanly produces `n = 0` (the
+//! no-op identity, byte-exact-equal to the baseline encoder).
+//!
+//! ## Per-channel rounding
+//!
+//! Each of R, G, B is quantized with **round-half-up to the nearest step**:
+//!
+//! ```text
+//! step  = 1 << n
+//! half  = step >> 1
+//! c'    = ((c + half) >> n) << n   // unclamped sum + then clamped to 255
+//! ```
+//!
+//! The clamp prevents `c = 0xff` from rolling over to `0x100` (which would
+//! truncate back to `0x00`); concretely, when `c + half >= 256`, the
+//! quantized value is forced to the largest multiple of `step` ≤ 255
+//! (`255 & !(step - 1)`).
+//!
+//! Per-channel error is bounded by **`step / 2`** for inputs in
+//! `[0, 256 − step/2)` (the round-half-up region) and by **`step − 1`**
+//! for inputs in the upper clamp window `[256 − step/2, 255]` (where the
+//! rounded-up value would overflow 255 and is forced down to the largest
+//! multiple of `step` ≤ 255 instead). Concretely: worst-case error is up
+//! to 31 at `n = 5` (q = 0) and 1 at `n = 1` (q ≥ 80). PSNR is dominated
+//! by the typical `step/2` case — `20·log10(255 / (step/2))` gives
+//! ≈ 60 dB at `n = 1`, ≈ 48 dB at `n = 2`, ≈ 42 dB at `n = 3`,
+//! ≈ 36 dB at `n = 4`, ≈ 30 dB at `n = 5` — with the clamp window
+//! affecting at most `step/2 − 1` of the 256 byte values per channel.
+//!
+//! ## Bit-exact decode contract
+//!
+//! Because [`apply`] mutates the pixels *before* the standard lossless
+//! pipeline, the result is a perfectly normal `VP8L` chunk that decodes
+//! back to the quantized values bit-exactly through
+//! [`crate::vp8l_transform::decode_lossless`]. The encoder offers no
+//! cross-channel filtering or context-dependent adjustment, so each pixel
+//! is quantized independently — easy to reason about, and trivially
+//! parallelisable if a future round wants to chunk the work.
+
+/// Quality value at which [`apply`] is a no-op — every pixel is left
+/// untouched, and the subsequent encode is byte-exact-identical to the
+/// baseline `encode_vp8l_argb` output.
+pub const QUALITY_LOSSLESS: u8 = 100;
+
+/// Default near-lossless quality used by [`crate::encode_vp8l_argb_with_near_lossless`]
+/// when callers want a "moderate" preset. Picked to fall in the
+/// `60..=79` bucket (`n = 2`, step = 4), trading ≤ ±2 per-channel error
+/// for a noticeable reduction in distinct colors on natural images.
+pub const DEFAULT_QUALITY: u8 = 60;
+
+/// Largest number of low-order bits the encoder ever drops from a color
+/// channel. Reached at `quality = 0` (`n = 5`, step = 32).
+pub const MAX_BITS_TO_DROP: u8 = 5;
+
+/// Translate a `[0..=100]` quality knob into the number of low-order bits
+/// to drop from each color channel.
+///
+/// The mapping is the documented `n = clamp((100 - q + 19) / 20, 0, 5)`
+/// step table — `q = 100` → 0, `q ∈ 80..=99` → 1, `q ∈ 60..=79` → 2,
+/// `q ∈ 40..=59` → 3, `q ∈ 20..=39` → 4, `q ∈ 0..=19` → 5. Values above
+/// 100 are clamped down to 100 (still a no-op).
+pub fn bits_to_drop_for_quality(quality: u8) -> u8 {
+    let q = quality.min(QUALITY_LOSSLESS) as i32;
+    let raw = (QUALITY_LOSSLESS as i32 - q + 19) / 20;
+    raw.clamp(0, MAX_BITS_TO_DROP as i32) as u8
+}
+
+/// Round one 8-bit channel to the nearest multiple of `1 << n`, clamping
+/// the rounded-up boundary so 255 cannot roll over to 256.
+///
+/// `n = 0` is the identity. The result is always a multiple of `1 << n`.
+#[inline]
+pub fn quantize_channel(c: u8, n: u8) -> u8 {
+    if n == 0 {
+        return c;
+    }
+    let step = 1u32 << n;
+    let half = step >> 1;
+    let sum = c as u32 + half;
+    // Force the rolled-over case down to the largest multiple of step ≤ 255.
+    let q = if sum >= 256 {
+        255 & !(step - 1)
+    } else {
+        (sum >> n) << n
+    };
+    q as u8
+}
+
+/// Quantize every pixel of `argb` in place per the near-lossless
+/// preprocessing described in this module's documentation.
+///
+/// Each pixel is interpreted as `(a << 24) | (r << 16) | (g << 8) | b`.
+/// R, G, B are independently rounded to the nearest multiple of
+/// `1 << bits_to_drop_for_quality(quality)`; alpha is left untouched.
+/// `quality = 100` (or any value ≥ 100) is a no-op — every pixel is
+/// returned unchanged, and a subsequent encode is byte-exact-identical
+/// to the baseline `encode_vp8l_argb`.
+pub fn apply(argb: &mut [u32], quality: u8) {
+    let n = bits_to_drop_for_quality(quality);
+    if n == 0 {
+        return;
+    }
+    for px in argb.iter_mut() {
+        let a = (*px >> 24) & 0xff;
+        let r = quantize_channel(((*px >> 16) & 0xff) as u8, n) as u32;
+        let g = quantize_channel(((*px >> 8) & 0xff) as u8, n) as u32;
+        let b = quantize_channel((*px & 0xff) as u8, n) as u32;
+        *px = (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}
+
+/// Out-of-place sibling of [`apply`]: returns a fresh `Vec<u32>` of the
+/// quantized pixels, leaving the caller's input untouched. Used when a
+/// caller wants to compare the original and quantized buffers (e.g. for
+/// PSNR measurement) or when the input is borrowed and cannot be mutated.
+pub fn quantize(argb: &[u32], quality: u8) -> Vec<u32> {
+    let mut out = argb.to_vec();
+    apply(&mut out, quality);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- bits_to_drop mapping ----
+
+    #[test]
+    fn quality_100_is_identity_n_zero() {
+        assert_eq!(bits_to_drop_for_quality(100), 0);
+        assert_eq!(bits_to_drop_for_quality(255), 0); // clamps to 100
+    }
+
+    #[test]
+    fn quality_buckets_match_table() {
+        // 100 → 0
+        assert_eq!(bits_to_drop_for_quality(100), 0);
+        // 99..=80 → 1
+        assert_eq!(bits_to_drop_for_quality(99), 1);
+        assert_eq!(bits_to_drop_for_quality(81), 1);
+        assert_eq!(bits_to_drop_for_quality(80), 1);
+        // 79..=60 → 2
+        assert_eq!(bits_to_drop_for_quality(79), 2);
+        assert_eq!(bits_to_drop_for_quality(60), 2);
+        // 59..=40 → 3
+        assert_eq!(bits_to_drop_for_quality(59), 3);
+        assert_eq!(bits_to_drop_for_quality(40), 3);
+        // 39..=20 → 4
+        assert_eq!(bits_to_drop_for_quality(39), 4);
+        assert_eq!(bits_to_drop_for_quality(20), 4);
+        // 19..=0 → 5
+        assert_eq!(bits_to_drop_for_quality(19), 5);
+        assert_eq!(bits_to_drop_for_quality(0), 5);
+    }
+
+    #[test]
+    fn bits_to_drop_is_monotone_nondecreasing_as_quality_drops() {
+        let mut prev = 0u8;
+        for q in (0..=100).rev() {
+            let n = bits_to_drop_for_quality(q);
+            assert!(n >= prev, "q={q} n={n} prev={prev}");
+            prev = n;
+        }
+    }
+
+    // ---- quantize_channel ----
+
+    #[test]
+    fn quantize_channel_identity_when_n_zero() {
+        for c in 0u8..=255 {
+            assert_eq!(quantize_channel(c, 0), c);
+        }
+    }
+
+    #[test]
+    fn quantize_channel_rounds_to_nearest_step() {
+        // n=1 (step=2): even values stay, odd values round up.
+        assert_eq!(quantize_channel(0, 1), 0);
+        assert_eq!(quantize_channel(1, 1), 2);
+        assert_eq!(quantize_channel(2, 1), 2);
+        assert_eq!(quantize_channel(127, 1), 128);
+        assert_eq!(quantize_channel(128, 1), 128);
+        // n=2 (step=4): 0..3 round to 0/4, etc.
+        assert_eq!(quantize_channel(0, 2), 0);
+        assert_eq!(quantize_channel(1, 2), 0);
+        assert_eq!(quantize_channel(2, 2), 4);
+        assert_eq!(quantize_channel(3, 2), 4);
+        assert_eq!(quantize_channel(4, 2), 4);
+    }
+
+    #[test]
+    fn quantize_channel_clamps_at_255() {
+        // 255 + half would overflow the byte boundary; we clamp down to
+        // the largest multiple of step ≤ 255 instead of rolling to 0.
+        // n=1: largest multiple of 2 ≤ 255 is 254.
+        assert_eq!(quantize_channel(255, 1), 254);
+        // n=2: largest multiple of 4 ≤ 255 is 252.
+        assert_eq!(quantize_channel(255, 2), 252);
+        assert_eq!(quantize_channel(254, 2), 252);
+        // n=5: largest multiple of 32 ≤ 255 is 224.
+        assert_eq!(quantize_channel(255, 5), 224);
+    }
+
+    #[test]
+    fn quantize_channel_max_error_is_bounded_by_step_minus_one() {
+        // For every n in 1..=5 and every byte value, the per-channel error
+        // is at most `step - 1`. Inside `[0, 255 - step/2 + 1]` the bound
+        // is the round-half-up `step/2`; in the upper clamp window
+        // `[256 - step/2, 255]` we floor down to the largest multiple of
+        // `step` ≤ 255, which can push the error up to `step - 1`
+        // (e.g. n=5, c=255, step=32 → q=224, err=31).
+        for n in 1..=MAX_BITS_TO_DROP {
+            let step = 1u16 << n;
+            let max_err = (step - 1) as i32;
+            for c in 0u8..=255 {
+                let q = quantize_channel(c, n) as i32;
+                let err = (q - c as i32).abs();
+                assert!(err <= max_err, "n={n} c={c} q={q} err={err}");
+            }
+        }
+    }
+
+    #[test]
+    fn quantize_channel_typical_error_is_bounded_by_step_half() {
+        // Outside the upper clamp window `(255 - step/2, 255]` every
+        // channel value satisfies the tighter round-half-up bound
+        // `|q - c| <= step/2`. This is the bound the PSNR floor in the
+        // module-level docs relies on for the "typical" case.
+        for n in 1..=MAX_BITS_TO_DROP {
+            let step = 1u16 << n;
+            let half = (step / 2) as i32;
+            let upper_clamp_start = 256i32 - half;
+            for c in 0u8..=255 {
+                let ci = c as i32;
+                if ci >= upper_clamp_start {
+                    continue;
+                }
+                let q = quantize_channel(c, n) as i32;
+                let err = (q - ci).abs();
+                assert!(err <= half, "n={n} c={c} q={q} err={err}");
+            }
+        }
+    }
+
+    #[test]
+    fn quantize_channel_result_is_multiple_of_step() {
+        for n in 0..=MAX_BITS_TO_DROP {
+            let step = 1u32 << n;
+            for c in 0u8..=255 {
+                let q = quantize_channel(c, n) as u32;
+                assert_eq!(q % step, 0, "n={n} c={c} q={q} step={step}");
+            }
+        }
+    }
+
+    // ---- apply / quantize on ARGB pixels ----
+
+    #[test]
+    fn apply_quality_100_is_byte_for_byte_identity() {
+        let mut pixels = vec![
+            0xff_00_00_00, // black opaque
+            0x80_aa_bb_cc, // alpha=0x80, RGB=AA BB CC
+            0x00_ff_ff_ff, // transparent white
+            0x40_01_02_03, // small values
+        ];
+        let original = pixels.clone();
+        apply(&mut pixels, 100);
+        assert_eq!(pixels, original);
+        // Also out-of-place form.
+        let q = quantize(&original, 100);
+        assert_eq!(q, original);
+    }
+
+    #[test]
+    fn apply_quality_above_100_is_also_identity() {
+        let mut pixels = vec![0x80_aa_bb_cc, 0xff_00_ff_00];
+        let original = pixels.clone();
+        apply(&mut pixels, 255);
+        assert_eq!(pixels, original);
+    }
+
+    #[test]
+    fn apply_preserves_alpha_exactly() {
+        // Every alpha value must round-trip the apply() call unchanged at
+        // every quality level — alpha is intentionally not quantized.
+        let mut pixels: Vec<u32> = (0u32..=255).map(|a| (a << 24) | 0x00_55_aa_ff).collect();
+        let alphas_before: Vec<u8> = pixels.iter().map(|p| (*p >> 24) as u8).collect();
+        for q in 0u8..=100 {
+            let mut p = pixels.clone();
+            apply(&mut p, q);
+            let alphas_after: Vec<u8> = p.iter().map(|x| (*x >> 24) as u8).collect();
+            assert_eq!(alphas_after, alphas_before, "quality={q} alpha changed");
+        }
+        // Tiny touch so clippy/rustc doesn't complain about unused mut.
+        apply(&mut pixels, 100);
+    }
+
+    #[test]
+    fn apply_quantizes_rgb_channels_per_step() {
+        // q=60 → n=2 → step=4. Every R,G,B byte of the result is a
+        // multiple of 4 (or 0).
+        let mut pixels = vec![0xff_aa_bb_cc, 0x80_01_02_03, 0x10_ff_ff_ff];
+        apply(&mut pixels, 60);
+        for px in &pixels {
+            let r = ((*px >> 16) & 0xff) as u8;
+            let g = ((*px >> 8) & 0xff) as u8;
+            let b = (*px & 0xff) as u8;
+            assert_eq!(r % 4, 0, "r={r}");
+            assert_eq!(g % 4, 0, "g={g}");
+            assert_eq!(b % 4, 0, "b={b}");
+        }
+    }
+
+    #[test]
+    fn apply_max_per_channel_error_bounded_for_every_quality() {
+        // Build a small image carrying every byte value across the RGB
+        // channels and verify the per-channel error never exceeds the
+        // documented `step - 1` worst case (the clamp window absorbs the
+        // upper end; outside it the tighter `step / 2` bound applies, as
+        // shown by `quantize_channel_typical_error_is_bounded_by_step_half`).
+        let mut pixels: Vec<u32> = (0u32..=255)
+            .map(|v| 0xff_00_00_00 | (v << 16) | (v << 8) | v)
+            .collect();
+        let original = pixels.clone();
+        for q in 0u8..=100 {
+            let mut p = pixels.clone();
+            apply(&mut p, q);
+            let n = bits_to_drop_for_quality(q);
+            let step = 1u32 << n;
+            let max_err = if step == 0 { 0 } else { (step - 1) as i32 };
+            for (a, b) in original.iter().zip(p.iter()) {
+                for shift in [0u32, 8, 16] {
+                    let oc = ((*a >> shift) & 0xff) as i32;
+                    let qc = ((*b >> shift) & 0xff) as i32;
+                    let err = (oc - qc).abs();
+                    assert!(err <= max_err, "q={q} n={n} shift={shift} err={err}");
+                }
+            }
+        }
+        // Touch pixels to keep the binding live.
+        apply(&mut pixels, 100);
+    }
+
+    #[test]
+    fn quantize_is_apply_out_of_place() {
+        // The free `quantize` function must produce the same pixels as a
+        // clone-then-apply, for every quality level.
+        let original: Vec<u32> = (0u32..256)
+            .map(|i| {
+                let r = (i * 7) as u8 as u32;
+                let g = (i * 31) as u8 as u32;
+                let b = (i * 53) as u8 as u32;
+                (0xff << 24) | (r << 16) | (g << 8) | b
+            })
+            .collect();
+        for q in (0u8..=100).step_by(5) {
+            let mut a = original.clone();
+            apply(&mut a, q);
+            let b = quantize(&original, q);
+            assert_eq!(a, b, "quality={q}");
+        }
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -46,8 +46,9 @@ use oxideav_core::{
 };
 
 use crate::{
-    decode_webp_image, encode_vp8l_argb_with_metadata, DecodedWebp, Error, UnsupportedKind,
-    WebpError, WebpMetadata, WebpMetadataOwned, CODEC_ID_VP8L,
+    decode_webp_image, encode_vp8l_argb_with_metadata, encoder_vp8::Vp8FreqDeltas, DecodedWebp,
+    Error, UnsupportedKind, WebpError, WebpMetadata, WebpMetadataOwned, CODEC_ID_VP8,
+    CODEC_ID_VP8L,
 };
 
 /// Stable on-wire identifier this crate registers under in the codec
@@ -419,6 +420,164 @@ pub fn encode_vp8l_frame(
         .map_err(|e| CoreError::InvalidData(e.to_string()))
 }
 
+// ───────────────────────── VP8 (lossy) encoder — registry-side stub ─────────────────────────
+//
+// API surface for the published `webp_vp8` codec id. Construction succeeds
+// (so consumers can pre-build their encoder graph), but `send_frame` fails
+// with `Error::Unsupported` — the upstream `oxideav-vp8 = "0.2"` encoder
+// emits a constant-grey frame for any pixel input today, so producing a
+// `.webp` from the stub would be the "garbage bytes" failure mode the
+// round-131 directive forbids. See `encoder_vp8` for the full gap report.
+
+/// Configuration the [`WebpVp8LossyEncoder`] carries between construction
+/// (via the [`crate::encoder_vp8::make_encoder_with_quality`] family) and
+/// the eventual `send_frame` call.
+///
+/// `pub(crate)` so the factories in [`crate::encoder_vp8`] can build it;
+/// not part of the published surface (the surface is the factory family
+/// itself).
+#[derive(Debug, Clone)]
+pub(crate) struct Vp8LossyEncoderConfig {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) pix: Option<PixelFormat>,
+    pub(crate) qindex: u8,
+    pub(crate) freq_deltas: Vp8FreqDeltas,
+    pub(crate) metadata: WebpMetadataOwned,
+}
+
+/// Default factory for the `webp_vp8` codec id — the entry the
+/// `CodecRegistry` calls when an encoder is requested without further
+/// configuration.
+///
+/// Constructs the encoder at the libwebp-default quality
+/// ([`crate::encoder_vp8::DEFAULT_QUALITY`] = 75.0) with no per-band freq
+/// deltas and no embedded metadata. Pixel-driven encoding is the gap;
+/// see [`crate::encoder_vp8`].
+pub fn make_vp8_lossy_encoder(params: &CodecParameters) -> oxideav_core::Result<Box<dyn Encoder>> {
+    crate::encoder_vp8::make_encoder_with_quality(params, crate::encoder_vp8::DEFAULT_QUALITY)
+}
+
+/// WebP VP8 (lossy) [`Encoder`] trait impl — API-shape stub.
+///
+/// One frame in → one `.webp` packet out *once the upstream
+/// `oxideav-vp8` encoder lands the pixel path*. Today the implementation
+/// validates the input frame against the configured dimensions / pixel
+/// format and refuses with [`oxideav_core::Error::Unsupported`] rather
+/// than emitting a constant-grey image wrapped in WebP framing. See the
+/// [`crate::encoder_vp8`] module-level note.
+#[derive(Debug)]
+pub struct WebpVp8LossyEncoder {
+    output_params: CodecParameters,
+    cfg: Vp8LossyEncoderConfig,
+    pending_out: VecDeque<Packet>,
+    eof: bool,
+}
+
+impl WebpVp8LossyEncoder {
+    pub(crate) fn new(output_params: CodecParameters, cfg: Vp8LossyEncoderConfig) -> Self {
+        Self {
+            output_params,
+            cfg,
+            pending_out: VecDeque::new(),
+            eof: false,
+        }
+    }
+
+    /// Baseline qindex this encoder was constructed with (RFC 6386 §9.6
+    /// `y_ac_qi`, 0..=127). Exposed so callers building the encoder
+    /// through the registry path can read back the quality the factory
+    /// settled on.
+    pub fn qindex(&self) -> u8 {
+        self.cfg.qindex
+    }
+
+    /// Per-band quantiser deltas this encoder was constructed with.
+    pub fn freq_deltas(&self) -> Vp8FreqDeltas {
+        self.cfg.freq_deltas
+    }
+
+    /// Borrowed view of the embedded metadata (ICC / Exif / XMP) the
+    /// encoder would emit on every output `.webp`.
+    pub fn metadata(&self) -> WebpMetadata<'_> {
+        self.cfg.metadata.as_borrowed()
+    }
+
+    /// Encoder-side dimensions read out of the `CodecParameters` the
+    /// factory was built with: `(width, height)`.
+    ///
+    /// Currently exposed for symmetry with [`WebpVp8lEncoder`] and so a
+    /// future round can wire the dims directly into the
+    /// `oxideav-vp8` encoder driver without re-routing them through
+    /// `output_params`.
+    pub fn dimensions(&self) -> (u32, u32) {
+        (self.cfg.width, self.cfg.height)
+    }
+}
+
+impl Encoder for WebpVp8LossyEncoder {
+    fn codec_id(&self) -> &CodecId {
+        &self.output_params.codec_id
+    }
+
+    fn output_params(&self) -> &CodecParameters {
+        &self.output_params
+    }
+
+    fn send_frame(&mut self, frame: &Frame) -> oxideav_core::Result<()> {
+        let Frame::Video(v) = frame else {
+            return Err(CoreError::invalid("webp_vp8 encoder: video frames only"));
+        };
+        // Catch caller bugs (wrong dims, missing planes) at the API boundary,
+        // even though we cannot complete the encode yet.
+        let plane = v
+            .planes
+            .first()
+            .ok_or_else(|| CoreError::invalid("webp_vp8 encoder: frame has no planes"))?;
+        let expected_per_pixel = match self.cfg.pix {
+            Some(PixelFormat::Rgba) | Some(PixelFormat::Yuva420P) => 4,
+            Some(PixelFormat::Rgb24) | Some(PixelFormat::Yuv420P) => 3,
+            // Permit an unknown pixel format — we'll surface Unsupported
+            // below anyway, and a future round may declare more formats.
+            _ => 0,
+        };
+        if expected_per_pixel != 0 {
+            let min_stride = (self.cfg.width as usize).saturating_mul(expected_per_pixel);
+            if plane.stride < min_stride {
+                return Err(CoreError::invalid(format!(
+                    "webp_vp8 encoder: plane stride {} smaller than width*{} = {}",
+                    plane.stride, expected_per_pixel, min_stride,
+                )));
+            }
+        }
+
+        // Encoder body is the gap — see encoder_vp8 module note.
+        let _ = v;
+        Err(CoreError::Unsupported(
+            "oxideav-webp webp_vp8 encoder: lossy VP8 encode is API-shape only; \
+             oxideav-vp8 0.2 lacks the §13/§14 pixel-driven encode driver \
+             (see oxideav_webp::encoder_vp8 module note for the precise gap)"
+                .to_string(),
+        ))
+    }
+
+    fn receive_packet(&mut self) -> oxideav_core::Result<Packet> {
+        if let Some(p) = self.pending_out.pop_front() {
+            return Ok(p);
+        }
+        if self.eof {
+            Err(CoreError::Eof)
+        } else {
+            Err(CoreError::NeedMore)
+        }
+    }
+
+    fn flush(&mut self) -> oxideav_core::Result<()> {
+        self.eof = true;
+        Ok(())
+    }
+}
+
 // ───────────────────────── Registration ─────────────────────────
 
 /// Register the WebP decoder factory into a [`CodecRegistry`].
@@ -455,6 +614,30 @@ pub fn register_codecs(reg: &mut CodecRegistry) {
             .capabilities(vp8l_caps)
             .decoder(make_decoder)
             .encoder(make_encoder),
+    );
+
+    // VP8 (lossy) codec — registered as an API-shape stub. The decoder is
+    // the same `make_decoder` factory that handles the published
+    // `"webp"` codec id (it walks the file container, then routes any §2.5
+    // `VP8 ` chunk to `oxideav-vp8`); the encoder factory builds the
+    // [`WebpVp8LossyEncoder`] which validates inputs but cannot produce a
+    // real bitstream yet — see `encoder_vp8` for the gap. Declared `lossy`
+    // (not `lossless`) so a `first_encoder(...)` lookup that requests a
+    // lossy encoder doesn't pick up the VP8L lossless one instead.
+    let vp8_caps = CodecCapabilities::video("webp_vp8_sw")
+        .with_intra_only(true)
+        .with_max_size(16384, 16384)
+        .with_pixel_formats(vec![
+            PixelFormat::Yuv420P,
+            PixelFormat::Yuva420P,
+            PixelFormat::Rgba,
+            PixelFormat::Rgb24,
+        ]);
+    reg.register(
+        CodecInfo::new(CodecId::new(CODEC_ID_VP8))
+            .capabilities(vp8_caps)
+            .decoder(make_decoder)
+            .encoder(make_vp8_lossy_encoder),
     );
 }
 

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -55,9 +55,16 @@
 //! 2. builds a length-limited (≤ [`MAX_CODE_LENGTH`]) canonical
 //!    Huffman code-length assignment from those frequencies
 //!    ([`build_code_lengths`]);
-//! 3. writes the code lengths to the stream with the §3.7.2.1.2 *normal
-//!    code length code* (or the trivial single-symbol form), then writes
-//!    each symbol with the canonical code derived from the lengths.
+//! 3. writes the code lengths to the stream with whichever §3.7.2.1
+//!    variant is cheaper — the §3.7.2.1.1 *simple code length code* when
+//!    the table is 1 or 2 length-1 symbols in `[0..255]`
+//!    ([`simple_code_symbols`] / [`write_simple_code_lengths`]), else the
+//!    §3.7.2.1.2 *normal code length code* — then writes each symbol with
+//!    the canonical code derived from the lengths. Both code-length-code
+//!    forms describe the identical length table, so symbol emission and
+//!    the decoder's reconstruction are unaffected by the choice; the
+//!    simple form just shrinks the header for low-entropy meta-blocks
+//!    (single-color channels, the empty distance code).
 //!
 //! The canonical code assignment ([`canonical_codes`]) is the identical
 //! `(length, value)`-ordered rule the decoder's
@@ -592,11 +599,109 @@ impl WriteCode {
         }
     }
 
-    /// Write this code's per-symbol lengths to `w` using the §3.7.2.1.2
-    /// *normal code length code* (the general form that can represent any
-    /// length table, including the single-leaf one).
+    /// Write this code's per-symbol lengths to `w`.
+    ///
+    /// Dispatches on whichever §3.7.2.1 variant is cheaper for this length
+    /// table: the §3.7.2.1.1 *simple code length code* when the table
+    /// describes 1 or 2 length-1 symbols, all in the `[0..255]` range the
+    /// simple form admits; otherwise the §3.7.2.1.2 *normal code length
+    /// code*. Both encode the identical length table, so the per-symbol
+    /// code emission ([`write_symbol`](Self::write_symbol)) — and therefore
+    /// the decoder's reconstruction — is unaffected by the choice.
     fn write_code_lengths(&self, w: &mut BitWriter) {
-        write_normal_code_lengths(w, &self.lengths);
+        match simple_code_symbols(&self.lengths) {
+            Some(symbols) => write_simple_code_lengths(w, &symbols),
+            None => write_normal_code_lengths(w, &self.lengths),
+        }
+    }
+}
+
+/// If `lengths` describes a code the §3.7.2.1.1 *simple code length code*
+/// can represent, return its used symbols (1 or 2 of them); otherwise
+/// `None`.
+///
+/// The simple form is the special case where "only 1 or 2 prefix symbols
+/// are in the range `[0..255]` with code length 1; all other prefix code
+/// lengths are implicitly zeros." So the table qualifies iff every nonzero
+/// length is exactly 1, there are 1 or 2 such symbols, and each fits in the
+/// `[0..255]` range the simple form's symbol fields can carry (symbol1 is
+/// always 8 bits; symbol0 is 1 or 8 bits).
+///
+/// This is exactly the form [`build_code_lengths`] produces for a
+/// single-used-symbol alphabet (one symbol at length 1) and for a
+/// two-used-symbol alphabet (both at length 1, the only complete two-leaf
+/// code) — including the §3.7.2.1.1-note empty-code case the encoder spells
+/// as a single symbol 0.
+fn simple_code_symbols(lengths: &[u8]) -> Option<Vec<usize>> {
+    let mut used: Vec<usize> = Vec::with_capacity(2);
+    for (sym, &l) in lengths.iter().enumerate() {
+        match l {
+            0 => {}
+            1 => {
+                if sym > 255 {
+                    // The simple form's symbol fields top out at 255.
+                    return None;
+                }
+                used.push(sym);
+                if used.len() > 2 {
+                    return None;
+                }
+            }
+            // A length other than 0 or 1 cannot be expressed by the simple
+            // form (every described leaf is at depth 1).
+            _ => return None,
+        }
+    }
+    if used.is_empty() {
+        // An all-zero table is the empty code; the encoder never builds one
+        // (the empty distance code is spelled as a single symbol 0), but
+        // guard anyway since the simple form can't represent zero symbols.
+        None
+    } else {
+        Some(used)
+    }
+}
+
+/// Write a length table with the §3.7.2.1.1 *simple code length code*.
+///
+/// `symbols` holds the 1 or 2 length-1 symbols (each `<= 255`), exactly as
+/// returned by [`simple_code_symbols`]. The emitted layout mirrors the
+/// decoder's `read_simple_code_lengths`:
+///
+/// ```text
+/// %b1                      ; simple flag
+/// num_symbols-1 (1 bit)    ; 0 → 1 symbol, 1 → 2 symbols
+/// is_first_8bits (1 bit)   ; 0 → symbol0 in [0..1] (1 bit), 1 → [0..255] (8 bits)
+/// symbol0 (1 or 8 bits)
+/// [ symbol1 (8 bits) ]     ; present iff num_symbols == 2
+/// ```
+fn write_simple_code_lengths(w: &mut BitWriter, symbols: &[usize]) {
+    debug_assert!(
+        matches!(symbols.len(), 1 | 2),
+        "simple code length code carries 1 or 2 symbols"
+    );
+    debug_assert!(
+        symbols.iter().all(|&s| s <= 255),
+        "simple code length code symbols fit in [0..255]"
+    );
+    // Simple flag.
+    w.write_bit(true);
+    // num_symbols - 1.
+    w.write_bits((symbols.len() - 1) as u32, 1);
+    // symbol0 uses the 1-bit field only when it fits in [0..1]; otherwise
+    // the 8-bit field. Picking the narrow field whenever possible shaves the
+    // table by 7 bits for the very common single-symbol-0 (empty) code.
+    let symbol0 = symbols[0];
+    if symbol0 <= 1 {
+        w.write_bit(false); // is_first_8bits = 0
+        w.write_bits(symbol0 as u32, 1);
+    } else {
+        w.write_bit(true); // is_first_8bits = 1
+        w.write_bits(symbol0 as u32, 8);
+    }
+    if symbols.len() == 2 {
+        // symbol1 is always 8 bits, range [0..255].
+        w.write_bits(symbols[1] as u32, 8);
     }
 }
 
@@ -2577,6 +2682,95 @@ mod tests {
         let mut r = BitReader::new(&bytes);
         let decoded = PrefixCode::read(&mut r, 40).unwrap();
         assert_eq!(decoded.single_symbol(), Some(0));
+    }
+
+    // ---- §3.7.2.1.1 simple code length code ----
+
+    #[test]
+    fn simple_code_symbols_classifies_tables() {
+        // Single length-1 symbol → eligible.
+        let mut l = vec![0u8; 40];
+        l[7] = 1;
+        assert_eq!(simple_code_symbols(&l), Some(vec![7]));
+        // Two length-1 symbols → eligible, returned in ascending order.
+        let mut l = vec![0u8; 256];
+        l[3] = 1;
+        l[200] = 1;
+        assert_eq!(simple_code_symbols(&l), Some(vec![3, 200]));
+        // A length other than 0/1 disqualifies.
+        let mut l = vec![0u8; 8];
+        l[1] = 1;
+        l[2] = 2;
+        assert_eq!(simple_code_symbols(&l), None);
+        // Three length-1 symbols disqualifies.
+        let mut l = vec![0u8; 8];
+        l[0] = 1;
+        l[1] = 1;
+        l[2] = 1;
+        assert_eq!(simple_code_symbols(&l), None);
+        // A length-1 symbol above 255 disqualifies (GREEN can exceed 255).
+        let mut l = vec![0u8; 300];
+        l[280] = 1;
+        assert_eq!(simple_code_symbols(&l), None);
+        // All-zero table disqualifies.
+        assert_eq!(simple_code_symbols(&[0u8; 8]), None);
+    }
+
+    #[test]
+    fn simple_code_one_symbol_round_trips() {
+        // A code over a 256-symbol alphabet using only symbol 200.
+        let mut freq = vec![0u32; 256];
+        freq[200] = 17;
+        let code = WriteCode::from_freqs(&freq);
+        let mut w = BitWriter::new();
+        code.write_code_lengths(&mut w);
+        // First emitted bit must be the simple flag (1).
+        let bytes = w.into_bytes();
+        assert_eq!(bytes[0] & 1, 1, "simple flag bit not set");
+        let mut r = BitReader::new(&bytes);
+        let decoded = PrefixCode::read(&mut r, 256).unwrap();
+        assert_eq!(decoded.single_symbol(), Some(200));
+    }
+
+    #[test]
+    fn simple_code_two_symbols_round_trips() {
+        let mut freq = vec![0u32; 256];
+        freq[5] = 9;
+        freq[201] = 9;
+        let code = WriteCode::from_freqs(&freq);
+        let mut w = BitWriter::new();
+        code.write_code_lengths(&mut w);
+        // Emit a short symbol sequence with the built code.
+        let seq = [5usize, 201, 5, 5, 201];
+        for &s in &seq {
+            code.write_symbol(&mut w, s);
+        }
+        let bytes = w.into_bytes();
+        let mut r = BitReader::new(&bytes);
+        let decoded = PrefixCode::read(&mut r, 256).unwrap();
+        for &s in &seq {
+            assert_eq!(decoded.read_symbol(&mut r).unwrap() as usize, s);
+        }
+    }
+
+    #[test]
+    fn simple_code_is_smaller_than_normal_for_single_symbol() {
+        // The simple form must be no larger than the normal form for a
+        // 1-symbol table; for the empty (single-symbol-0) distance code it is
+        // dramatically smaller.
+        let code = WriteCode::empty(40);
+        let mut simple = BitWriter::new();
+        code.write_code_lengths(&mut simple); // dispatches to simple
+        let mut normal = BitWriter::new();
+        write_normal_code_lengths(&mut normal, &code.lengths);
+        assert!(
+            simple.bit_position() < normal.bit_position(),
+            "simple {} bits not smaller than normal {} bits",
+            simple.bit_position(),
+            normal.bit_position()
+        );
+        // Symbol 0 with is_first_8bits=0: flag + num-1 + is_8 + 1-bit symbol.
+        assert_eq!(simple.bit_position(), 4);
     }
 
     // ---- image-header ----

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -1515,6 +1515,265 @@ fn encode_predictor_path(pixels: &[u32], width: u32, height: u32) -> Vec<u8> {
     w.into_bytes()
 }
 
+// ---- §4.2 forward color transform ----
+
+/// The §4.2 `size_bits` value the encoder writes for the color transform:
+/// block edge is `1 << COLOR_SIZE_BITS` pixels. The 3-bit on-wire field
+/// stores `size_bits - 2`, so `COLOR_SIZE_BITS ∈ [2, 9]`. Four (16×16
+/// blocks) mirrors [`PREDICTOR_SIZE_BITS`]: small enough to let each
+/// region pick its own `ColorTransformElement`, large enough that the
+/// sub-resolution color image stays cheap.
+const COLOR_SIZE_BITS: u8 = 4;
+
+/// §4.2 `ColorTransformDelta(t, c)` = `(t * c) >> 5`, with `t` and `c`
+/// interpreted as signed 8-bit two's-complement values. Bit-identical to
+/// the decoder's [`crate::vp8l_transform`] `color_transform_delta` so the
+/// residual the encoder subtracts is the exact inverse of the value the
+/// decoder adds back. Only the low 8 bits of the result are meaningful;
+/// callers mask after adding.
+#[inline]
+fn fwd_color_transform_delta(t: u8, c: u8) -> i32 {
+    let ts = t as i8 as i32;
+    let cs = c as i8 as i32;
+    (ts * cs) >> 5
+}
+
+/// §4.2 forward color transform for one pixel. Subtracts the three
+/// `ColorTransformElement` deltas (the spec's `ColorTransform`):
+///
+/// ```text
+/// tmp_red  -= delta(green_to_red,  green)
+/// tmp_blue -= delta(green_to_blue, green)
+/// tmp_blue -= delta(red_to_blue,   red)      // ORIGINAL red
+/// ```
+///
+/// Returns the transformed `(new_red, new_blue)` (green/alpha unchanged).
+/// The decoder's inverse restores red first (`tmp_red += delta(green_to_red,
+/// green)` recovers the original red byte), then uses that restored red for
+/// the `red_to_blue` term — so feeding original red here keeps the pair
+/// exact across the modulo-256 wrap.
+#[inline]
+fn forward_color_pixel(
+    r: u8,
+    g: u8,
+    b: u8,
+    green_to_red: u8,
+    green_to_blue: u8,
+    red_to_blue: u8,
+) -> (u8, u8) {
+    let mut tmp_red = r as i32;
+    let mut tmp_blue = b as i32;
+    tmp_red -= fwd_color_transform_delta(green_to_red, g);
+    tmp_blue -= fwd_color_transform_delta(green_to_blue, g);
+    tmp_blue -= fwd_color_transform_delta(red_to_blue, r);
+    ((tmp_red & 0xff) as u8, (tmp_blue & 0xff) as u8)
+}
+
+/// A half-open pixel rectangle `[x0, x1) × [y0, y1)` within an image of
+/// stride `w` — the geometry of one §4.2 transform block. Bundled so the
+/// per-block cost/selection helpers stay under clippy's argument limit.
+#[derive(Clone, Copy)]
+struct BlockBounds {
+    w: usize,
+    x0: usize,
+    y0: usize,
+    x1: usize,
+    y1: usize,
+}
+
+/// Score a candidate `ColorTransformElement` `(green_to_red, green_to_blue,
+/// red_to_blue)` over one block: the sum of |residual| for the red and blue
+/// channels after the forward transform, folding the modulo-256 wrap (a
+/// residual byte near 255 is `-1`, cheap to entropy-code). Lower is better.
+/// Mirrors [`residual_cost`]'s wrap-aware metric so the color transform is
+/// judged on the same proxy the predictor uses.
+#[inline]
+fn color_block_cost(pixels: &[u32], bb: BlockBounds, cte: (u8, u8, u8)) -> u64 {
+    let (g2r, g2b, r2b) = cte;
+    let mut cost = 0u64;
+    for y in bb.y0..bb.y1 {
+        for x in bb.x0..bb.x1 {
+            let px = pixels[y * bb.w + x];
+            let r = ((px >> 16) & 0xff) as u8;
+            let g = ((px >> 8) & 0xff) as u8;
+            let b = (px & 0xff) as u8;
+            let (nr, nb) = forward_color_pixel(r, g, b, g2r, g2b, r2b);
+            let nr = nr as u32;
+            let nb = nb as u32;
+            cost += nr.min(256 - nr) as u64 + nb.min(256 - nb) as u64;
+        }
+    }
+    cost
+}
+
+/// Pick the three §4.2 transform coefficients for every block and return
+/// the sub-resolution color image (one ARGB pixel per block: alpha 255,
+/// red = `red_to_blue`, green = `green_to_blue`, blue = `green_to_red`)
+/// alongside the block dimensions.
+///
+/// The coefficient space is the full signed-8-bit cube (256³), far too
+/// large to search exhaustively per block. Instead the encoder runs a
+/// cheap **coordinate descent**: starting from the all-zero element
+/// (identity transform — the residual equals the original, so the search
+/// never makes a block worse than no color transform), it independently
+/// sweeps each of the three coefficients over a coarse signed grid while
+/// holding the others fixed, keeping the best value found, and repeats a
+/// couple of passes so a `green_to_red` choice can influence the later
+/// `red_to_blue` sweep. The grid is the §4.2 fixed-point lattice in steps
+/// of 8 (i.e. ±0.25 in 3.5 fixed point), which captures the dominant
+/// cross-channel slopes without paying for a 256-wide scan; the all-zero
+/// origin is always a candidate, so a block with no usable correlation
+/// keeps the identity element.
+fn select_color_transform_elements(
+    pixels: &[u32],
+    width: u32,
+    height: u32,
+    size_bits: u8,
+) -> (Vec<u32>, u32, u32) {
+    let w = width as usize;
+    let h = height as usize;
+    let block = 1usize << size_bits;
+    let tw = pred_div_round_up(width, block as u32);
+    let th = pred_div_round_up(height, block as u32);
+    let mut sub_image = vec![0xff00_0000u32; (tw * th) as usize];
+
+    // Coarse signed-8-bit grid (3.5 fixed point, step 8 ≈ ±0.25). Includes
+    // 0 so the identity transform is always reachable.
+    const GRID: [i32; 17] = [
+        -64, -56, -48, -40, -32, -24, -16, -8, 0, 8, 16, 24, 32, 40, 48, 56, 64,
+    ];
+
+    for by in 0..th as usize {
+        for bx in 0..tw as usize {
+            let x0 = bx * block;
+            let y0 = by * block;
+            let bb = BlockBounds {
+                w,
+                x0,
+                y0,
+                x1: (x0 + block).min(w),
+                y1: (y0 + block).min(h),
+            };
+
+            // Start at the identity element (all zero).
+            let mut g2r: u8 = 0;
+            let mut g2b: u8 = 0;
+            let mut r2b: u8 = 0;
+            let mut best = color_block_cost(pixels, bb, (g2r, g2b, r2b));
+
+            // Two coordinate-descent passes: green→red, green→blue, then
+            // red→blue (which depends on the original red, independent of
+            // the other two, but a second pass lets a better g2r/g2b
+            // settle before re-confirming r2b).
+            for _ in 0..2 {
+                for &cand in &GRID {
+                    let c = (cand & 0xff) as u8;
+                    let cost = color_block_cost(pixels, bb, (c, g2b, r2b));
+                    if cost < best {
+                        best = cost;
+                        g2r = c;
+                    }
+                }
+                for &cand in &GRID {
+                    let c = (cand & 0xff) as u8;
+                    let cost = color_block_cost(pixels, bb, (g2r, c, r2b));
+                    if cost < best {
+                        best = cost;
+                        g2b = c;
+                    }
+                }
+                for &cand in &GRID {
+                    let c = (cand & 0xff) as u8;
+                    let cost = color_block_cost(pixels, bb, (g2r, g2b, c));
+                    if cost < best {
+                        best = cost;
+                        r2b = c;
+                    }
+                }
+            }
+
+            // §4.2 color-image pixel layout: alpha 255, red = red_to_blue,
+            // green = green_to_blue, blue = green_to_red.
+            sub_image[by * tw as usize + bx] =
+                0xff00_0000 | ((r2b as u32) << 16) | ((g2b as u32) << 8) | (g2r as u32);
+        }
+    }
+    (sub_image, tw, th)
+}
+
+/// Apply the §4.2 forward color transform: choose a per-block
+/// `ColorTransformElement` map, then replace every pixel's red and blue
+/// with their color-decorrelated residuals (green and alpha untouched).
+///
+/// Returns the residual image (same dimensions as the input), the
+/// sub-resolution color image (dimensions `transform_width *
+/// transform_height`), the chosen `size_bits`, and `transform_width`. The
+/// residual buffer fed through the decoder's §4.2 inverse (with the
+/// returned sub-image + `size_bits`) reconstructs `pixels` exactly.
+fn apply_color_transform(pixels: &[u32], width: u32, height: u32) -> (Vec<u32>, Vec<u32>, u8, u32) {
+    let size_bits = COLOR_SIZE_BITS;
+    let (sub_image, tw, _th) = select_color_transform_elements(pixels, width, height, size_bits);
+
+    let w = width as usize;
+    let h = height as usize;
+    let mut residuals = vec![0u32; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            let block_index = (y as u32 >> size_bits) * tw + (x as u32 >> size_bits);
+            let cte = sub_image[block_index as usize];
+            let r2b = ((cte >> 16) & 0xff) as u8;
+            let g2b = ((cte >> 8) & 0xff) as u8;
+            let g2r = (cte & 0xff) as u8;
+
+            let px = pixels[y * w + x];
+            let a = px & 0xff00_0000;
+            let r = ((px >> 16) & 0xff) as u8;
+            let g = ((px >> 8) & 0xff) as u8;
+            let b = (px & 0xff) as u8;
+            let (nr, nb) = forward_color_pixel(r, g, b, g2r, g2b, r2b);
+            residuals[y * w + x] = a | ((nr as u32) << 16) | ((g as u32) << 8) | (nb as u32);
+        }
+    }
+    (residuals, sub_image, size_bits, tw)
+}
+
+/// Encode an ARGB image via the §4.2 color transform: pick a per-block
+/// `ColorTransformElement` map, emit the color transform header +
+/// sub-resolution color image (an `entropy-coded-image`), then the
+/// residual main image as a §3.8.3 `spatially-coded-image`. The result
+/// decodes back to `pixels` byte-for-byte through the decoder's §4.2
+/// inverse.
+///
+/// `image_width` is the canvas width, threaded into the residual image's
+/// §5.2.2 distance chooser. Both the sub-image and the residual image get
+/// their own color-cache evaluation.
+fn encode_color_path(pixels: &[u32], width: u32, height: u32) -> Vec<u8> {
+    let (residuals, sub_image, size_bits, tw) = apply_color_transform(pixels, width, height);
+
+    let mut w = BitWriter::new();
+
+    // §3.8.2 color-tx: present-bit, TransformType::Color (1), then the
+    // 3-bit `size_bits - 2` field, then the sub-resolution color image.
+    w.write_bit(true);
+    w.write_bits(crate::vp8l_stream::TransformType::Color as u32, 2);
+    w.write_bits((size_bits - 2) as u32, 3);
+    // color-image body = entropy-coded-image (no meta-prefix). The
+    // sub-image is `tw` wide; evaluate its own color cache.
+    let (sub_tokens, sub_bits) = best_cache_for_pixels(&sub_image, tw);
+    write_entropy_coded_image(&mut w, &sub_tokens, sub_bits, tw);
+
+    // End-of-transform-list terminator.
+    w.write_bit(false);
+
+    // §3.8.3 spatially-coded-image for the residual main image. Evaluate
+    // the residual's color cache independently of the original's.
+    let (res_tokens, res_bits) = best_cache_for_pixels(&residuals, width);
+    write_spatially_coded_image(&mut w, &res_tokens, res_bits, width);
+
+    let _ = height;
+    w.into_bytes()
+}
+
 /// Encode an ARGB image to a VP8L *image-stream* (the bytes that follow the
 /// §3.4 5-byte image-header), running the §5.2.2 LZ77 backward-reference
 /// matcher so repeated pixel runs compress.
@@ -1621,6 +1880,17 @@ pub fn encode_argb_literals_with_width_selected(
     if image_width > 1 && !pixels.is_empty() && pixels.len() % image_width as usize == 0 {
         let height = pixels.len() as u32 / image_width;
         let cand = encode_predictor_path(pixels, image_width, height);
+        if cand.len() < best_bytes.len() {
+            best_bytes = cand;
+            best_code_bits = 0;
+        }
+
+        // §4.2 color transform. Like the predictor, it needs the real 2-D
+        // layout, so it is only a candidate at `image_width > 1`. The
+        // residual main image runs its own color-cache evaluation
+        // internally, so `best_code_bits` (a main-image cache field) is set
+        // to `0` when the color transform wins.
+        let cand = encode_color_path(pixels, image_width, height);
         if cand.len() < best_bytes.len() {
             best_bytes = cand;
             best_code_bits = 0;
@@ -2731,6 +3001,266 @@ mod tests {
         let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
         let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
         assert_eq!(img.pixels(), pixels.as_slice());
+    }
+
+    // ---- §4.2 forward color transform ----
+
+    /// The forward `forward_color_pixel` is the exact inverse of the
+    /// decoder's per-pixel §4.2 add-back: applying the forward transform
+    /// with an element, then re-running the inverse arithmetic the decoder
+    /// uses, restores the original red/blue across the modulo-256 wrap.
+    /// The subtlety the test pins down: the forward uses the *original* red
+    /// for the `red_to_blue` term, while the inverse uses the
+    /// already-restored red — they agree because the inverse recovers red
+    /// before touching blue.
+    #[test]
+    fn forward_color_pixel_is_inverse_of_decoder_add_back() {
+        // Cover a spread of channel values and signed coefficients
+        // (including the [128..255] → negative int8 range).
+        let coeffs: [(u8, u8, u8); 5] = [
+            (0, 0, 0),
+            (16, 24, 32),
+            (0xf0, 0x10, 0xc0), // negative g2r/r2b, positive g2b
+            (0x80, 0x7f, 0x40),
+            (200, 50, 250),
+        ];
+        let samples: [(u8, u8, u8); 6] = [
+            (0, 0, 0),
+            (255, 255, 255),
+            (10, 200, 30),
+            (250, 5, 128),
+            (123, 45, 210),
+            (1, 254, 2),
+        ];
+        for &(g2r, g2b, r2b) in &coeffs {
+            for &(r, g, b) in &samples {
+                let (nr, nb) = forward_color_pixel(r, g, b, g2r, g2b, r2b);
+                // Re-run the decoder's inverse arithmetic (mirrors
+                // `vp8l_transform::inverse_color_pixel`).
+                let dlt = |t: u8, c: u8| -> i32 { ((t as i8 as i32) * (c as i8 as i32)) >> 5 };
+                let mut tr = nr as i32;
+                let mut tb = nb as i32;
+                tr += dlt(g2r, g);
+                tb += dlt(g2b, g);
+                tb += dlt(r2b, (tr & 0xff) as u8);
+                assert_eq!(
+                    (tr & 0xff) as u8,
+                    r,
+                    "red mismatch for coeff=({g2r},{g2b},{r2b}) px=({r},{g},{b})"
+                );
+                assert_eq!(
+                    (tb & 0xff) as u8,
+                    b,
+                    "blue mismatch for coeff=({g2r},{g2b},{r2b}) px=({r},{g},{b})"
+                );
+            }
+        }
+    }
+
+    /// Every coefficient the selector emits is a representable signed-8-bit
+    /// value (trivially true since they are stored as `u8`), and the
+    /// sub-image pixels carry the §4.2 layout (alpha 0xff, red/green/blue =
+    /// r2b/g2b/g2r). This guards against an off-by-channel packing bug.
+    #[test]
+    fn color_transform_coefficients_in_valid_range_and_layout() {
+        let w = 40u32;
+        let h = 24u32; // non-multiple of 16 to exercise partial blocks.
+        let mut state = 0x5A5A_1234u32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|i| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                let g = i % 200;
+                // r/b correlated with g plus noise → non-trivial coeffs.
+                let r = (g + (state & 0x1f)) & 0xff;
+                let b = (g.wrapping_sub(state >> 8)) & 0xff;
+                0xff00_0000 | (r << 16) | (g << 8) | b
+            })
+            .collect();
+        let (sub_image, tw, th) = select_color_transform_elements(&pixels, w, h, COLOR_SIZE_BITS);
+        assert_eq!(sub_image.len(), (tw * th) as usize);
+        for &cte in &sub_image {
+            // Alpha must be opaque; channels are u8 by construction so any
+            // 0..=255 value is a valid signed-8-bit coefficient.
+            assert_eq!((cte >> 24) & 0xff, 0xff, "sub-image pixel not opaque");
+        }
+    }
+
+    /// An image with strong red/blue↔green correlation that subtract-green
+    /// does *not* fully capture (the correlation slope is fractional, not
+    /// 1:1) shrinks under the §4.2 color transform versus the best
+    /// non-color-transform path, and round-trips bit-exact. This is the
+    /// round-134 headline measurement.
+    ///
+    /// Green is high-entropy *noise* (no spatial structure, so the §4.1
+    /// predictor and §3.4 LZ77 have nothing to exploit), while red and blue
+    /// are constructed as the §4.2 transform deltas of green/red plus a
+    /// near-constant base and ±1 jitter. The matching color-transform
+    /// coefficients (g2r=16, g2b=24, r2b=8) therefore *subtract out* the
+    /// green/red contribution, collapsing the red/blue residuals onto a
+    /// tiny near-constant distribution that entropy-codes far cheaper.
+    /// Subtract-green (a single fixed slope of 1, in the unsigned domain)
+    /// cannot model these signed fractional slopes and leaves a wide
+    /// residual.
+    #[test]
+    fn color_transform_shrinks_correlated_image_and_round_trips() {
+        let w = 64u32;
+        let h = 64u32;
+        // The §4.2 signed delta the construction inverts.
+        let delta = |t: i32, c: u8| -> i32 { (t * (c as i8 as i32)) >> 5 };
+        let mut state = 0x1357_9BDFu32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                let g = (state & 0xff) as u8;
+                let jitter_r = ((state >> 8) & 0x01) as i32;
+                let jitter_b = ((state >> 9) & 0x01) as i32;
+                // r = base + delta(16, g): the color transform with
+                // green_to_red=16 produces (r - delta(16,g)) = base + jitter,
+                // a near-constant residual.
+                let r = ((8 + delta(16, g) + jitter_r) & 0xff) as u32;
+                // b = base + delta(24, g) + delta(8, r): green_to_blue=24
+                // and red_to_blue=8 likewise collapse blue to a constant.
+                let b = ((8 + delta(24, g) + delta(8, (r & 0xff) as u8) + jitter_b) & 0xff) as u32;
+                0xff00_0000 | (r << 16) | ((g as u32) << 8) | b
+            })
+            .collect();
+
+        // Best non-color-transform baseline: no-tx / subtract-green ×
+        // each cache size, plus the predictor path — everything the
+        // production chooser would consider EXCEPT the color transform.
+        let no_color = {
+            let mut best = encode_literals_with_options(&pixels, false, None, w);
+            for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+                let c = encode_literals_with_options(&pixels, false, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+                let c = encode_literals_with_options(&pixels, true, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+            }
+            let c = encode_literals_with_options(&pixels, true, None, w);
+            if c.len() < best.len() {
+                best = c;
+            }
+            let c = encode_predictor_path(&pixels, w, h);
+            if c.len() < best.len() {
+                best = c;
+            }
+            best
+        };
+        let with_color = encode_color_path(&pixels, w, h);
+        eprintln!(
+            "[round-134] 64x64 fractional-correlation: no-color-tx={} B, color-tx={} B ({:.1}% reduction)",
+            no_color.len(),
+            with_color.len(),
+            100.0 * (no_color.len() as f64 - with_color.len() as f64) / no_color.len() as f64,
+        );
+        assert!(
+            with_color.len() < no_color.len(),
+            "color transform ({} B) did not beat the best non-color path ({} B)",
+            with_color.len(),
+            no_color.len(),
+        );
+
+        // Bit-exact round trip through the color path explicitly.
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&with_color);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+
+        // And through the production chooser, which now includes the color
+        // candidate: the resulting stream still decodes pixel-exact.
+        let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+        let framed2 = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img2 = crate::decode_lossless_image(&framed2).unwrap().unwrap();
+        assert_eq!(img2.pixels(), pixels.as_slice());
+    }
+
+    /// The color path round-trips bit-exact on a noisy, uncorrelated image
+    /// on non-power-of-two dimensions too — even when the coordinate-descent
+    /// search falls back to near-identity elements, the forward/inverse
+    /// pair must reconstruct every pixel. Guards the partial-block geometry
+    /// and the modulo-256 wrap.
+    #[test]
+    fn color_transform_round_trips_on_noise() {
+        let w = 23u32;
+        let h = 19u32;
+        let mut state = 0xBADC_0FFEu32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state | 0xff00_0000
+            })
+            .collect();
+        let stream = encode_color_path(&pixels, w, h);
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&stream);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+    }
+
+    /// The color transform does not regress the production chooser on an
+    /// uncorrelated-noise image: the chooser never returns a stream larger
+    /// than the no-color baseline, because the color candidate only wins
+    /// when strictly smaller. (The identity element guarantees the color
+    /// path is never *much* worse, but the chooser's `<` comparison is what
+    /// formally prevents a regression.)
+    #[test]
+    fn color_transform_does_not_regress_on_uncorrelated_noise() {
+        let w = 32u32;
+        let h = 32u32;
+        let mut state = 0x0BAD_BEEFu32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state | 0xff00_0000
+            })
+            .collect();
+        let chosen = encode_argb_literals_with_width(&pixels, w);
+        // Baseline = chooser without the color candidate. Re-derive it the
+        // same way the chooser does, minus the color path.
+        let baseline = {
+            let mut best = encode_literals_with_options(&pixels, false, None, w);
+            for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+                let c = encode_literals_with_options(&pixels, false, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+                let c = encode_literals_with_options(&pixels, true, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+            }
+            let c = encode_literals_with_options(&pixels, true, None, w);
+            if c.len() < best.len() {
+                best = c;
+            }
+            let c = encode_predictor_path(&pixels, w, h);
+            if c.len() < best.len() {
+                best = c;
+            }
+            best
+        };
+        assert!(
+            chosen.len() <= baseline.len(),
+            "chooser with color candidate ({} B) regressed vs baseline ({} B)",
+            chosen.len(),
+            baseline.len(),
+        );
     }
 
     /// `encode_argb_literals` picks the smallest of the four

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -1774,6 +1774,196 @@ fn encode_color_path(pixels: &[u32], width: u32, height: u32) -> Vec<u8> {
     w.into_bytes()
 }
 
+// ---- §4.4 forward color-indexing (palette) transform ----
+
+/// §4.4 threshold: the maximum distinct-color count for which the
+/// color-indexing transform is applicable. Above this the palette would
+/// not fit the 8-bit `color_table_size` field (`ReadBits(8) + 1`).
+const COLOR_INDEXING_MAX_COLORS: usize = 256;
+
+/// §4.4 pixel-bundling `width_bits` for a given palette size, per the
+/// spec's Table 3 ("Color Table Size to Bundled Pixel Bit Width
+/// Mapping"). Bit-identical to the decoder's
+/// [`crate::vp8l_transform`] `color_indexing_width_bits`, so the
+/// subsampled width the encoder packs to matches the width the decoder
+/// reads the main image at.
+#[inline]
+fn fwd_color_indexing_width_bits(color_table_size: usize) -> u8 {
+    if color_table_size <= 2 {
+        3
+    } else if color_table_size <= 4 {
+        2
+    } else if color_table_size <= 16 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Collect the distinct ARGB colors of `pixels` in first-appearance
+/// (scan-line) order, returning `None` the moment the count would exceed
+/// [`COLOR_INDEXING_MAX_COLORS`] — at which point the §4.4 transform is
+/// inapplicable and the chooser skips it.
+///
+/// First-appearance order is one valid palette ordering; the spec places
+/// no constraint on the palette order (the index is what matters), so
+/// any deterministic ordering round-trips. First-appearance keeps the
+/// build a single O(n) pass with a 2^24-entry presence bitmap keyed on
+/// the low 24 bits plus an alpha disambiguation list, falling back to a
+/// linear scan only when two colors share their low 24 bits.
+fn build_palette(pixels: &[u32]) -> Option<Vec<u32>> {
+    let mut palette: Vec<u32> = Vec::new();
+    // 2^24-bit presence map over the low 24 bits (RGB) as a fast reject;
+    // collisions (same RGB, different alpha) fall through to the linear
+    // membership check against `palette`. 2 MiB heap, freed on return.
+    let mut seen_low = vec![0u8; 1 << 21]; // 2^24 bits.
+    for &px in pixels {
+        let low = (px & 0x00ff_ffff) as usize;
+        let byte = low >> 3;
+        let bit = 1u8 << (low & 7);
+        if seen_low[byte] & bit == 0 {
+            seen_low[byte] |= bit;
+            palette.push(px);
+            if palette.len() > COLOR_INDEXING_MAX_COLORS {
+                return None;
+            }
+        } else if !palette.contains(&px) {
+            // Same low-24 bits, different full ARGB (alpha differs).
+            palette.push(px);
+            if palette.len() > COLOR_INDEXING_MAX_COLORS {
+                return None;
+            }
+        }
+    }
+    Some(palette)
+}
+
+/// §4.4 forward subtraction-coding of the color table, the inverse of the
+/// decoder's [`crate::vp8l_transform::inverse_color_table`]. Entry `i` is
+/// replaced by the per-channel `(entry[i] - entry[i-1]) mod 256`; entry 0
+/// is left as-is. The decoder reconstructs by running prefix sums, so the
+/// stored deltas (typically low-entropy) decode back to the original
+/// palette exactly.
+fn forward_color_table(color_table: &[u32]) -> Vec<u32> {
+    let mut out = Vec::with_capacity(color_table.len());
+    for (i, &cur) in color_table.iter().enumerate() {
+        if i == 0 {
+            out.push(cur);
+            continue;
+        }
+        let prev = color_table[i - 1];
+        let a = (((cur >> 24) & 0xff).wrapping_sub((prev >> 24) & 0xff)) & 0xff;
+        let r = (((cur >> 16) & 0xff).wrapping_sub((prev >> 16) & 0xff)) & 0xff;
+        let g = (((cur >> 8) & 0xff).wrapping_sub((prev >> 8) & 0xff)) & 0xff;
+        let b = ((cur & 0xff).wrapping_sub(prev & 0xff)) & 0xff;
+        out.push((a << 24) | (r << 16) | (g << 8) | b);
+    }
+    out
+}
+
+/// §4.4 forward pixel replacement + bundling. Given `pixels` (canvas
+/// `width × height`) and the `index_of` map from ARGB color to palette
+/// index, produce the packed main image at the subsampled width
+/// `DIV_ROUND_UP(width, 1 << width_bits)`.
+///
+/// Each output pixel is opaque (`alpha = 255`, `red = blue = 0`) with the
+/// palette index(es) in its green channel. When `width_bits == 0` one
+/// index occupies the whole green byte; otherwise `count = 1 << width_bits`
+/// indices are bundled LSB-first into one green byte (`bits = 8 / count`
+/// per index), exactly matching the decoder's
+/// [`crate::vp8l_transform::inverse_color_indexing`] un-bundling. Indices
+/// beyond the row's last column (the partial trailing bundle) are zero,
+/// which the decoder never reads back because the un-bundler stops at
+/// `orig_width`.
+fn apply_color_indexing(
+    pixels: &[u32],
+    width: u32,
+    height: u32,
+    index_of: &impl Fn(u32) -> u8,
+    width_bits: u8,
+) -> (Vec<u32>, u32) {
+    let w = width as usize;
+    let h = height as usize;
+    let count = 1usize << width_bits;
+    let bits = 8 / count; // 8, 4, 2, or 1 bits per index.
+    let packed_w = pred_div_round_up(width, count as u32) as usize;
+    let mut packed = vec![0xff00_0000u32; packed_w * h];
+    for y in 0..h {
+        for px in 0..packed_w {
+            let mut green = 0u32;
+            for j in 0..count {
+                let x = px * count + j;
+                if x >= w {
+                    break;
+                }
+                let index = index_of(pixels[y * w + x]) as u32;
+                green |= index << (j * bits);
+            }
+            packed[y * packed_w + px] = 0xff00_0000 | (green << 8);
+        }
+    }
+    (packed, packed_w as u32)
+}
+
+/// Encode an ARGB image via the §4.4 color-indexing (palette) transform:
+/// build the palette, emit the §3.8.2 color-indexing transform header
+/// (present-bit, `TransformType::ColorIndexing`, 8-bit `color_table_size -
+/// 1`), then the palette as a §3.8.2 `entropy-coded-image` (a
+/// `color_table_size × 1` image, subtraction-coded), then the index image
+/// (one palette index per pixel, packed into the green channel with §4.4
+/// pixel-bundling for palettes ≤ 16 colors) as a §3.8.3
+/// `spatially-coded-image` at the subsampled width.
+///
+/// Returns `None` when the image has more than [`COLOR_INDEXING_MAX_COLORS`]
+/// distinct colors (the transform is inapplicable). The returned bytes
+/// decode back to `pixels` byte-for-byte through the decoder's §4.4
+/// inverse.
+fn encode_color_indexing_path(pixels: &[u32], width: u32, height: u32) -> Option<Vec<u8>> {
+    let palette = build_palette(pixels)?;
+    if palette.is_empty() {
+        return None;
+    }
+    let color_table_size = palette.len();
+    let width_bits = fwd_color_indexing_width_bits(color_table_size);
+
+    // Color-to-index lookup. The palette is small (≤256), so a flat
+    // 256-slot map keyed on the low byte plus a linear fallback would be
+    // overkill; a HashMap keeps the closure simple and the build O(n).
+    let mut index_map = std::collections::HashMap::with_capacity(color_table_size);
+    for (i, &c) in palette.iter().enumerate() {
+        index_map.insert(c, i as u8);
+    }
+    let index_of = |c: u32| -> u8 { index_map[&c] };
+
+    let (packed, packed_w) = apply_color_indexing(pixels, width, height, &index_of, width_bits);
+
+    let mut w = BitWriter::new();
+
+    // §3.8.2 color-indexing-tx: present-bit, TransformType::ColorIndexing
+    // (3), then the 8-bit `color_table_size - 1` field.
+    w.write_bit(true);
+    w.write_bits(crate::vp8l_stream::TransformType::ColorIndexing as u32, 2);
+    w.write_bits((color_table_size - 1) as u32, 8);
+
+    // color-indexing-image body = entropy-coded-image (no meta-prefix),
+    // a `color_table_size × 1` subtraction-coded palette. Evaluate its own
+    // color cache.
+    let table = forward_color_table(&palette);
+    let (table_tokens, table_bits) = best_cache_for_pixels(&table, color_table_size as u32);
+    write_entropy_coded_image(&mut w, &table_tokens, table_bits, color_table_size as u32);
+
+    // End-of-transform-list terminator.
+    w.write_bit(false);
+
+    // §3.8.3 spatially-coded-image for the packed index image at the
+    // subsampled width. Evaluate its own color cache.
+    let (idx_tokens, idx_bits) = best_cache_for_pixels(&packed, packed_w);
+    write_spatially_coded_image(&mut w, &idx_tokens, idx_bits, packed_w);
+
+    let _ = height;
+    Some(w.into_bytes())
+}
+
 /// Encode an ARGB image to a VP8L *image-stream* (the bytes that follow the
 /// §3.4 5-byte image-header), running the §5.2.2 LZ77 backward-reference
 /// matcher so repeated pixel runs compress.
@@ -1894,6 +2084,22 @@ pub fn encode_argb_literals_with_width_selected(
         if cand.len() < best_bytes.len() {
             best_bytes = cand;
             best_code_bits = 0;
+        }
+
+        // §4.4 color-indexing (palette) transform. Applicable only when the
+        // image has ≤ 256 distinct colors; `encode_color_indexing_path`
+        // returns `None` otherwise, so high-color images skip it without
+        // paying for a doomed encode. On a low-color image the palette path
+        // replaces every pixel with a single index byte (and bundles 2/4/8
+        // indices per byte for palettes ≤ 16 colors), so it typically wins
+        // by a wide margin. The packed index image runs its own color-cache
+        // evaluation internally, so `best_code_bits` (a main-image cache
+        // field) is set to `0` when the color-indexing transform wins.
+        if let Some(cand) = encode_color_indexing_path(pixels, image_width, height) {
+            if cand.len() < best_bytes.len() {
+                best_bytes = cand;
+                best_code_bits = 0;
+            }
         }
     }
 
@@ -3263,6 +3469,247 @@ mod tests {
         );
     }
 
+    // ---- §4.4 color-indexing (palette) transform ----
+
+    /// §4.4 width_bits mapping matches the decoder's Table 3 thresholds.
+    #[test]
+    fn color_indexing_width_bits_matches_table_3() {
+        assert_eq!(fwd_color_indexing_width_bits(1), 3);
+        assert_eq!(fwd_color_indexing_width_bits(2), 3);
+        assert_eq!(fwd_color_indexing_width_bits(3), 2);
+        assert_eq!(fwd_color_indexing_width_bits(4), 2);
+        assert_eq!(fwd_color_indexing_width_bits(5), 1);
+        assert_eq!(fwd_color_indexing_width_bits(16), 1);
+        assert_eq!(fwd_color_indexing_width_bits(17), 0);
+        assert_eq!(fwd_color_indexing_width_bits(256), 0);
+    }
+
+    /// `build_palette` collects distinct colors in first-appearance order
+    /// and rejects images with more than 256 distinct colors.
+    #[test]
+    fn build_palette_collects_distinct_and_rejects_high_color() {
+        let pixels = [
+            0xff11_2233u32,
+            0xff44_5566,
+            0xff11_2233, // repeat
+            0xaa11_2233, // same RGB, different alpha → distinct
+        ];
+        let pal = build_palette(&pixels).unwrap();
+        assert_eq!(pal, vec![0xff11_2233, 0xff44_5566, 0xaa11_2233]);
+
+        // 257 distinct colors → None.
+        let many: Vec<u32> = (0..257u32).map(|i| 0xff00_0000 | i).collect();
+        assert!(build_palette(&many).is_none());
+        // Exactly 256 distinct colors → Some.
+        let edge: Vec<u32> = (0..256u32).map(|i| 0xff00_0000 | i).collect();
+        assert_eq!(build_palette(&edge).unwrap().len(), 256);
+    }
+
+    /// `forward_color_table` is the exact inverse of the decoder's
+    /// subtraction-decoding, so feeding its output through
+    /// `inverse_color_table` restores the original palette.
+    #[test]
+    fn forward_color_table_inverts_decoder() {
+        let palette = vec![0xff11_2233u32, 0xee44_5566, 0x80ab_cdef, 0x00ff_0010];
+        let mut decoded = forward_color_table(&palette);
+        crate::vp8l_transform::inverse_color_table(&mut decoded);
+        assert_eq!(decoded, palette);
+    }
+
+    /// A ≤16-color synthetic image picks the color-indexing transform with
+    /// pixel-bundling and shrinks substantially versus every non-palette
+    /// candidate; the resulting stream is bit-exact decodable.
+    #[test]
+    fn color_indexing_bundled_shrinks_and_round_trips() {
+        let w = 64u32;
+        let h = 64u32;
+        // 8-color palette → width_bits = 1 (two indices per green byte).
+        let palette = [
+            0xff10_2030u32,
+            0xff40_5060,
+            0xff70_8090,
+            0xffa0_b0c0,
+            0xffd0_e0f0,
+            0xff00_1122,
+            0xff33_4455,
+            0xff66_7788,
+        ];
+        let mut state = 0x2468_ACE0u32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                palette[(state as usize) % palette.len()]
+            })
+            .collect();
+
+        // Confirm the palette path bundles (width_bits = 1 for 8 colors).
+        assert_eq!(fwd_color_indexing_width_bits(palette.len()), 1);
+
+        // Best non-palette baseline: everything the production chooser
+        // considers EXCEPT the color-indexing transform.
+        let no_palette = {
+            let mut best = encode_literals_with_options(&pixels, false, None, w);
+            for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+                let c = encode_literals_with_options(&pixels, false, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+                let c = encode_literals_with_options(&pixels, true, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+            }
+            let c = encode_literals_with_options(&pixels, true, None, w);
+            if c.len() < best.len() {
+                best = c;
+            }
+            let c = encode_predictor_path(&pixels, w, h);
+            if c.len() < best.len() {
+                best = c;
+            }
+            let c = encode_color_path(&pixels, w, h);
+            if c.len() < best.len() {
+                best = c;
+            }
+            best
+        };
+        let with_palette = encode_color_indexing_path(&pixels, w, h).unwrap();
+        eprintln!(
+            "[round-135] 64x64 8-color bundled: no-palette={} B, palette={} B ({:.1}% reduction)",
+            no_palette.len(),
+            with_palette.len(),
+            100.0 * (no_palette.len() as f64 - with_palette.len() as f64) / no_palette.len() as f64,
+        );
+        assert!(
+            with_palette.len() < no_palette.len(),
+            "color-indexing ({} B) did not beat the best non-palette path ({} B)",
+            with_palette.len(),
+            no_palette.len(),
+        );
+
+        // Bit-exact round trip through the palette path explicitly.
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&with_palette);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+
+        // And through the production chooser, which now includes the palette
+        // candidate and should pick it.
+        let chosen = encode_argb_literals_with_width(&pixels, w);
+        assert_eq!(
+            chosen.len(),
+            with_palette.len(),
+            "production chooser did not select the color-indexing path"
+        );
+        let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+        let framed2 = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img2 = crate::decode_lossless_image(&framed2).unwrap().unwrap();
+        assert_eq!(img2.pixels(), pixels.as_slice());
+    }
+
+    /// An unbundled palette (17..256 colors, width_bits = 0) round-trips
+    /// bit-exact: one index per green byte, no pixel-bundling.
+    #[test]
+    fn color_indexing_unbundled_round_trips() {
+        let w = 40u32;
+        let h = 30u32;
+        // 64-color palette → width_bits = 0 (no bundling).
+        let palette: Vec<u32> = (0..64u32)
+            .map(|i| 0xff00_0000 | (i * 0x0004_0301))
+            .collect();
+        assert_eq!(fwd_color_indexing_width_bits(palette.len()), 0);
+        let mut state = 0xDEAD_BEEFu32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                palette[(state as usize) % palette.len()]
+            })
+            .collect();
+
+        let with_palette = encode_color_indexing_path(&pixels, w, h).unwrap();
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&with_palette);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+
+        // The chooser should pick it on this low-color image.
+        let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+        let framed2 = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img2 = crate::decode_lossless_image(&framed2).unwrap().unwrap();
+        assert_eq!(img2.pixels(), pixels.as_slice());
+    }
+
+    /// Bundling on a non-power-of-two width exercises the partial trailing
+    /// bundle: the last green byte of each row holds fewer than `count`
+    /// indices, and the decoder's un-bundler must stop at `orig_width`.
+    /// Covers width_bits = 2 (4 indices/byte) and width_bits = 3 (8/byte).
+    #[test]
+    fn color_indexing_bundled_partial_row_round_trips() {
+        for palette_len in [2usize, 4] {
+            // palette_len 2 → width_bits 3 (8/byte); 4 → width_bits 2 (4/byte).
+            let w = 23u32; // not a multiple of 8 or 4.
+            let h = 7u32;
+            let palette: Vec<u32> = (0..palette_len as u32)
+                .map(|i| 0xff00_0000 | (i * 0x0011_2233))
+                .collect();
+            let mut state = 0x0F0F_0F0Fu32 ^ palette_len as u32;
+            let pixels: Vec<u32> = (0..(w * h))
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 17;
+                    state ^= state << 5;
+                    palette[(state as usize) % palette.len()]
+                })
+                .collect();
+            let with_palette = encode_color_indexing_path(&pixels, w, h).unwrap();
+            let header = build_image_header(w, h, false);
+            let mut payload = header.to_vec();
+            payload.extend_from_slice(&with_palette);
+            let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+            let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+            assert_eq!(
+                img.pixels(),
+                pixels.as_slice(),
+                "palette_len {palette_len} partial-row round trip failed"
+            );
+        }
+    }
+
+    /// A > 256-color image is NOT eligible for the color-indexing transform:
+    /// `encode_color_indexing_path` returns `None` and the production
+    /// chooser falls back to a non-palette path, still decoding bit-exact.
+    #[test]
+    fn color_indexing_rejected_on_high_color_image() {
+        let w = 40u32;
+        let h = 40u32;
+        // 1600 pixels, almost all distinct → > 256 colors.
+        let mut state = 0xABCD_1234u32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state | 0xff00_0000
+            })
+            .collect();
+        assert!(build_palette(&pixels).is_none());
+        assert!(encode_color_indexing_path(&pixels, w, h).is_none());
+
+        // The chooser still produces a valid, decodable stream.
+        let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+        let framed = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+    }
+
     /// `encode_argb_literals` picks the smallest of the four
     /// `(no-tx | sg) × (no-cache | cache)` paths it evaluates, so on
     /// any image its output equals the minimum of all four candidate
@@ -4010,15 +4457,22 @@ mod tests {
         );
     }
 
-    /// On a palette-heavy synthetic image the chooser must pick a
-    /// non-zero cache size: every pixel is drawn from a small palette
-    /// repeated in a pseudo-random order, so each repeat is a
-    /// `CacheRef` win that more than pays for the §5.2.3 header.
-    /// (a) of the round-132 brief.
+    /// On a palette-heavy synthetic image the §5.2.3 color-cache axis must
+    /// pick a non-zero cache size: every pixel is drawn from a small palette
+    /// repeated in a pseudo-random order, so each repeat is a `CacheRef` win
+    /// that more than pays for the §5.2.3 header. (a) of the round-132 brief.
+    ///
+    /// As of round 135 the production chooser ([`encode_argb_literals_with_width_selected`])
+    /// also evaluates the §4.4 color-indexing transform, which wins outright
+    /// on a 12-color image (it replaces each pixel with a one-byte index and
+    /// reports `code_bits = 0`, since its caches are internal to the packed
+    /// index image). To keep this test scoped to the cache-size axis — the
+    /// round-132 brief's actual subject — it exercises the
+    /// no-transform × cache cross-product directly via
+    /// [`best_cache_for_pixels`] rather than the full transform chooser.
     #[test]
     fn size_selection_picks_nonzero_on_palette_heavy_image() {
         let w = 64u32;
-        let h = 64u32;
         let palette: [u32; 12] = [
             0xff10_2030,
             0xff40_5060,
@@ -4033,15 +4487,19 @@ mod tests {
             0xff11_2233,
             0xff44_5566,
         ];
-        let mut pixels = Vec::with_capacity((w * h) as usize);
+        let mut pixels = Vec::with_capacity((w * 64) as usize);
         let mut state = 0x1357_9bdfu32;
-        for _ in 0..(w * h) {
+        for _ in 0..(w * 64) {
             state ^= state << 13;
             state ^= state >> 17;
             state ^= state << 5;
             pixels.push(palette[(state as usize) % palette.len()]);
         }
-        let (_, chosen) = encode_argb_literals_with_width_selected(&pixels, w);
+        // Cache-size axis only: `best_cache_for_pixels` cross-products the
+        // no-cache baseline against every candidate cache size and returns
+        // the winner's `code_bits`. The palette repeats reward a cache hit.
+        let (_, chosen_bits) = best_cache_for_pixels(&pixels, w);
+        let chosen = chosen_bits.unwrap_or(0);
         assert_ne!(
             chosen, 0,
             "palette-heavy image should engage the §5.2.3 color cache, got code_bits=0",

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -251,11 +251,21 @@ impl BitWriter {
 /// input with exactly one used symbol.
 ///
 /// The algorithm is a textbook Huffman build over a min-heap of
-/// `(frequency, node)` pairs, followed by a length-limiting pass that caps
-/// any over-long code at [`MAX_CODE_LENGTH`] while re-balancing so the
-/// Kraft sum stays exactly 1. For the small alphabets and pixel counts this
-/// encoder targets, the cap is rarely hit; the pass is correctness
-/// insurance, not an optimization.
+/// `(frequency, node)` pairs. If the unconstrained tree depth exceeds
+/// [`MAX_CODE_LENGTH`], the result is **discarded** and recomputed with the
+/// Package-Merge algorithm (Larmore–Hirschberg 1990) at the depth cap. Unlike
+/// a heuristic "lengthen the deepest leaf, shorten a short one" post-pass,
+/// Package-Merge solves the length-limited Huffman problem **optimally**: it
+/// returns the depth-≤ L assignment that minimises the expected code length
+/// ∑ freq[i] · len[i]. The selection therefore can only equal or improve on
+/// the heuristic post-pass on every input that triggers the cap, and is
+/// identical to the heuristic on every input that does not (because the
+/// unconstrained Huffman tree is itself optimal when it already fits under
+/// L).
+///
+/// For the small alphabets and pixel counts this encoder targets, the cap is
+/// rarely hit, but when it is the optimal solution can be measurably smaller
+/// than the heuristic's — see [`package_merge_code_lengths`].
 pub fn build_code_lengths(freqs: &[u32]) -> Vec<u8> {
     let n = freqs.len();
     let mut lengths = vec![0u8; n];
@@ -384,9 +394,193 @@ pub fn build_code_lengths(freqs: &[u32]) -> Vec<u8> {
     }
 
     if max_len > MAX_CODE_LENGTH {
-        limit_code_lengths(&mut lengths, &used);
+        // Discard the unconstrained build and replace it with the optimal
+        // length-limited solution. Package-Merge returns the per-symbol
+        // length assignment of depth ≤ MAX_CODE_LENGTH that minimises
+        // ∑ freq[s] · len[s] — strictly the best the encoder can do under
+        // the spec's 15-bit cap.
+        let pm = package_merge_code_lengths(freqs, MAX_CODE_LENGTH);
+        lengths[..n].copy_from_slice(&pm[..n]);
     }
 
+    lengths
+}
+
+/// Optimal length-limited Huffman code-length assignment via the
+/// **Package-Merge algorithm** (Larmore–Hirschberg, "A Fast Algorithm for
+/// Optimal Length-Limited Huffman Codes", *J. ACM* 1990). For an alphabet
+/// of `freqs.len()` symbols with frequencies `freqs[s]`, returns a
+/// `Vec<u8>` of code lengths, one per symbol (0 = unused), such that:
+///
+/// * every used symbol's length is in `1..=max_len`,
+/// * the Kraft sum `∑ 2^-len[s]` over used symbols equals exactly 1
+///   (i.e. the resulting canonical Huffman code is *complete*), and
+/// * `∑ freq[s] · len[s]` is minimised over every length assignment
+///   satisfying the first two conditions.
+///
+/// ## Algorithm (textbook description)
+///
+/// Treat each used symbol as a "coin" of value `2^-i` for `i = 1..=max_len`.
+/// We need to select coins from `max_len` lists (one per `i`) totalling
+/// exactly `n-1` (in units of `2^-max_len`), minimising total coin
+/// frequency — this is the classic *coin-collector* reformulation of
+/// length-limited Huffman:
+///
+/// 1. Build the list at level `max_len` as `n` "items", one per used
+///    symbol, with `weight = freq[s]` and `leaves = {s}`.
+/// 2. For `level = max_len` down to `2`, repeat (a)–(c):
+///    (a) sort the current list by weight (stable on first-appearance);
+///    (b) take pairs `(items[0], items[1]), (items[2], items[3]), …` —
+///    drop any trailing unpaired item; each pair becomes a "package" with
+///    `weight = weight_a + weight_b` and leaf-multiset = union of the
+///    pair's leaves;
+///    (c) merge the packages into the next level (`level - 1`)'s leaf
+///    list (which is again `n` leaves with `weight = freq[s]`).
+/// 3. After processing, the level-1 list contains `n` original leaves plus
+///    some packages. Sort it by weight and pick the lowest-weight `2n - 2`
+///    items.
+/// 4. For each leaf `s`, count how many times it appears across the
+///    selected items (each leaf appears at most `max_len` times). That
+///    count is `len[s]`.
+///
+/// Steps 1–4 give an optimal length-limited Huffman code; the Kraft sum
+/// invariant follows from the coin-collector reformulation and the choice
+/// of `2n - 2` items.
+///
+/// ## Special cases
+///
+/// * 0 used symbols → all-zero result (caller emits the spec's
+///   single-symbol-0 form).
+/// * 1 used symbol → `len[s] = 1` (§3.7.2.1.2 single-leaf form).
+/// * `n` used symbols where `2^max_len < n` (the cap cannot describe a
+///   prefix-free code for `n` symbols) → returns whatever the algorithm
+///   yields; in practice the encoder only invokes this routine for
+///   alphabets with `n ≤ 280 < 2^15`, so the case never arises.
+///
+/// This routine is the optimal replacement for the round 136 heuristic
+/// length-limiter. On histograms where the depth cap does not bite, both
+/// the heuristic and Package-Merge return the same lengths as the
+/// unconstrained Huffman build, so this routine is invoked only via the
+/// fallback path in [`build_code_lengths`]. On histograms where it does
+/// bite, Package-Merge's lengths are weakly smaller (in the
+/// `∑ freq[s] · len[s]` sense) than the heuristic's on every input, and
+/// strictly smaller on inputs where the heuristic's local "lengthen the
+/// longest leaf" greedy is sub-optimal — see the `tests` module's
+/// `package_merge_beats_heuristic_on_pathological_histogram` case.
+pub fn package_merge_code_lengths(freqs: &[u32], max_len: usize) -> Vec<u8> {
+    let n = freqs.len();
+    let mut lengths = vec![0u8; n];
+
+    // Collect used symbols and short-circuit the 0- and 1-symbol cases.
+    let used: Vec<usize> = (0..n).filter(|&s| freqs[s] > 0).collect();
+    match used.len() {
+        0 => return lengths,
+        1 => {
+            lengths[used[0]] = 1;
+            return lengths;
+        }
+        _ => {}
+    }
+    debug_assert!(max_len >= 1);
+
+    // An `Item` is either a leaf (one symbol) or a package of two children.
+    // We track only the multiset of leaves it represents — that is the
+    // information needed to recover per-symbol lengths at the end. Storing
+    // a sorted, deduplicated `(symbol_index_in_used, count)` list would be
+    // cheaper, but a plain `Vec<usize>` of `used`-indices keeps the code
+    // simple and the alphabet sizes involved are small (n ≤ 280).
+    #[derive(Clone)]
+    struct Item {
+        weight: u64,
+        // Indices into `used` (so 0..used.len()), each occurrence counted.
+        leaves: Vec<u16>,
+    }
+
+    let u = used.len();
+    // Level `max_len`'s starting list: one item per used symbol.
+    let mut current: Vec<Item> = (0..u)
+        .map(|i| Item {
+            weight: freqs[used[i]] as u64,
+            leaves: vec![i as u16],
+        })
+        .collect();
+
+    // Stable sort by weight (ascending). `sort_by_key` is stable.
+    current.sort_by_key(|it| it.weight);
+
+    // Iterate from level = max_len down to level = 2. At each step we pair
+    // adjacent items into packages and merge those packages with the
+    // original `u` leaves at the next level.
+    for _ in 1..max_len {
+        // Pair up. A trailing unpaired item is dropped.
+        let pairs = current.len() / 2;
+        let mut packages: Vec<Item> = Vec::with_capacity(pairs);
+        for k in 0..pairs {
+            let a = &current[2 * k];
+            let b = &current[2 * k + 1];
+            let mut leaves = Vec::with_capacity(a.leaves.len() + b.leaves.len());
+            leaves.extend_from_slice(&a.leaves);
+            leaves.extend_from_slice(&b.leaves);
+            packages.push(Item {
+                weight: a.weight + b.weight,
+                leaves,
+            });
+        }
+        // Merge `packages` with a fresh leaf list. Both are sorted (the
+        // leaf list trivially by repeated stable sort, the package list by
+        // construction from a sorted source via pair-sums in ascending
+        // order). A straight merge keeps the combined list sorted in O(n).
+        let leaves_iter: Vec<Item> = (0..u)
+            .map(|i| Item {
+                weight: freqs[used[i]] as u64,
+                leaves: vec![i as u16],
+            })
+            .collect();
+        // We need leaves stably sorted by weight (matching the level-max
+        // initial sort). Reuse the same key.
+        let mut leaves_sorted = leaves_iter;
+        leaves_sorted.sort_by_key(|it| it.weight);
+
+        let mut merged: Vec<Item> = Vec::with_capacity(packages.len() + leaves_sorted.len());
+        let (mut i, mut j) = (0usize, 0usize);
+        while i < leaves_sorted.len() && j < packages.len() {
+            if leaves_sorted[i].weight <= packages[j].weight {
+                merged.push(leaves_sorted[i].clone());
+                i += 1;
+            } else {
+                merged.push(packages[j].clone());
+                j += 1;
+            }
+        }
+        while i < leaves_sorted.len() {
+            merged.push(leaves_sorted[i].clone());
+            i += 1;
+        }
+        while j < packages.len() {
+            merged.push(packages[j].clone());
+            j += 1;
+        }
+        current = merged;
+    }
+
+    // Pick the lowest-weight (2u - 2) items from the level-1 list. Per the
+    // coin-collector formulation that is exactly the number of selections
+    // needed for a complete code over `u` leaves.
+    let take = 2 * u - 2;
+    debug_assert!(current.len() >= take, "package-merge ran out of items");
+    let mut counts = vec![0u8; u];
+    for it in current.iter().take(take) {
+        for &li in &it.leaves {
+            counts[li as usize] += 1;
+        }
+    }
+
+    // counts[i] is the code length of used[i].
+    for (i, &c) in counts.iter().enumerate() {
+        debug_assert!(c >= 1, "every used symbol must be selected at least once");
+        debug_assert!(c as usize <= max_len, "package-merge length exceeded cap");
+        lengths[used[i]] = c;
+    }
     lengths
 }
 
@@ -394,12 +588,13 @@ pub fn build_code_lengths(freqs: &[u32]) -> Vec<u8> {
 /// exactly 1, using the standard "move a too-long leaf up and lengthen a
 /// short leaf to compensate" rebalancing pass.
 ///
-/// This is the approach a length-limited Huffman post-pass uses when a
-/// pathological frequency distribution would otherwise need codes longer
-/// than the format allows. It produces a *valid* (complete) code that is at
-/// most marginally sub-optimal; exactness of the round trip is unaffected
-/// because the decoder reconstructs pixels from whatever complete code the
-/// lengths describe.
+/// **Historical / comparison path only.** [`build_code_lengths`] no longer
+/// calls this routine — it falls back to [`package_merge_code_lengths`]
+/// when the depth cap is exceeded, which is provably optimal. This routine
+/// is retained so the `tests` module can demonstrate the byte delta
+/// between the round-136 heuristic and the round-137 optimal solution on
+/// histograms that trigger the cap.
+#[cfg(test)]
 fn limit_code_lengths(lengths: &mut [u8], used: &[usize]) {
     // Clamp.
     for &s in used {
@@ -4998,6 +5193,298 @@ mod tests {
                 chooser_prefix <= scan_prefix,
                 "d={d}: chooser code {chooser_code} (prefix {chooser_prefix}) > scan-line {scan_code} (prefix {scan_prefix})",
             );
+        }
+    }
+
+    // ---- Package-Merge length-limited Huffman (round 137) ----
+
+    /// Helper: integer Kraft sum over denominator `2^max_len`. A complete
+    /// code has Kraft sum exactly `2^max_len`; a deficient code is less.
+    fn kraft_sum(lengths: &[u8], max_len: usize) -> i64 {
+        let mut k = 0i64;
+        for &l in lengths {
+            if l > 0 {
+                k += 1i64 << (max_len - l as usize);
+            }
+        }
+        k
+    }
+
+    /// Helper: total bit cost `∑ freq[s] · len[s]`.
+    fn weighted_length(freqs: &[u32], lengths: &[u8]) -> u64 {
+        freqs
+            .iter()
+            .zip(lengths.iter())
+            .map(|(&f, &l)| f as u64 * l as u64)
+            .sum()
+    }
+
+    /// Package-Merge produces the §3.7.2.1.2 single-leaf form for a
+    /// single-used-symbol input.
+    #[test]
+    fn package_merge_single_symbol_is_length_one() {
+        let mut freq = vec![0u32; 8];
+        freq[5] = 17;
+        let l = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+        assert_eq!(l[5], 1);
+        assert_eq!(l.iter().filter(|&&v| v != 0).count(), 1);
+    }
+
+    /// Two used symbols both get length 1 — the only complete two-leaf
+    /// code.
+    #[test]
+    fn package_merge_two_symbols_length_one_each() {
+        let mut freq = vec![0u32; 4];
+        freq[1] = 7;
+        freq[2] = 3;
+        let l = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+        assert_eq!(l[1], 1);
+        assert_eq!(l[2], 1);
+        assert_eq!(l[0], 0);
+        assert_eq!(l[3], 0);
+    }
+
+    /// Package-Merge's Kraft sum is exactly 1 on every input with at least
+    /// two used symbols, satisfying §3.7.2's completeness invariant.
+    #[test]
+    fn package_merge_kraft_sum_is_exactly_one() {
+        let cases: &[&[u32]] = &[
+            &[100, 1, 1, 1, 50, 25, 4, 2],
+            &[1, 1, 1, 1, 1, 1, 1, 1],
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            // Fibonacci-like distribution, the textbook worst case for
+            // unconstrained Huffman tree depth.
+            &[
+                1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584,
+            ],
+        ];
+        for &freq in cases {
+            let l = package_merge_code_lengths(freq, MAX_CODE_LENGTH);
+            assert_eq!(
+                kraft_sum(&l, MAX_CODE_LENGTH),
+                1i64 << MAX_CODE_LENGTH,
+                "freq={freq:?} lengths={l:?}",
+            );
+            for (s, &len) in l.iter().enumerate() {
+                if freq[s] > 0 {
+                    assert!(len >= 1 && (len as usize) <= MAX_CODE_LENGTH);
+                } else {
+                    assert_eq!(len, 0);
+                }
+            }
+        }
+    }
+
+    /// On a histogram whose unconstrained Huffman tree fits under the
+    /// cap, Package-Merge returns the unconstrained build's lengths
+    /// (because the unconstrained build is already optimal).
+    #[test]
+    fn package_merge_matches_huffman_when_cap_not_triggered() {
+        // 8 symbols with a mild skew; max Huffman depth here is well
+        // below 15.
+        let freq = vec![40u32, 10, 5, 5, 1, 3, 2, 1];
+        let huff = build_code_lengths(&freq);
+        let pm = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+        // Both must have the same weighted length (i.e. both optimal).
+        assert_eq!(weighted_length(&freq, &huff), weighted_length(&freq, &pm));
+        // Both must be complete codes.
+        assert_eq!(kraft_sum(&huff, MAX_CODE_LENGTH), 1i64 << MAX_CODE_LENGTH);
+        assert_eq!(kraft_sum(&pm, MAX_CODE_LENGTH), 1i64 << MAX_CODE_LENGTH);
+    }
+
+    /// A pathological histogram that forces the unconstrained Huffman tree
+    /// past the 15-bit cap. The classic recipe is a Fibonacci-ish weight
+    /// vector — the unconstrained tree is a maximally-skewed Vine, with
+    /// depth ≈ n. Pick n = 20 so the unconstrained max depth is 19 > 15.
+    fn pathological_freqs() -> Vec<u32> {
+        // 20 symbols; pure Fibonacci is the textbook worst case.
+        let mut f = vec![1u32, 1];
+        while f.len() < 20 {
+            let n = f.len();
+            f.push(f[n - 1] + f[n - 2]);
+        }
+        f
+    }
+
+    /// Package-Merge's bit cost on the pathological histogram is **at most
+    /// the heuristic post-pass's** bit cost, and **strictly less** when the
+    /// heuristic is sub-optimal. This is the round 137 win.
+    #[test]
+    fn package_merge_beats_heuristic_on_pathological_histogram() {
+        let freq = pathological_freqs();
+
+        // Unconstrained Huffman lengths (would exceed 15 here).
+        let unconstrained = unconstrained_huffman_for_test(&freq);
+        let max_unconstrained = *unconstrained.iter().max().unwrap();
+        assert!(
+            (max_unconstrained as usize) > MAX_CODE_LENGTH,
+            "test pre-condition: unconstrained depth must exceed cap (got {max_unconstrained})",
+        );
+
+        // Apply the round 136 heuristic post-pass to the unconstrained
+        // lengths.
+        let mut heuristic = unconstrained.clone();
+        let used: Vec<usize> = (0..freq.len()).filter(|&s| freq[s] > 0).collect();
+        limit_code_lengths(&mut heuristic, &used);
+        // Both must be complete.
+        assert_eq!(
+            kraft_sum(&heuristic, MAX_CODE_LENGTH),
+            1i64 << MAX_CODE_LENGTH,
+            "heuristic must remain complete",
+        );
+
+        let pm = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+        assert_eq!(
+            kraft_sum(&pm, MAX_CODE_LENGTH),
+            1i64 << MAX_CODE_LENGTH,
+            "package-merge must be complete",
+        );
+
+        let wl_heuristic = weighted_length(&freq, &heuristic);
+        let wl_pm = weighted_length(&freq, &pm);
+        assert!(
+            wl_pm <= wl_heuristic,
+            "package-merge must be no worse than heuristic: pm={wl_pm} heuristic={wl_heuristic}",
+        );
+        // The headline claim of round 137: strictly smaller on a
+        // depth-cap-triggering pathological input.
+        assert!(
+            wl_pm < wl_heuristic,
+            "package-merge should strictly beat heuristic here: pm={wl_pm} heuristic={wl_heuristic}",
+        );
+    }
+
+    /// A deeper Fibonacci(25) histogram, where the unconstrained Huffman
+    /// tree depth is 24 (well past the 15-bit cap). On this input the
+    /// round-137 Package-Merge solution saves **759 bits (~95 bytes)** of
+    /// payload over the round-136 heuristic post-pass — a measurable
+    /// improvement on a depth-cap-triggered alphabet.
+    #[test]
+    fn package_merge_beats_heuristic_on_fib25() {
+        let mut freq = vec![1u32, 1];
+        while freq.len() < 25 {
+            let n = freq.len();
+            freq.push(freq[n - 1] + freq[n - 2]);
+        }
+        let unconstrained = unconstrained_huffman_for_test(&freq);
+        assert!((*unconstrained.iter().max().unwrap() as usize) > MAX_CODE_LENGTH);
+
+        let mut heuristic = unconstrained.clone();
+        let used: Vec<usize> = (0..freq.len()).filter(|&s| freq[s] > 0).collect();
+        limit_code_lengths(&mut heuristic, &used);
+        let pm = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+
+        let wl_heuristic = weighted_length(&freq, &heuristic);
+        let wl_pm = weighted_length(&freq, &pm);
+        // The exact recorded delta at round-137 land; locked into the test
+        // so any regression in the Package-Merge implementation surfaces.
+        assert_eq!(
+            wl_heuristic - wl_pm,
+            759,
+            "Fibonacci(25) heuristic={wl_heuristic} pm={wl_pm}",
+        );
+        // Cap honoured on both.
+        assert!(heuristic.iter().all(|&l| (l as usize) <= MAX_CODE_LENGTH));
+        assert!(pm.iter().all(|&l| (l as usize) <= MAX_CODE_LENGTH));
+        // Both complete.
+        assert_eq!(
+            kraft_sum(&heuristic, MAX_CODE_LENGTH),
+            1i64 << MAX_CODE_LENGTH,
+        );
+        assert_eq!(kraft_sum(&pm, MAX_CODE_LENGTH), 1i64 << MAX_CODE_LENGTH);
+    }
+
+    /// Unconstrained Huffman build, copied from `build_code_lengths`
+    /// minus the depth-cap fallback. Used by the comparison test to
+    /// recover the pre-cap tree lengths.
+    fn unconstrained_huffman_for_test(freqs: &[u32]) -> Vec<u8> {
+        let n = freqs.len();
+        let mut lengths = vec![0u8; n];
+        let used: Vec<usize> = (0..n).filter(|&s| freqs[s] > 0).collect();
+        match used.len() {
+            0 => return lengths,
+            1 => {
+                lengths[used[0]] = 1;
+                return lengths;
+            }
+            _ => {}
+        }
+        // Naive O(n^2) repeated min-find for clarity in test code.
+        let mut parent: Vec<isize> = vec![-1; n];
+        let mut node_freq: Vec<u64> = (0..n).map(|s| freqs[s] as u64).collect();
+        let mut live: Vec<usize> = used.clone();
+        while live.len() > 1 {
+            // Find the two minimum-weight live nodes.
+            live.sort_by_key(|&x| node_freq[x]);
+            let a = live.remove(0);
+            let b = live.remove(0);
+            let new_node = node_freq.len();
+            node_freq.push(node_freq[a] + node_freq[b]);
+            parent.push(-1);
+            parent[a] = new_node as isize;
+            parent[b] = new_node as isize;
+            live.push(new_node);
+        }
+        for &s in &used {
+            let mut depth = 0usize;
+            let mut cur = s as isize;
+            while parent[cur as usize] != -1 {
+                cur = parent[cur as usize];
+                depth += 1;
+            }
+            lengths[s] = depth as u8;
+        }
+        lengths
+    }
+
+    /// `build_code_lengths` now invokes Package-Merge on the fallback
+    /// path: on the pathological histogram, its bit cost must equal
+    /// Package-Merge's (strictly better than the round 136 heuristic).
+    #[test]
+    fn build_code_lengths_uses_package_merge_on_overflow() {
+        let freq = pathological_freqs();
+        let lengths = build_code_lengths(&freq);
+
+        // Cap enforced.
+        let max = *lengths.iter().max().unwrap();
+        assert!(
+            (max as usize) <= MAX_CODE_LENGTH,
+            "depth cap honoured (got {max})",
+        );
+        // Complete.
+        assert_eq!(
+            kraft_sum(&lengths, MAX_CODE_LENGTH),
+            1i64 << MAX_CODE_LENGTH,
+        );
+
+        // Bit-exact match with package-merge.
+        let pm = package_merge_code_lengths(&freq, MAX_CODE_LENGTH);
+        assert_eq!(
+            weighted_length(&freq, &lengths),
+            weighted_length(&freq, &pm)
+        );
+    }
+
+    /// The cap-triggered code must still round-trip through the round-104
+    /// prefix reader — Package-Merge is bit-correct, not just numerically
+    /// better.
+    #[test]
+    fn package_merge_round_trips_through_prefix_reader() {
+        let freq = pathological_freqs();
+        let code = WriteCode::from_freqs(&freq);
+
+        let mut w = BitWriter::new();
+        code.write_code_lengths(&mut w);
+        // Emit one of each used symbol.
+        let used: Vec<usize> = (0..freq.len()).filter(|&s| freq[s] > 0).collect();
+        for &s in &used {
+            code.write_symbol(&mut w, s);
+        }
+        let bytes = w.into_bytes();
+        let mut r = BitReader::new(&bytes);
+        let decoded = PrefixCode::read(&mut r, freq.len()).unwrap();
+        for &s in &used {
+            assert_eq!(decoded.read_symbol(&mut r).unwrap() as usize, s);
         }
     }
 }

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -1168,6 +1168,353 @@ pub fn apply_subtract_green(pixels: &mut [u32]) {
     }
 }
 
+// ---- §3.5.1 / §4.1 forward predictor transform ----
+
+/// The number of §4.1 prediction modes (`[0..13]`).
+const NUM_PREDICTOR_MODES: u8 = 14;
+
+/// The §4.1 `size_bits` value the encoder writes: block edge is
+/// `1 << PREDICTOR_SIZE_BITS` pixels. The 3-bit on-wire field stores
+/// `size_bits - 2`, so `PREDICTOR_SIZE_BITS ∈ [2, 9]`. Four (16×16 blocks)
+/// balances per-block mode granularity against the cost of the
+/// sub-resolution predictor image: smaller blocks adapt the predictor to
+/// local image structure but inflate the sub-image, larger blocks shrink
+/// the sub-image but force one mode over a wide area.
+const PREDICTOR_SIZE_BITS: u8 = 4;
+
+/// §4.1 `(a + b) / 2` per ARGB channel. Bit-identical to the decoder's
+/// `average2` so the forward residual the encoder subtracts is the exact
+/// inverse of the value the decoder will add back.
+#[inline]
+fn pred_average2(a: u32, b: u32) -> u32 {
+    let f = |sh: u32| -> u32 {
+        let ca = (a >> sh) & 0xff;
+        let cb = (b >> sh) & 0xff;
+        (ca + cb) / 2
+    };
+    (f(24) << 24) | (f(16) << 16) | (f(8) << 8) | f(0)
+}
+
+/// §4.1 `Clamp(a)` to `[0, 255]`.
+#[inline]
+fn pred_clamp(a: i32) -> i32 {
+    a.clamp(0, 255)
+}
+
+/// §4.1 `ClampAddSubtractFull(a, b, c) = Clamp(a + b - c)` per channel.
+#[inline]
+fn pred_clamp_add_subtract_full(a: u32, b: u32, c: u32) -> u32 {
+    let f = |sh: u32| -> u32 {
+        let ca = ((a >> sh) & 0xff) as i32;
+        let cb = ((b >> sh) & 0xff) as i32;
+        let cc = ((c >> sh) & 0xff) as i32;
+        pred_clamp(ca + cb - cc) as u32
+    };
+    (f(24) << 24) | (f(16) << 16) | (f(8) << 8) | f(0)
+}
+
+/// §4.1 `ClampAddSubtractHalf(a, b) = Clamp(a + (a - b) / 2)` per channel.
+#[inline]
+fn pred_clamp_add_subtract_half(a: u32, b: u32) -> u32 {
+    let f = |sh: u32| -> u32 {
+        let ca = ((a >> sh) & 0xff) as i32;
+        let cb = ((b >> sh) & 0xff) as i32;
+        pred_clamp(ca + (ca - cb) / 2) as u32
+    };
+    (f(24) << 24) | (f(16) << 16) | (f(8) << 8) | f(0)
+}
+
+/// §4.1 `Select(L, T, TL)`: whichever of `L` / `T` is closer (Manhattan
+/// distance) to the per-channel `L + T - TL` estimate.
+#[inline]
+fn pred_select(l: u32, t: u32, tl: u32) -> u32 {
+    let ch = |p: u32, sh: u32| ((p >> sh) & 0xff) as i32;
+    let p_alpha = ch(l, 24) + ch(t, 24) - ch(tl, 24);
+    let p_red = ch(l, 16) + ch(t, 16) - ch(tl, 16);
+    let p_green = ch(l, 8) + ch(t, 8) - ch(tl, 8);
+    let p_blue = ch(l, 0) + ch(t, 0) - ch(tl, 0);
+
+    let p_l = (p_alpha - ch(l, 24)).abs()
+        + (p_red - ch(l, 16)).abs()
+        + (p_green - ch(l, 8)).abs()
+        + (p_blue - ch(l, 0)).abs();
+    let p_t = (p_alpha - ch(t, 24)).abs()
+        + (p_red - ch(t, 16)).abs()
+        + (p_green - ch(t, 8)).abs()
+        + (p_blue - ch(t, 0)).abs();
+
+    if p_l < p_t {
+        l
+    } else {
+        t
+    }
+}
+
+/// §4.1: compute the prediction for `mode ∈ [0..13]` given the four
+/// already-encoded neighbours. Bit-identical to the decoder's `predict`;
+/// see [`crate::vp8l_transform::inverse_predictor`].
+fn pred_predict(mode: u8, l: u32, t: u32, tr: u32, tl: u32) -> u32 {
+    match mode {
+        0 => 0xff00_0000,
+        1 => l,
+        2 => t,
+        3 => tr,
+        4 => tl,
+        5 => pred_average2(pred_average2(l, tr), t),
+        6 => pred_average2(l, tl),
+        7 => pred_average2(l, t),
+        8 => pred_average2(tl, t),
+        9 => pred_average2(t, tr),
+        10 => pred_average2(pred_average2(l, tl), pred_average2(t, tr)),
+        11 => pred_select(l, t, tl),
+        12 => pred_clamp_add_subtract_full(l, t, tl),
+        13 => pred_clamp_add_subtract_half(pred_average2(l, t), tl),
+        _ => 0xff00_0000,
+    }
+}
+
+/// §4.1 forward residual: `residual = actual - pred` per channel, wrapped
+/// to 8 bits. The exact inverse of the decoder's `add_pred`
+/// (`final = residual + pred`), so a decode of the residual restores the
+/// original pixel byte-for-byte.
+#[inline]
+fn sub_pred(actual: u32, pred: u32) -> u32 {
+    let f = |sh: u32| -> u32 {
+        let ca = (actual >> sh) & 0xff;
+        let cp = (pred >> sh) & 0xff;
+        ca.wrapping_sub(cp) & 0xff
+    };
+    (f(24) << 24) | (f(16) << 16) | (f(8) << 8) | f(0)
+}
+
+/// `DIV_ROUND_UP(num, den)` (§3.5.1) — the ceil-division used for the
+/// predictor sub-resolution image dimensions.
+#[inline]
+fn pred_div_round_up(num: u32, den: u32) -> u32 {
+    num.div_ceil(den)
+}
+
+/// The §4.1 prediction value for pixel `(x, y)` given the
+/// already-reconstructed `pixels` buffer and the block's `mode`. Applies
+/// the §4.1 border rules: the left-topmost pixel predicts `0xff000000`,
+/// the top row predicts L, the left column predicts T, and the rightmost
+/// column substitutes the row's leftmost pixel for TR. Identical to the
+/// decoder's per-pixel branch in
+/// [`crate::vp8l_transform::inverse_predictor`].
+#[inline]
+fn predict_at(pixels: &[u32], w: usize, x: usize, y: usize, mode: u8) -> u32 {
+    let idx = y * w + x;
+    if x == 0 && y == 0 {
+        0xff00_0000
+    } else if y == 0 {
+        pixels[idx - 1]
+    } else if x == 0 {
+        pixels[idx - w]
+    } else {
+        let l = pixels[idx - 1];
+        let t = pixels[idx - w];
+        let tl = pixels[idx - w - 1];
+        let tr = if x == w - 1 {
+            // Rightmost column: TR is the row's leftmost pixel.
+            pixels[idx - w - (w - 1)]
+        } else {
+            pixels[idx - w + 1]
+        };
+        pred_predict(mode, l, t, tr, tl)
+    }
+}
+
+/// Per-channel sum of absolute residuals for one prediction — a cheap
+/// proxy for the post-entropy cost. A block whose residuals cluster near
+/// zero (or wrap near 255, which is `-1`) costs fewer bits, so the score
+/// folds the modulo-256 wrap by treating each residual byte as the
+/// distance to the nearer of `0` and `256`.
+#[inline]
+fn residual_cost(actual: u32, pred: u32) -> u32 {
+    let res = sub_pred(actual, pred);
+    let mut cost = 0u32;
+    for sh in [24u32, 16, 8, 0] {
+        let r = (res >> sh) & 0xff;
+        // Distance to the nearer of 0 / 256: small magnitudes (whether
+        // a small positive residual or a small wrap-around negative one)
+        // score low, matching the entropy stage's bias toward 0.
+        cost += r.min(256 - r);
+    }
+    cost
+}
+
+/// Pick the §4.1 prediction mode for every block of the image and return
+/// the sub-resolution predictor image (one ARGB pixel per block, mode in
+/// the green channel) alongside the block dimensions.
+///
+/// For each block the encoder scores all 14 modes by the
+/// [`residual_cost`] proxy summed over the block's pixels, predicting from
+/// the *original* (un-transformed) neighbour pixels — the decoder
+/// reconstructs from those same already-decoded originals, so the
+/// prediction the encoder scores is the prediction the decoder computes.
+/// The lowest-cost mode wins; ties resolve to the lower mode index.
+fn select_predictor_modes(
+    pixels: &[u32],
+    width: u32,
+    height: u32,
+    size_bits: u8,
+) -> (Vec<u32>, u32, u32) {
+    let w = width as usize;
+    let h = height as usize;
+    let block = 1usize << size_bits;
+    let tw = pred_div_round_up(width, block as u32);
+    let th = pred_div_round_up(height, block as u32);
+    let mut sub_image = vec![0xff00_0000u32; (tw * th) as usize];
+
+    for by in 0..th as usize {
+        for bx in 0..tw as usize {
+            let x0 = bx * block;
+            let y0 = by * block;
+            let x1 = (x0 + block).min(w);
+            let y1 = (y0 + block).min(h);
+
+            let mut best_mode = 0u8;
+            let mut best_cost = u64::MAX;
+            for mode in 0..NUM_PREDICTOR_MODES {
+                let mut cost = 0u64;
+                'rows: for y in y0..y1 {
+                    for x in x0..x1 {
+                        let pred = predict_at(pixels, w, x, y, mode);
+                        cost += residual_cost(pixels[y * w + x], pred) as u64;
+                        if cost >= best_cost {
+                            // This mode has already lost; skip the rest of
+                            // the block. The partial `cost` is only used to
+                            // bail, never to win (it is `>= best_cost`).
+                            break 'rows;
+                        }
+                    }
+                }
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_mode = mode;
+                }
+            }
+            // Mode lives in the green channel; alpha 0xff keeps the
+            // sub-image pixels opaque (alpha is irrelevant to the decoder,
+            // which reads only green).
+            sub_image[by * tw as usize + bx] = 0xff00_0000 | ((best_mode as u32) << 8);
+        }
+    }
+    (sub_image, tw, th)
+}
+
+/// Apply the §4.1 forward predictor transform: choose a per-block mode map,
+/// then replace every pixel with its residual (`actual - pred`).
+///
+/// Returns the residual image (same dimensions as the input), the
+/// sub-resolution predictor image (mode in green, dimensions
+/// `transform_width * transform_height`), the chosen `size_bits`, and
+/// `transform_width`. The residual buffer fed through the decoder's
+/// §4.1 inverse (with the returned sub-image + `size_bits`) reconstructs
+/// `pixels` exactly.
+fn apply_predictor_transform(
+    pixels: &[u32],
+    width: u32,
+    height: u32,
+) -> (Vec<u32>, Vec<u32>, u8, u32) {
+    let size_bits = PREDICTOR_SIZE_BITS;
+    let (sub_image, tw, _th) = select_predictor_modes(pixels, width, height, size_bits);
+
+    let w = width as usize;
+    let h = height as usize;
+    let mut residuals = vec![0u32; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            let block_index = (y as u32 >> size_bits) * tw + (x as u32 >> size_bits);
+            let mode = ((sub_image[block_index as usize] >> 8) & 0xff) as u8;
+            let pred = predict_at(pixels, w, x, y, mode);
+            residuals[y * w + x] = sub_pred(pixels[y * w + x], pred);
+        }
+    }
+    (residuals, sub_image, size_bits, tw)
+}
+
+/// Encode the residual main image as a §5.2.2 token stream with an
+/// optional §5.2.3 color cache, picking the smaller of (no-cache,
+/// each-candidate-cache). Returns the winning tokens, the chosen
+/// cache `code_bits` (`None` for no cache), and that path's `image_width`.
+///
+/// Shared by the predictor path: the residual image runs the same LZ77 +
+/// color-cache machinery as the no-transform path, so the cache axis is
+/// re-evaluated against the residual distribution (not the original).
+fn best_cache_for_pixels(working: &[u32], image_width: u32) -> (Vec<Token>, Option<u32>) {
+    let base_tokens = tokenize_lz77(working);
+    let mut best_len = {
+        let mut w = BitWriter::new();
+        write_entropy_coded_image_probe(&mut w, &base_tokens, None, image_width);
+        w.into_bytes().len()
+    };
+    let mut best_tokens = base_tokens.clone();
+    let mut best_bits: Option<u32> = None;
+    for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+        let toks = cacheify_tokens(&base_tokens, working, bits);
+        let mut w = BitWriter::new();
+        write_entropy_coded_image_probe(&mut w, &toks, Some(bits), image_width);
+        let len = w.into_bytes().len();
+        if len < best_len {
+            best_len = len;
+            best_tokens = toks;
+            best_bits = Some(bits);
+        }
+    }
+    (best_tokens, best_bits)
+}
+
+/// Thin wrapper that measures an `entropy-coded-image` body's encoded
+/// length for the [`best_cache_for_pixels`] chooser. Identical bytes to
+/// what the residual main image emits (modulo the meta-prefix bit, which
+/// is a single bit and so does not change the relative ordering of the
+/// candidates), so the chooser's winner is a faithful proxy.
+fn write_entropy_coded_image_probe(
+    w: &mut BitWriter,
+    tokens: &[Token],
+    color_cache_code_bits: Option<u32>,
+    image_width: u32,
+) {
+    write_entropy_coded_image(w, tokens, color_cache_code_bits, image_width);
+}
+
+/// Encode an ARGB image via the §4.1 predictor transform: pick a per-block
+/// mode map, emit the predictor transform header + sub-resolution
+/// predictor image (an `entropy-coded-image`), then the residual main
+/// image as a §3.8.3 `spatially-coded-image`. The result decodes back to
+/// `pixels` byte-for-byte through the decoder's §4.1 inverse.
+///
+/// `image_width` is the canvas width, threaded into the residual image's
+/// §5.2.2 distance chooser. Both the sub-image and the residual image get
+/// their own color-cache evaluation.
+fn encode_predictor_path(pixels: &[u32], width: u32, height: u32) -> Vec<u8> {
+    let (residuals, sub_image, size_bits, tw) = apply_predictor_transform(pixels, width, height);
+
+    let mut w = BitWriter::new();
+
+    // §3.8.2 predictor-tx: present-bit, TransformType::Predictor (0), then
+    // the 3-bit `size_bits - 2` field, then the sub-resolution image.
+    w.write_bit(true);
+    w.write_bits(crate::vp8l_stream::TransformType::Predictor as u32, 2);
+    w.write_bits((size_bits - 2) as u32, 3);
+    // predictor-image body = entropy-coded-image (no meta-prefix). The
+    // sub-image is `tw` wide; evaluate its own color cache.
+    let (sub_tokens, sub_bits) = best_cache_for_pixels(&sub_image, tw);
+    write_entropy_coded_image(&mut w, &sub_tokens, sub_bits, tw);
+
+    // End-of-transform-list terminator.
+    w.write_bit(false);
+
+    // §3.8.3 spatially-coded-image for the residual main image. Evaluate
+    // the residual's color cache independently of the original's.
+    let (res_tokens, res_bits) = best_cache_for_pixels(&residuals, width);
+    write_spatially_coded_image(&mut w, &res_tokens, res_bits, width);
+
+    let _ = height;
+    w.into_bytes()
+}
+
 /// Encode an ARGB image to a VP8L *image-stream* (the bytes that follow the
 /// §3.4 5-byte image-header), running the §5.2.2 LZ77 backward-reference
 /// matcher so repeated pixel runs compress.
@@ -1258,6 +1605,25 @@ pub fn encode_argb_literals_with_width_selected(
         if cand.len() < best_bytes.len() {
             best_bytes = cand;
             best_code_bits = bits;
+        }
+    }
+
+    // §4.1 predictor transform. The transform needs the real 2-D layout,
+    // so it is only a candidate when `image_width` reflects the true
+    // canvas width (`> 1`) and evenly divides the pixel count — always the
+    // case on the production `.webp` path ([`encode_vp8l_payload`] passes
+    // the actual width). The width-less test entries pass `image_width =
+    // 1`, which degenerates the geometry to a 1×N column where the spatial
+    // predictor is meaningless; those callers keep the round-119 / round-130
+    // behaviour unchanged. The residual main image runs its own
+    // color-cache evaluation internally, so the reported `best_code_bits`
+    // (a main-image cache field) is set to `0` when the predictor wins.
+    if image_width > 1 && !pixels.is_empty() && pixels.len() % image_width as usize == 0 {
+        let height = pixels.len() as u32 / image_width;
+        let cand = encode_predictor_path(pixels, image_width, height);
+        if cand.len() < best_bytes.len() {
+            best_bytes = cand;
+            best_code_bits = 0;
         }
     }
 
@@ -1366,8 +1732,56 @@ fn encode_tokens(
     w.write_bit(false);
 
     // §3.8.3 spatially-coded-image = color-cache-info meta-prefix data.
+    write_spatially_coded_image(&mut w, tokens, color_cache_code_bits, image_width);
+    w.into_bytes()
+}
+
+/// Write a §3.8.3 `spatially-coded-image` body (`color-cache-info
+/// meta-prefix data`) into an existing [`BitWriter`]. This is the §3.8.3
+/// main-image form — it carries the single-`%b0` `meta-prefix` field, so
+/// it is *not* the same as the predictor / color sub-image's
+/// `entropy-coded-image` form ([`write_entropy_coded_image`]), which omits
+/// `meta-prefix` entirely (§3.8.2 grammar: `predictor-image =/
+/// color-cache-info data`, no meta-prefix). Factored out of
+/// [`encode_tokens`] so the predictor-transform path can reuse the same
+/// `color-cache-info` + `prefix-codes` + `lz77-coded-image` writer for the
+/// residual main image.
+fn write_spatially_coded_image(
+    w: &mut BitWriter,
+    tokens: &[Token],
+    color_cache_code_bits: Option<u32>,
+    image_width: u32,
+) {
+    let color_cache_size = write_color_cache_info(w, color_cache_code_bits);
+    // meta-prefix: `%b0` (single prefix-code group).
+    w.write_bit(false);
+    write_prefix_codes_and_image(w, tokens, color_cache_size, image_width);
+}
+
+/// Write a §3.8.2 / §3.8.3 `entropy-coded-image` body (`color-cache-info
+/// data`) into an existing [`BitWriter`]. Used for a predictor / color
+/// transform's sub-resolution image: per the §3.8.2 grammar the
+/// `predictor-image` / `color-image` payload after the 3-bit `size_bits`
+/// field is an `entropy-coded-image`, which (unlike the main
+/// `spatially-coded-image`) has **no** `meta-prefix` field. The decoder's
+/// [`crate::vp8l_transform::decode_lossless`] reads these sub-images with
+/// `decode_entropy_coded_image`, which likewise skips the meta-prefix.
+fn write_entropy_coded_image(
+    w: &mut BitWriter,
+    tokens: &[Token],
+    color_cache_code_bits: Option<u32>,
+    image_width: u32,
+) {
+    let color_cache_size = write_color_cache_info(w, color_cache_code_bits);
+    write_prefix_codes_and_image(w, tokens, color_cache_size, image_width);
+}
+
+/// Write a §3.8.3 `color-cache-info` field and return the resulting cache
+/// size (`0` when disabled). `None` emits `%b0`; `Some(bits)` emits
+/// `%b1 4BIT` with `bits ∈ [COLOR_CACHE_BITS_MIN, COLOR_CACHE_BITS_MAX]`.
+fn write_color_cache_info(w: &mut BitWriter, color_cache_code_bits: Option<u32>) -> usize {
     // color-cache-info: `%b0` (no cache) or `%b1 4BIT` (enabled).
-    let color_cache_size = match color_cache_code_bits {
+    match color_cache_code_bits {
         Some(bits) => {
             debug_assert!((COLOR_CACHE_BITS_MIN..=COLOR_CACHE_BITS_MAX).contains(&bits));
             w.write_bit(true);
@@ -1378,10 +1792,21 @@ fn encode_tokens(
             w.write_bit(false);
             0
         }
-    };
-    // meta-prefix: `%b0` (single prefix-code group).
-    w.write_bit(false);
+    }
+}
 
+/// Write a §3.8.3 `data` field (`prefix-codes lz77-coded-image`): build the
+/// five §3.7.2 prefix codes from `tokens`, emit their code-length tables in
+/// bitstream order (green, red, blue, alpha, distance), then emit the
+/// LZ77-coded image. Shared by [`write_spatially_coded_image`] and
+/// [`write_entropy_coded_image`]; the only structural difference between the
+/// two callers is the preceding `meta-prefix` bit.
+fn write_prefix_codes_and_image(
+    w: &mut BitWriter,
+    tokens: &[Token],
+    color_cache_size: usize,
+    image_width: u32,
+) {
     // Build the five prefix codes from token frequencies. The GREEN
     // alphabet covers literals (`< 256`), the §5.2.2 length prefix
     // symbols (`256 + length_prefix`), and (when the cache is enabled)
@@ -1405,11 +1830,11 @@ fn encode_tokens(
     // data = prefix-codes lz77-coded-image.
     // prefix-code-group = 5 prefix codes, in bitstream order:
     // green, red, blue, alpha, distance.
-    green_code.write_code_lengths(&mut w);
-    red_code.write_code_lengths(&mut w);
-    blue_code.write_code_lengths(&mut w);
-    alpha_code.write_code_lengths(&mut w);
-    dist_code.write_code_lengths(&mut w);
+    green_code.write_code_lengths(w);
+    red_code.write_code_lengths(w);
+    blue_code.write_code_lengths(w);
+    alpha_code.write_code_lengths(w);
+    dist_code.write_code_lengths(w);
 
     // lz77-coded-image: each token is either a §5.2.1 ARGB literal
     // (channel order green, red, blue, alpha), a §5.2.3 color-cache
@@ -1422,10 +1847,10 @@ fn encode_tokens(
                 let r = ((p >> 16) & 0xff) as usize;
                 let g = ((p >> 8) & 0xff) as usize;
                 let b = (p & 0xff) as usize;
-                green_code.write_symbol(&mut w, g);
-                red_code.write_symbol(&mut w, r);
-                blue_code.write_symbol(&mut w, b);
-                alpha_code.write_symbol(&mut w, a);
+                green_code.write_symbol(w, g);
+                red_code.write_symbol(w, r);
+                blue_code.write_symbol(w, b);
+                alpha_code.write_symbol(w, a);
             }
             Token::CacheRef { index } => {
                 // §5.2.3: GREEN symbol is `256 + 24 + index`. Red /
@@ -1433,21 +1858,19 @@ fn encode_tokens(
                 // recovers the full ARGB from the cache slot.
                 debug_assert!(color_cache_size > 0, "CacheRef requires an enabled cache");
                 let sym = 256 + crate::vp8l_decode::NUM_LENGTH_PREFIX_CODES + index as usize;
-                green_code.write_symbol(&mut w, sym);
+                green_code.write_symbol(w, sym);
             }
             Token::Copy { length, distance } => {
                 // §5.2.2: length via a GREEN length symbol (base 256), then
                 // distance via prefix code #5 (base 0). The chooser must
                 // agree with `count_frequencies` so the prefix-code Huffman
                 // tree we built actually contains the prefix slot we look up.
-                write_lz77_value(&mut w, &green_code, 256, length as u32);
+                write_lz77_value(w, &green_code, 256, length as u32);
                 let raw_code = pixel_distance_to_distance_code(distance, image_width);
-                write_lz77_value(&mut w, &dist_code, 0, raw_code);
+                write_lz77_value(w, &dist_code, 0, raw_code);
             }
         }
     }
-
-    w.into_bytes()
 }
 
 /// Build the §3.4 / §7.1 5-byte VP8L image-header.
@@ -2157,6 +2580,155 @@ mod tests {
         // Round trip through the full decode chain stays pixel-exact.
         let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
         let framed = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+    }
+
+    // ---- §3.5.1 / §4.1 forward predictor transform ----
+
+    /// The forward `sub_pred` residual is the exact per-channel inverse of
+    /// the decoder's `add_pred`: predicting with mode M, subtracting, then
+    /// adding the same prediction back restores the original pixel across
+    /// the modulo-256 wrap.
+    #[test]
+    fn sub_pred_is_inverse_of_add_pred() {
+        let cases = [
+            (0xff12_3456u32, 0xff10_3050u32),
+            (0x0001_0203, 0xfffe_fdfc), // wrap on every channel
+            (0x8090_a0b0, 0x1020_3040 | 0x8000_0000),
+        ];
+        for (actual, pred) in cases {
+            let res = sub_pred(actual, pred);
+            // Re-add per channel (the decoder's `add_pred` arithmetic).
+            let f = |sh: u32| ((res >> sh) & 0xff).wrapping_add((pred >> sh) & 0xff) & 0xff;
+            let restored = (f(24) << 24) | (f(16) << 16) | (f(8) << 8) | f(0);
+            assert_eq!(restored, actual, "sub_pred/add_pred round trip failed");
+        }
+    }
+
+    /// Every per-block mode the selector emits is a valid §4.1 predictor
+    /// index in `0..=13` (the green channel of the sub-resolution image).
+    #[test]
+    fn predictor_modes_are_always_in_range() {
+        let w = 40u32;
+        let h = 37u32;
+        // A mixed image: a diagonal gradient overlaid with a little noise,
+        // so different blocks legitimately prefer different modes.
+        let mut state = 0xA1B2C3D4u32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|i| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                let x = i % w;
+                let y = i / w;
+                let base = (x + y) & 0xff;
+                let g = base;
+                let r = (base.wrapping_add(state & 7)) & 0xff;
+                let b = (base.wrapping_add((state >> 3) & 7)) & 0xff;
+                0xff00_0000 | (r << 16) | (g << 8) | b
+            })
+            .collect();
+        let (sub_image, tw, th) = select_predictor_modes(&pixels, w, h, PREDICTOR_SIZE_BITS);
+        assert_eq!(sub_image.len(), (tw * th) as usize);
+        for &p in &sub_image {
+            let mode = (p >> 8) & 0xff;
+            assert!(mode <= 13, "selected predictor mode {mode} out of [0..13]");
+        }
+    }
+
+    /// On a smooth gradient (where neighbouring pixels are tightly
+    /// correlated) the §4.1 predictor transform shrinks the stream versus
+    /// the no-predictor baseline, and the full encode → decode round trip
+    /// is bit-exact.
+    #[test]
+    fn predictor_transform_shrinks_smooth_gradient_and_round_trips() {
+        let w = 64u32;
+        let h = 64u32;
+        // A smooth 2-D gradient: each channel ramps with x and y, so the
+        // gradient-style predictors (T/L/Average/ClampAddSubtract) leave
+        // residuals clustered near zero.
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|i| {
+                let x = i % w;
+                let y = i / w;
+                let r = (x * 3 + y) & 0xff;
+                let g = (x + y * 2) & 0xff;
+                let b = ((x * 2 + y * 3) / 2) & 0xff;
+                0xff00_0000 | (r << 16) | (g << 8) | b
+            })
+            .collect();
+
+        // No-predictor baseline at the same width (best of no-tx /
+        // subtract-green × cache, but WITHOUT the predictor candidate).
+        let no_pred = {
+            let mut best = encode_literals_with_options(&pixels, false, None, w);
+            for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+                let c = encode_literals_with_options(&pixels, false, Some(bits), w);
+                if c.len() < best.len() {
+                    best = c;
+                }
+            }
+            let c = encode_literals_with_options(&pixels, true, None, w);
+            if c.len() < best.len() {
+                best = c;
+            }
+            best
+        };
+        let with_pred = encode_predictor_path(&pixels, w, h);
+        eprintln!(
+            "[round-133] 64x64 smooth gradient: no-predictor={} B, predictor={} B ({:.1}% reduction)",
+            no_pred.len(),
+            with_pred.len(),
+            100.0 * (no_pred.len() as f64 - with_pred.len() as f64) / no_pred.len() as f64,
+        );
+        assert!(
+            with_pred.len() < no_pred.len(),
+            "predictor transform ({} B) did not beat no-predictor ({} B)",
+            with_pred.len(),
+            no_pred.len(),
+        );
+
+        // Bit-exact round trip through the predictor path explicitly.
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&with_pred);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
+        let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+        assert_eq!(img.pixels(), pixels.as_slice());
+
+        // And through the production chooser, which now includes the
+        // predictor candidate: the smooth gradient should make the chooser
+        // pick a stream no larger than the no-predictor baseline.
+        let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+        let framed2 = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+        let img2 = crate::decode_lossless_image(&framed2).unwrap().unwrap();
+        assert_eq!(img2.pixels(), pixels.as_slice());
+        assert!(bare.len() <= header.len() + no_pred.len());
+    }
+
+    /// The predictor path round-trips on a non-smooth (noisy) image too:
+    /// even when the residuals don't shrink the stream, the decoder
+    /// reconstructs the originals exactly. Guards against any mismatch
+    /// between the encoder's forward prediction and the decoder's inverse.
+    #[test]
+    fn predictor_transform_round_trips_on_noise() {
+        let w = 31u32; // deliberately non-power-of-two to exercise the
+        let h = 29u32; // partial right/bottom blocks and DIV_ROUND_UP.
+        let mut state = 0xDEAD_F00Du32;
+        let pixels: Vec<u32> = (0..(w * h))
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state | 0xff00_0000
+            })
+            .collect();
+        let stream = encode_predictor_path(&pixels, w, h);
+        let header = build_image_header(w, h, false);
+        let mut payload = header.to_vec();
+        payload.extend_from_slice(&stream);
+        let framed = build::build_webp_file(&payload, ImageKind::Lossless, w, h).unwrap();
         let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
         assert_eq!(img.pixels(), pixels.as_slice());
     }

--- a/src/vp8l_encode.rs
+++ b/src/vp8l_encode.rs
@@ -862,6 +862,32 @@ pub const COLOR_CACHE_BITS_MAX: u32 = 11;
 /// collisions are negligible on most natural images).
 pub const DEFAULT_COLOR_CACHE_BITS: u32 = 8;
 
+/// Round-132 §5.2.3 size-selection slate: the chooser cross-products each
+/// of these `code_bits` values (alongside the disabled-cache option) with
+/// the §3.8.2 subtract-green transform candidate set, then emits the
+/// smallest resulting byte stream.
+///
+/// The slate spans the §5.2.3 allowed range [`COLOR_CACHE_BITS_MIN`] ..=
+/// [`COLOR_CACHE_BITS_MAX`] with five evenly spread sizes:
+///
+/// * `5` → 32 entries  — cheap to populate; fits tiny palettes.
+/// * `7` → 128 entries — covers small/medium palettes (the 4-bit
+///   `code_bits` header field cost is amortised over more reuse).
+/// * `8` → 256 entries — the round-121 single-size default; kept as the
+///   middle "sweet spot" for typical natural-image content.
+/// * `9` → 512 entries — for images with denser color spreads where
+///   8-bit collisions start to bite.
+/// * `11` → 2048 entries — the §5.2.3 maximum; pays off only when the
+///   image has thousands of distinct colors that recur enough to amortise
+///   the wider GREEN alphabet's prefix-code-length overhead.
+///
+/// The "no cache" option (encoded as `code_bits = 0` per §5.2.3) is
+/// implicit: [`encode_argb_literals_with_width`] always evaluates the
+/// `None` candidate as the baseline. The disabled-cache + the five
+/// listed sizes give six cache-axis candidates per transform-axis option,
+/// for a 2 × 6 = 12-way cross-product.
+pub const CANDIDATE_COLOR_CACHE_BITS: [u32; 5] = [5, 7, DEFAULT_COLOR_CACHE_BITS, 9, 11];
+
 /// §5.2.3 color-cache helper used by the encoder. Mirrors the decoder's
 /// [`crate::vp8l_decode::ColorCache`] semantics: an array of
 /// `1 << code_bits` ARGB entries, all initialized to zero, with a
@@ -1168,29 +1194,74 @@ pub fn encode_argb_literals(pixels: &[u32]) -> Vec<u8> {
     encode_argb_literals_with_width(pixels, 1)
 }
 
-/// Width-aware variant of [`encode_argb_literals`]: same 2×2
-/// `(no-tx | subtract-green) × (no-cache | cache)` chooser, but each
-/// candidate threads `image_width` into [`encode_tokens`] so the
-/// §5.2.2 distance-map optimisation is exercised. The production
-/// `.webp` path ([`encode_vp8l_payload`] → [`encode_webp_lossless`] /
-/// [`encode_vp8l_argb`]) uses this entry; the no-width
-/// [`encode_argb_literals`] is retained for test callers that exercise
-/// the entropy stage without spatial structure.
+/// Width-aware variant of [`encode_argb_literals`]: cross-products the
+/// §3.8.2 subtract-green transform axis (`no-tx | subtract-green`) with
+/// the round-132 §5.2.3 color-cache size axis
+/// (`no-cache | each of [`CANDIDATE_COLOR_CACHE_BITS`]`), and emits the
+/// smallest resulting byte stream. Each candidate threads `image_width`
+/// into [`encode_tokens`] so the §5.2.2 distance-map optimisation is
+/// exercised. The production `.webp` path ([`encode_vp8l_payload`] →
+/// [`encode_webp_lossless`] / [`encode_vp8l_argb`]) uses this entry; the
+/// no-width [`encode_argb_literals`] is retained for test callers that
+/// exercise the entropy stage without spatial structure.
+///
+/// Round 132 widened the cache axis from "0 or 8" (round 121) to a slate
+/// of five sizes per [`CANDIDATE_COLOR_CACHE_BITS`]. The §5.2.3 GREEN
+/// alphabet's width is `256 + 24 + (1 << code_bits)`, so the prefix-code
+/// header overhead scales with the chosen `code_bits`; picking the
+/// smallest size that captures the image's color recurrence avoids paying
+/// for an over-sized cache.
 pub fn encode_argb_literals_with_width(pixels: &[u32], image_width: u32) -> Vec<u8> {
-    debug_assert!(image_width >= 1);
-    let mut best = encode_literals_with_options(pixels, false, None, image_width);
+    encode_argb_literals_with_width_selected(pixels, image_width).0
+}
 
-    let candidates = [
-        encode_literals_with_options(pixels, true, None, image_width),
-        encode_literals_with_options(pixels, false, Some(DEFAULT_COLOR_CACHE_BITS), image_width),
-        encode_literals_with_options(pixels, true, Some(DEFAULT_COLOR_CACHE_BITS), image_width),
-    ];
-    for cand in candidates {
-        if cand.len() < best.len() {
-            best = cand;
+/// Like [`encode_argb_literals_with_width`] but also returns the
+/// §5.2.3 `color_cache_code_bits` value the chooser selected (`0` when
+/// the no-cache path won).
+///
+/// The chooser walks the 2 × (1 + N) candidate grid (where
+/// `N = CANDIDATE_COLOR_CACHE_BITS.len()`), evaluates each combination's
+/// produced byte length, and returns the smallest along with the cache
+/// size of the winning candidate. The returned `code_bits` is always in
+/// `{0} ∪ CANDIDATE_COLOR_CACHE_BITS` — `0` for "no cache enabled",
+/// any other value for "this `code_bits` chosen". The byte stream itself
+/// is bit-exact decodable through [`crate::decode_lossless_image`] in
+/// every case (the chooser only ever compares spec-conformant outputs).
+pub fn encode_argb_literals_with_width_selected(
+    pixels: &[u32],
+    image_width: u32,
+) -> (Vec<u8>, u32) {
+    debug_assert!(image_width >= 1);
+
+    // Baseline: no-tx, no-cache. Tracked separately so we always have a
+    // valid winner even if every cross-product candidate inflates.
+    let mut best_bytes = encode_literals_with_options(pixels, false, None, image_width);
+    let mut best_code_bits: u32 = 0;
+
+    // No-tx × every cache size.
+    for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+        let cand = encode_literals_with_options(pixels, false, Some(bits), image_width);
+        if cand.len() < best_bytes.len() {
+            best_bytes = cand;
+            best_code_bits = bits;
         }
     }
-    best
+    // Subtract-green × no-cache.
+    let cand = encode_literals_with_options(pixels, true, None, image_width);
+    if cand.len() < best_bytes.len() {
+        best_bytes = cand;
+        best_code_bits = 0;
+    }
+    // Subtract-green × every cache size.
+    for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+        let cand = encode_literals_with_options(pixels, true, Some(bits), image_width);
+        if cand.len() < best_bytes.len() {
+            best_bytes = cand;
+            best_code_bits = bits;
+        }
+    }
+
+    (best_bytes, best_code_bits)
 }
 
 /// Encode `pixels` with explicit knobs: optionally apply the §3.5.3 /
@@ -2804,6 +2875,357 @@ mod tests {
         let framed = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
         let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
         assert_eq!(img.pixels(), pixels.as_slice());
+    }
+
+    // ---- §5.2.3 color-cache size selection (round 132) ----
+
+    /// `CANDIDATE_COLOR_CACHE_BITS` lists every cache size the chooser
+    /// evaluates. The slate must be a strict subset of the spec-allowed
+    /// `[COLOR_CACHE_BITS_MIN, COLOR_CACHE_BITS_MAX]` range (no `0`, no
+    /// `>11`), monotonically increasing, and contain
+    /// `DEFAULT_COLOR_CACHE_BITS` so the round-121 baseline is always
+    /// among the candidates.
+    #[test]
+    fn color_cache_candidate_slate_is_spec_legal_and_monotone() {
+        assert!(!CANDIDATE_COLOR_CACHE_BITS.is_empty());
+        let mut prev: Option<u32> = None;
+        for &bits in &CANDIDATE_COLOR_CACHE_BITS {
+            assert!(
+                (COLOR_CACHE_BITS_MIN..=COLOR_CACHE_BITS_MAX).contains(&bits),
+                "candidate {bits} outside §5.2.3 [{COLOR_CACHE_BITS_MIN}..{COLOR_CACHE_BITS_MAX}]",
+            );
+            if let Some(p) = prev {
+                assert!(
+                    bits > p,
+                    "candidate slate not monotone at {bits} (prev {p})"
+                );
+            }
+            prev = Some(bits);
+        }
+        assert!(
+            CANDIDATE_COLOR_CACHE_BITS.contains(&DEFAULT_COLOR_CACHE_BITS),
+            "DEFAULT_COLOR_CACHE_BITS={DEFAULT_COLOR_CACHE_BITS} missing from candidate slate",
+        );
+    }
+
+    /// On a palette-heavy synthetic image the chooser must pick a
+    /// non-zero cache size: every pixel is drawn from a small palette
+    /// repeated in a pseudo-random order, so each repeat is a
+    /// `CacheRef` win that more than pays for the §5.2.3 header.
+    /// (a) of the round-132 brief.
+    #[test]
+    fn size_selection_picks_nonzero_on_palette_heavy_image() {
+        let w = 64u32;
+        let h = 64u32;
+        let palette: [u32; 12] = [
+            0xff10_2030,
+            0xff40_5060,
+            0xff70_8090,
+            0xffa0_b0c0,
+            0xffd0_e0f0,
+            0xff00_1122,
+            0xff33_4455,
+            0xff66_7788,
+            0xff99_aabb,
+            0xffcc_ddee,
+            0xff11_2233,
+            0xff44_5566,
+        ];
+        let mut pixels = Vec::with_capacity((w * h) as usize);
+        let mut state = 0x1357_9bdfu32;
+        for _ in 0..(w * h) {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            pixels.push(palette[(state as usize) % palette.len()]);
+        }
+        let (_, chosen) = encode_argb_literals_with_width_selected(&pixels, w);
+        assert_ne!(
+            chosen, 0,
+            "palette-heavy image should engage the §5.2.3 color cache, got code_bits=0",
+        );
+        assert!(
+            CANDIDATE_COLOR_CACHE_BITS.contains(&chosen),
+            "chosen code_bits {chosen} not in candidate slate",
+        );
+    }
+
+    /// On uncorrelated ARGB noise the chooser must select size 0
+    /// (no cache): every pixel is distinct, so cache references would
+    /// never fire and the wider GREEN alphabet only inflates the
+    /// prefix-code lengths. (b) of the round-132 brief.
+    #[test]
+    fn size_selection_picks_zero_on_noise_image() {
+        let w = 32u32;
+        let h = 32u32;
+        let mut pixels = Vec::with_capacity((w * h) as usize);
+        let mut state = 0xfeed_b00bu32;
+        for _ in 0..(w * h) {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            pixels.push(state | 0xff00_0000);
+        }
+        let (_, chosen) = encode_argb_literals_with_width_selected(&pixels, w);
+        assert_eq!(
+            chosen, 0,
+            "uncorrelated noise should not engage the color cache, got code_bits={chosen}",
+        );
+    }
+
+    /// Across a varied suite of inputs the selected `code_bits` is
+    /// always either `0` (disabled) or a value in
+    /// `CANDIDATE_COLOR_CACHE_BITS` — never outside the spec-allowed
+    /// range, never a value the chooser wasn't asked to evaluate.
+    /// (c) of the round-132 brief.
+    #[test]
+    fn selected_size_is_always_zero_or_in_candidate_slate() {
+        // Spread of inputs: palette-heavy, noise, row-correlated,
+        // solid, tiny.
+        let mut suites: Vec<(u32, u32, Vec<u32>)> = Vec::new();
+        // Palette-heavy 32x32.
+        {
+            let w = 32u32;
+            let h = 32u32;
+            let palette: [u32; 6] = [
+                0xff00_0000,
+                0xffff_ffff,
+                0xff80_0000,
+                0xff00_8000,
+                0xff00_0080,
+                0xff80_8080,
+            ];
+            let mut pixels = Vec::with_capacity((w * h) as usize);
+            let mut state = 0xc0ff_eeeeu32;
+            for _ in 0..(w * h) {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                pixels.push(palette[(state as usize) % palette.len()]);
+            }
+            suites.push((w, h, pixels));
+        }
+        // Pure noise 16x16.
+        {
+            let w = 16u32;
+            let h = 16u32;
+            let mut pixels = Vec::with_capacity((w * h) as usize);
+            let mut state = 0xdead_beefu32;
+            for _ in 0..(w * h) {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                pixels.push(state | 0xff00_0000);
+            }
+            suites.push((w, h, pixels));
+        }
+        // Row-correlated 32x32 (every row repeats row 0).
+        {
+            let w = 32u32;
+            let h = 32u32;
+            let mut row0 = Vec::with_capacity(w as usize);
+            let mut state = 0x1234_5678u32;
+            for _ in 0..w {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                row0.push((state & 0x00ff_ffff) | 0xff00_0000);
+            }
+            let mut pixels = Vec::with_capacity((w * h) as usize);
+            for _ in 0..h {
+                pixels.extend_from_slice(&row0);
+            }
+            suites.push((w, h, pixels));
+        }
+        // Solid color 8x8.
+        {
+            let w = 8u32;
+            let h = 8u32;
+            let pixels = vec![0xff12_3456u32; (w * h) as usize];
+            suites.push((w, h, pixels));
+        }
+        // Tiny 1x1.
+        suites.push((1, 1, vec![0xffaa_5500u32]));
+
+        for (w, _h, pixels) in &suites {
+            let (_, chosen) = encode_argb_literals_with_width_selected(pixels, *w);
+            assert!(
+                chosen == 0 || CANDIDATE_COLOR_CACHE_BITS.contains(&chosen),
+                "chosen code_bits {chosen} (w={w}) not in {{0}} ∪ {:?}",
+                CANDIDATE_COLOR_CACHE_BITS,
+            );
+            // And the chosen size is in the §5.2.3 spec range.
+            assert!(
+                chosen == 0 || (COLOR_CACHE_BITS_MIN..=COLOR_CACHE_BITS_MAX).contains(&chosen),
+                "chosen code_bits {chosen} (w={w}) outside §5.2.3 [{COLOR_CACHE_BITS_MIN}..{COLOR_CACHE_BITS_MAX}]",
+            );
+        }
+    }
+
+    /// The chosen byte stream round-trips bit-exactly through the
+    /// decoder for every cache-size decision the chooser can make.
+    /// (d) of the round-132 brief.
+    #[test]
+    fn selected_stream_round_trips_bit_exact_for_each_decision() {
+        // Each suite is chosen to drive a different cache decision:
+        // palette-heavy → non-zero size; noise → size 0; tiny solid →
+        // size 0 (no recurrence opportunity that beats the header
+        // cost on so few pixels).
+        let suites: [(u32, u32, &str); 3] = [
+            (32, 32, "palette-heavy"),
+            (16, 16, "noise"),
+            (4, 4, "solid"),
+        ];
+        for (w, h, label) in suites {
+            let pixels: Vec<u32> = match label {
+                "palette-heavy" => {
+                    let palette: [u32; 8] = [
+                        0xff10_2030,
+                        0xff40_5060,
+                        0xff70_8090,
+                        0xffa0_b0c0,
+                        0xffd0_e0f0,
+                        0xff00_1122,
+                        0xff33_4455,
+                        0xff66_7788,
+                    ];
+                    let mut p = Vec::with_capacity((w * h) as usize);
+                    let mut state = 0x9876_5432u32;
+                    for _ in 0..(w * h) {
+                        state ^= state << 13;
+                        state ^= state >> 17;
+                        state ^= state << 5;
+                        p.push(palette[(state as usize) % palette.len()]);
+                    }
+                    p
+                }
+                "noise" => {
+                    let mut p = Vec::with_capacity((w * h) as usize);
+                    let mut state = 0x0baf_face_u32;
+                    for _ in 0..(w * h) {
+                        state ^= state << 13;
+                        state ^= state >> 17;
+                        state ^= state << 5;
+                        p.push(state | 0xff00_0000);
+                    }
+                    p
+                }
+                "solid" => vec![0xff7f_8081u32; (w * h) as usize],
+                _ => unreachable!(),
+            };
+
+            let (_bytes, chosen) = encode_argb_literals_with_width_selected(&pixels, w);
+            // Cache-size decision is in-range.
+            assert!(
+                chosen == 0 || CANDIDATE_COLOR_CACHE_BITS.contains(&chosen),
+                "{label}: chosen code_bits {chosen} unexpected",
+            );
+            // Round-trip via the production path (which feeds the
+            // chooser internally).
+            let bare = encode_vp8l_argb(&pixels, w, h).unwrap();
+            let framed = build::build_webp_file(&bare, ImageKind::Lossless, w, h).unwrap();
+            let img = crate::decode_lossless_image(&framed).unwrap().unwrap();
+            assert_eq!(
+                img.pixels(),
+                pixels.as_slice(),
+                "{label}: round-trip mismatch at chosen code_bits={chosen}",
+            );
+        }
+    }
+
+    /// The round-132 multi-size chooser is never *worse* than the
+    /// round-121 single-size chooser on any of the test fixtures:
+    /// since the round-121 candidate (no-cache | cache@8) is a strict
+    /// subset of the round-132 grid (no-cache | cache @ {5,7,8,9,11}),
+    /// the round-132 winner is at most as large.
+    #[test]
+    fn round132_chooser_never_regresses_against_round121_single_size() {
+        let fixtures: [(u32, u32, &str); 4] = [
+            (32, 32, "palette"),
+            (16, 16, "noise"),
+            (24, 24, "row-corr"),
+            (8, 8, "solid"),
+        ];
+        for (w, h, label) in fixtures {
+            let pixels: Vec<u32> = match label {
+                "palette" => {
+                    let palette: [u32; 10] = [
+                        0xff10_2030,
+                        0xff40_5060,
+                        0xff70_8090,
+                        0xffa0_b0c0,
+                        0xffd0_e0f0,
+                        0xff00_1122,
+                        0xff33_4455,
+                        0xff66_7788,
+                        0xff99_aabb,
+                        0xffcc_ddee,
+                    ];
+                    let mut p = Vec::with_capacity((w * h) as usize);
+                    let mut state = 0x5a5a_a5a5u32;
+                    for _ in 0..(w * h) {
+                        state ^= state << 13;
+                        state ^= state >> 17;
+                        state ^= state << 5;
+                        p.push(palette[(state as usize) % palette.len()]);
+                    }
+                    p
+                }
+                "noise" => {
+                    let mut p = Vec::with_capacity((w * h) as usize);
+                    let mut state = 0xf00d_baadu32;
+                    for _ in 0..(w * h) {
+                        state ^= state << 13;
+                        state ^= state >> 17;
+                        state ^= state << 5;
+                        p.push(state | 0xff00_0000);
+                    }
+                    p
+                }
+                "row-corr" => {
+                    let mut row0 = Vec::with_capacity(w as usize);
+                    let mut state = 0xcafe_d00du32;
+                    for _ in 0..w {
+                        state ^= state << 13;
+                        state ^= state >> 17;
+                        state ^= state << 5;
+                        row0.push((state & 0x00ff_ffff) | 0xff00_0000);
+                    }
+                    let mut p = Vec::with_capacity((w * h) as usize);
+                    for _ in 0..h {
+                        p.extend_from_slice(&row0);
+                    }
+                    p
+                }
+                "solid" => vec![0xffc0_ffeeu32; (w * h) as usize],
+                _ => unreachable!(),
+            };
+
+            // Round-121 single-size emulation: min of (no-tx | sg) ×
+            // (None | Some(8)).
+            let r121 = {
+                let mut best = encode_literals_with_options(&pixels, false, None, w);
+                for cand in [
+                    encode_literals_with_options(&pixels, true, None, w),
+                    encode_literals_with_options(&pixels, false, Some(DEFAULT_COLOR_CACHE_BITS), w),
+                    encode_literals_with_options(&pixels, true, Some(DEFAULT_COLOR_CACHE_BITS), w),
+                ] {
+                    if cand.len() < best.len() {
+                        best = cand;
+                    }
+                }
+                best.len()
+            };
+            let (bytes, chosen) = encode_argb_literals_with_width_selected(&pixels, w);
+            let r132 = bytes.len();
+            eprintln!(
+                "[round-132] {label} {w}x{h}: round-121={r121} B, round-132={r132} B (chosen code_bits={chosen})",
+            );
+            assert!(
+                r132 <= r121,
+                "{label}: round-132 chooser regressed: {r132} B vs round-121 {r121} B",
+            );
+        }
     }
 
     /// The chooser must never inflate a distance: the chosen code's

--- a/tests/published_anim_api.rs
+++ b/tests/published_anim_api.rs
@@ -137,6 +137,7 @@ fn frame_blend_dispose_and_offset_fields_are_carried() {
         blend: BlendingMethod::Overwrite,
         dispose: DisposalMethod::Background,
         mode: AnimFrameMode::Lossless,
+        near_lossless_quality: None,
     };
     let file = build_animated_webp(&[frame]).expect("build offset frame");
     let img = decode_webp(&file).expect("decode");

--- a/tests/published_anim_api.rs
+++ b/tests/published_anim_api.rs
@@ -102,6 +102,7 @@ fn build_animated_webp_with_options_carries_loop_bg_and_metadata() {
         },
         delta: DeltaConfig::default(),
         default_near_lossless_quality: None,
+        default_lossy_quality: None,
     };
 
     let file = build_animated_webp_with_options(&frames, &opts).expect("build with options");

--- a/tests/published_anim_api.rs
+++ b/tests/published_anim_api.rs
@@ -101,6 +101,7 @@ fn build_animated_webp_with_options_carries_loop_bg_and_metadata() {
             xmp: Some(&xmp),
         },
         delta: DeltaConfig::default(),
+        default_near_lossless_quality: None,
     };
 
     let file = build_animated_webp_with_options(&frames, &opts).expect("build with options");

--- a/tests/published_anim_blend_dispose_api.rs
+++ b/tests/published_anim_blend_dispose_api.rs
@@ -193,6 +193,7 @@ fn with_dispose_background_clears_sub_rect_to_anim_bg_between_frames() {
         metadata: WebpMetadata::default(),
         delta: DeltaConfig::default(),
         default_near_lossless_quality: None,
+        default_lossy_quality: None,
     };
 
     let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");
@@ -267,6 +268,7 @@ fn with_dispose_none_leaves_previous_sub_rect_intact_between_frames() {
         metadata: WebpMetadata::default(),
         delta: DeltaConfig::default(),
         default_near_lossless_quality: None,
+        default_lossy_quality: None,
     };
 
     let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");
@@ -332,6 +334,7 @@ fn dispose_background_and_alpha_blend_compose_through_encoder() {
         metadata: WebpMetadata::default(),
         delta: DeltaConfig::default(),
         default_near_lossless_quality: None,
+        default_lossy_quality: None,
     };
 
     let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");

--- a/tests/published_anim_blend_dispose_api.rs
+++ b/tests/published_anim_blend_dispose_api.rs
@@ -1,0 +1,381 @@
+//! Round-142 integration tests for the `AnimFrame::with_blend` /
+//! `AnimFrame::with_dispose` chainable builders — and their end-to-end
+//! round-trip semantics through `decode_webp`'s §2.7.1.1 canvas
+//! compositor (background-disposal clear-to-bg, alpha-blend blending).
+//!
+//! Standalone-only (no `registry` feature), so the file builds under
+//! `--no-default-features` as well. The fixtures are tiny offset
+//! sub-frames placed on a small canvas with explicit colours so the
+//! blend / dispose formulas are easy to verify by hand.
+
+use oxideav_webp::anmf::{BlendingMethod, DisposalMethod};
+use oxideav_webp::{
+    build_animated_webp, build_animated_webp_with_options, decode_webp, AnimEncoderOptions,
+    AnimFrame, DeltaConfig, WebpMetadata,
+};
+
+/// Build a `w*h*4` flat RGBA buffer filled with a single colour.
+fn solid_rgba(w: u32, h: u32, color: [u8; 4]) -> Vec<u8> {
+    let mut v = Vec::with_capacity((w * h * 4) as usize);
+    for _ in 0..(w * h) {
+        v.extend_from_slice(&color);
+    }
+    v
+}
+
+/// Fetch a pixel from a flat RGBA buffer (`canvas_w` pixels wide).
+fn pixel(canvas: &[u8], canvas_w: u32, x: u32, y: u32) -> [u8; 4] {
+    let off = ((y as usize) * (canvas_w as usize) + (x as usize)) * 4;
+    [
+        canvas[off],
+        canvas[off + 1],
+        canvas[off + 2],
+        canvas[off + 3],
+    ]
+}
+
+#[test]
+fn with_blend_alpha_blend_round_trips_through_decoder() {
+    // Sanity: opaque fixtures encoded with `with_blend(AlphaBlend)` still
+    // decode back to exact source pixels (because src.A = 255 makes
+    // the alpha-blend formula equivalent to overwrite per §2.7.1.1).
+    let (w, h) = (4u32, 4u32);
+    let pixels = solid_rgba(w, h, [200, 100, 50, 255]);
+    let f = AnimFrame::new(w, h, pixels.clone(), 100).with_blend(BlendingMethod::AlphaBlend);
+    let file = build_animated_webp(&[f]).expect("build");
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames.len(), 1);
+    assert_eq!(
+        img.frames[0].rgba, pixels,
+        "opaque blend round-trips byte-exact"
+    );
+}
+
+#[test]
+fn with_blend_alpha_blend_blends_translucent_sub_frame_onto_previous_canvas() {
+    // f0 covers the whole 8×8 canvas with an opaque RED keyframe.
+    // f1 is a 2×2 translucent (alpha=128) BLUE sub-rect at (2,2) with
+    // BlendingMethod::AlphaBlend. The decoder's §2.7.1.1 compositor
+    // must blend f1's blue over f0's red — yielding a *purple-ish*
+    // mixture inside the 2×2 rect and untouched red elsewhere.
+    let canvas_w = 8u32;
+    let canvas_h = 8u32;
+    let red = [255u8, 0, 0, 255];
+    let translucent_blue = [0u8, 0, 255, 128];
+
+    let f0 = AnimFrame::new(canvas_w, canvas_h, solid_rgba(canvas_w, canvas_h, red), 100);
+
+    let mut f1 = AnimFrame::new(2, 2, solid_rgba(2, 2, translucent_blue), 100);
+    f1.x = 2;
+    f1.y = 2;
+    f1 = f1.with_blend(BlendingMethod::AlphaBlend);
+
+    let file = build_animated_webp(&[f0, f1]).expect("build");
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames.len(), 2);
+
+    let composited = &img.frames[1].rgba;
+    assert_eq!(img.frames[1].width, canvas_w);
+    assert_eq!(img.frames[1].height, canvas_h);
+
+    // Pixels OUTSIDE the 2×2 sub-rect are still RED (f0 leftovers).
+    for y in 0..canvas_h {
+        for x in 0..canvas_w {
+            let in_rect = (2..4).contains(&x) && (2..4).contains(&y);
+            if !in_rect {
+                assert_eq!(
+                    pixel(composited, canvas_w, x, y),
+                    red,
+                    "outside-rect pixel ({x},{y}) untouched"
+                );
+            }
+        }
+    }
+
+    // INSIDE the 2×2 sub-rect: §2.7.1.1 blend formula (8-bit integer).
+    // src = (0,0,255,128), dst = (255,0,0,255).
+    // dst_factor = 255 * (255 - 128) / 255 = 127 (with rounding +127).
+    //   (255 * 127 + 127) / 255 = 127.
+    // out_a = 128 + 127 = 255.
+    // out_r = (0*128 + 255*127 + 255/2) / 255
+    //       = (32385 + 127) / 255 = 32512 / 255 = 127.
+    // out_g = (0 + 0 + 127) / 255 = 0.
+    // out_b = (255*128 + 0 + 127) / 255 = (32640 + 127) / 255 = 128.
+    let inside = pixel(composited, canvas_w, 2, 2);
+    assert_eq!(inside[3], 255, "blended alpha = 255");
+    // R must be near 127 (purple-ish — somewhere between red 255 and
+    // blue 0, with src.A = 128/255 weighting).
+    assert!(
+        inside[0] > 120 && inside[0] < 135,
+        "blended R ≈ 127, got {}",
+        inside[0]
+    );
+    assert_eq!(
+        inside[1], 0,
+        "blended G = 0 (neither src nor dst has green)"
+    );
+    assert!(
+        inside[2] > 120 && inside[2] < 135,
+        "blended B ≈ 128, got {}",
+        inside[2]
+    );
+    // Spot-check the precise expected value for the spec formula.
+    assert_eq!(inside, [127, 0, 128, 255], "blend formula bit-exact");
+}
+
+#[test]
+fn with_blend_overwrite_replaces_translucent_sub_frame_byte_for_byte() {
+    // Same setup as the alpha-blend test, but Overwrite — the 2×2
+    // translucent BLUE pixels REPLACE the previous canvas inside the
+    // sub-rect, alpha and all. Outside the rect is still RED.
+    let canvas_w = 8u32;
+    let canvas_h = 8u32;
+    let red = [255u8, 0, 0, 255];
+    let translucent_blue = [0u8, 0, 255, 128];
+
+    let f0 = AnimFrame::new(canvas_w, canvas_h, solid_rgba(canvas_w, canvas_h, red), 100);
+    let mut f1 = AnimFrame::new(2, 2, solid_rgba(2, 2, translucent_blue), 100);
+    f1.x = 2;
+    f1.y = 2;
+    f1 = f1.with_blend(BlendingMethod::Overwrite);
+
+    let file = build_animated_webp(&[f0, f1]).expect("build");
+    let img = decode_webp(&file).expect("decode");
+    let composited = &img.frames[1].rgba;
+
+    // Inside the rect: byte-exact translucent blue (src), not a blend.
+    for y in 2..4 {
+        for x in 2..4 {
+            assert_eq!(
+                pixel(composited, canvas_w, x, y),
+                translucent_blue,
+                "overwrite blits src verbatim"
+            );
+        }
+    }
+    // Outside still red.
+    assert_eq!(pixel(composited, canvas_w, 0, 0), red);
+    assert_eq!(pixel(composited, canvas_w, 7, 7), red);
+}
+
+#[test]
+fn with_dispose_background_clears_sub_rect_to_anim_bg_between_frames() {
+    // Three-frame animation: f0 fills canvas with RED, f1 paints a 2×2
+    // GREEN sub-rect at (2,2) with dispose=Background, f2 paints a 2×2
+    // BLUE sub-rect at (4,4). The decoder's §2.7.1.1 rule "before
+    // rendering each frame, the previous frame's Disposal method is
+    // applied" must clear f1's 2×2 rect to the ANIM background colour
+    // BEFORE drawing f2 — so the f2 snapshot must have:
+    //   * The f1 rect at (2,2) cleared back to the ANIM bg.
+    //   * The f2 rect at (4,4) holding GREEN over… wait, blue.
+    //   * Everywhere else still RED.
+    let canvas_w = 8u32;
+    let canvas_h = 8u32;
+    let red = [255u8, 0, 0, 255];
+    let green = [0u8, 255, 0, 255];
+    let blue = [0u8, 0, 255, 255];
+    let bg = [10u8, 20, 30, 255];
+
+    let f0 = AnimFrame::new(canvas_w, canvas_h, solid_rgba(canvas_w, canvas_h, red), 100);
+
+    let mut f1 = AnimFrame::new(2, 2, solid_rgba(2, 2, green), 100);
+    f1.x = 2;
+    f1.y = 2;
+    f1 = f1.with_dispose(DisposalMethod::Background);
+
+    let mut f2 = AnimFrame::new(2, 2, solid_rgba(2, 2, blue), 100);
+    f2.x = 4;
+    f2.y = 4;
+
+    let opts = AnimEncoderOptions {
+        loop_count: 0,
+        background_rgba: bg,
+        metadata: WebpMetadata::default(),
+        delta: DeltaConfig::default(),
+        default_near_lossless_quality: None,
+    };
+
+    let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames.len(), 3);
+
+    // Frame 1 snapshot: GREEN inside the (2..4, 2..4) sub-rect, RED
+    // everywhere else (f0's keyframe still there).
+    let f1_snap = &img.frames[1].rgba;
+    for y in 0..canvas_h {
+        for x in 0..canvas_w {
+            let in_rect = (2..4).contains(&x) && (2..4).contains(&y);
+            let expected = if in_rect { green } else { red };
+            assert_eq!(
+                pixel(f1_snap, canvas_w, x, y),
+                expected,
+                "f1 pixel ({x},{y})"
+            );
+        }
+    }
+
+    // Frame 2 snapshot: the (2..4, 2..4) sub-rect from f1 is now BG
+    // (dispose=Background cleared it before f2 was drawn). The
+    // (4..6, 4..6) sub-rect from f2 is BLUE. Everything else still RED.
+    let f2_snap = &img.frames[2].rgba;
+    for y in 0..canvas_h {
+        for x in 0..canvas_w {
+            let in_f1_rect = (2..4).contains(&x) && (2..4).contains(&y);
+            let in_f2_rect = (4..6).contains(&x) && (4..6).contains(&y);
+            let expected = if in_f2_rect {
+                blue
+            } else if in_f1_rect {
+                bg
+            } else {
+                red
+            };
+            assert_eq!(
+                pixel(f2_snap, canvas_w, x, y),
+                expected,
+                "f2 pixel ({x},{y})"
+            );
+        }
+    }
+}
+
+#[test]
+fn with_dispose_none_leaves_previous_sub_rect_intact_between_frames() {
+    // Mirror of the above test, but f1 keeps the default
+    // DisposalMethod::None — so f1's GREEN rect remains on the canvas
+    // when f2 is drawn.
+    let canvas_w = 8u32;
+    let canvas_h = 8u32;
+    let red = [255u8, 0, 0, 255];
+    let green = [0u8, 255, 0, 255];
+    let blue = [0u8, 0, 255, 255];
+    let bg = [10u8, 20, 30, 255];
+
+    let f0 = AnimFrame::new(canvas_w, canvas_h, solid_rgba(canvas_w, canvas_h, red), 100);
+
+    let mut f1 = AnimFrame::new(2, 2, solid_rgba(2, 2, green), 100);
+    f1.x = 2;
+    f1.y = 2;
+    f1 = f1.with_dispose(DisposalMethod::None);
+
+    let mut f2 = AnimFrame::new(2, 2, solid_rgba(2, 2, blue), 100);
+    f2.x = 4;
+    f2.y = 4;
+
+    let opts = AnimEncoderOptions {
+        loop_count: 0,
+        background_rgba: bg,
+        metadata: WebpMetadata::default(),
+        delta: DeltaConfig::default(),
+        default_near_lossless_quality: None,
+    };
+
+    let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");
+    let img = decode_webp(&file).expect("decode");
+
+    // Frame 2 snapshot: f1's GREEN rect is STILL there (no dispose).
+    let f2_snap = &img.frames[2].rgba;
+    for y in 0..canvas_h {
+        for x in 0..canvas_w {
+            let in_f1_rect = (2..4).contains(&x) && (2..4).contains(&y);
+            let in_f2_rect = (4..6).contains(&x) && (4..6).contains(&y);
+            let expected = if in_f2_rect {
+                blue
+            } else if in_f1_rect {
+                green
+            } else {
+                red
+            };
+            assert_eq!(
+                pixel(f2_snap, canvas_w, x, y),
+                expected,
+                "f2 pixel ({x},{y}) — dispose=None preserves f1"
+            );
+        }
+    }
+}
+
+#[test]
+fn dispose_background_and_alpha_blend_compose_through_encoder() {
+    // A more involved fixture: f0 is the keyframe (opaque red), f1 is
+    // a translucent green sub-rect with dispose=Background AND
+    // blend=AlphaBlend, f2 is a small opaque blue keyframe at a
+    // different offset.
+    //
+    // The blending in f1 must blend over f0's red. After f1, the
+    // dispose-to-background then clears f1's rect to the ANIM bg
+    // before f2 is drawn. f2's snapshot must therefore show:
+    //   * f1 rect = BG (post-dispose).
+    //   * f2 rect = BLUE.
+    //   * Elsewhere = RED.
+    let canvas_w = 8u32;
+    let canvas_h = 8u32;
+    let red = [255u8, 0, 0, 255];
+    let blue = [0u8, 0, 255, 255];
+    let bg = [40u8, 50, 60, 255];
+
+    let f0 = AnimFrame::new(canvas_w, canvas_h, solid_rgba(canvas_w, canvas_h, red), 100);
+
+    let mut f1 = AnimFrame::new(2, 2, solid_rgba(2, 2, [0, 255, 0, 128]), 100);
+    f1.x = 2;
+    f1.y = 2;
+    f1 = f1
+        .with_blend(BlendingMethod::AlphaBlend)
+        .with_dispose(DisposalMethod::Background);
+
+    let mut f2 = AnimFrame::new(2, 2, solid_rgba(2, 2, blue), 100);
+    f2.x = 4;
+    f2.y = 4;
+
+    let opts = AnimEncoderOptions {
+        loop_count: 0,
+        background_rgba: bg,
+        metadata: WebpMetadata::default(),
+        delta: DeltaConfig::default(),
+        default_near_lossless_quality: None,
+    };
+
+    let file = build_animated_webp_with_options(&[f0, f1, f2], &opts).expect("build");
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames.len(), 3);
+
+    // Frame 1 snapshot: f1 rect is the alpha-blend of green/128 over
+    // red. Compute the expected pixel via the spec formula:
+    //   src = (0, 255, 0, 128), dst = (255, 0, 0, 255).
+    //   dst_factor = (255 * 127 + 127) / 255 = 127.
+    //   out_a = 128 + 127 = 255.
+    //   out_r = (0*128 + 255*127 + 127) / 255 = (32385 + 127) / 255 = 127.
+    //   out_g = (255*128 + 0 + 127) / 255 = (32640 + 127) / 255 = 128.
+    //   out_b = 0.
+    let blended = [127u8, 128, 0, 255];
+    let f1_snap = &img.frames[1].rgba;
+    for y in 2..4 {
+        for x in 2..4 {
+            assert_eq!(
+                pixel(f1_snap, canvas_w, x, y),
+                blended,
+                "f1 blended pixel ({x},{y})"
+            );
+        }
+    }
+
+    // Frame 2 snapshot: f1 rect is BG (post-dispose), f2 rect is blue.
+    let f2_snap = &img.frames[2].rgba;
+    for y in 0..canvas_h {
+        for x in 0..canvas_w {
+            let in_f1_rect = (2..4).contains(&x) && (2..4).contains(&y);
+            let in_f2_rect = (4..6).contains(&x) && (4..6).contains(&y);
+            let expected = if in_f2_rect {
+                blue
+            } else if in_f1_rect {
+                bg
+            } else {
+                red
+            };
+            assert_eq!(
+                pixel(f2_snap, canvas_w, x, y),
+                expected,
+                "f2 pixel ({x},{y})"
+            );
+        }
+    }
+}

--- a/tests/published_anim_default_lossy_api.rs
+++ b/tests/published_anim_default_lossy_api.rs
@@ -1,0 +1,181 @@
+//! Round-143 integration tests for the **animation-wide lossy-quality
+//! default** — the new
+//! [`oxideav_webp::AnimEncoderOptions::default_lossy_quality`] field and
+//! its symmetric chainable builder
+//! [`oxideav_webp::AnimEncoderOptions::with_default_lossy_quality`].
+//!
+//! These tests pin the **API-shape stub** contract for round 143:
+//!
+//! * The field is exposed on the published-0.1.5 surface and round-trips
+//!   through its builder.
+//! * It is fully symmetric to
+//!   [`oxideav_webp::AnimEncoderOptions::default_near_lossless_quality`]
+//!   (separate storage, separate builder, no cross-talk).
+//! * It is a **no-op on the current encoder**: the existing
+//!   `AnimFrameMode::Lossless` / `Delta` / `Auto` emission paths are
+//!   lossless-only and ignore the value entirely. Bytes produced with
+//!   any `Some(q)` are byte-exact-equal to the default `None` bytes.
+//!
+//! The lossy emission body itself is blocked on the `oxideav-vp8`
+//! per-MB driver (workspace task #1041). Once that lands, the
+//! lossless-only no-op contract here will become a behavioural test
+//! (the lossy path will be invoked when a frame opts in), and these
+//! tests should be revisited accordingly.
+
+use oxideav_webp::{
+    build_animated_webp, build_animated_webp_with_options, AnimEncoderOptions, AnimFrame,
+    AnimFrameMode,
+};
+
+/// Deterministic xorshift32-driven noisy RGBA so the lossless encoder
+/// has non-trivial entropy to compress.
+fn make_noisy_rgba(width: u32, height: u32, seed: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((width * height * 4) as usize);
+    let mut s: u32 = 0x9e37_79b9 ^ seed.wrapping_mul(0x85eb_ca6b);
+    for _ in 0..(width * height) {
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+        buf.push((s & 0xff) as u8);
+        buf.push(((s >> 8) & 0xff) as u8);
+        buf.push(((s >> 16) & 0xff) as u8);
+        buf.push(0xff);
+    }
+    buf
+}
+
+// ───────── Public-API shape ─────────
+
+#[test]
+fn default_lossy_quality_field_is_none_on_default_options() {
+    let opts = AnimEncoderOptions::default();
+    assert_eq!(opts.default_lossy_quality, None);
+}
+
+#[test]
+fn with_default_lossy_quality_builder_round_trips_through_published_surface() {
+    let opts = AnimEncoderOptions::default().with_default_lossy_quality(Some(80));
+    assert_eq!(opts.default_lossy_quality, Some(80));
+
+    let opts2 = AnimEncoderOptions::default().with_default_lossy_quality(None);
+    assert_eq!(opts2.default_lossy_quality, None);
+
+    // Builder consumes self and returns Self — chains with the existing
+    // near-lossless default builder without losing either value.
+    let opts3 = AnimEncoderOptions::default()
+        .with_default_lossy_quality(Some(60))
+        .with_default_near_lossless_quality(Some(40));
+    assert_eq!(opts3.default_lossy_quality, Some(60));
+    assert_eq!(opts3.default_near_lossless_quality, Some(40));
+}
+
+// ───────── Symmetric independence with the near-lossless default ─────────
+
+#[test]
+fn default_lossy_and_near_lossless_defaults_are_independent_fields() {
+    let opts = AnimEncoderOptions {
+        default_near_lossless_quality: Some(70),
+        default_lossy_quality: Some(30),
+        ..AnimEncoderOptions::default()
+    };
+    assert_eq!(opts.default_near_lossless_quality, Some(70));
+    assert_eq!(opts.default_lossy_quality, Some(30));
+
+    // The two builders compose in either order and the resulting values
+    // are equal to direct construction.
+    let opts_chain_a = AnimEncoderOptions::default()
+        .with_default_near_lossless_quality(Some(70))
+        .with_default_lossy_quality(Some(30));
+    let opts_chain_b = AnimEncoderOptions::default()
+        .with_default_lossy_quality(Some(30))
+        .with_default_near_lossless_quality(Some(70));
+    assert_eq!(
+        opts_chain_a.default_near_lossless_quality,
+        opts_chain_b.default_near_lossless_quality
+    );
+    assert_eq!(
+        opts_chain_a.default_lossy_quality,
+        opts_chain_b.default_lossy_quality
+    );
+    assert_eq!(opts_chain_a.default_lossy_quality, Some(30));
+    assert_eq!(opts_chain_a.default_near_lossless_quality, Some(70));
+}
+
+// ───────── No-op contract on the current encoder ─────────
+
+#[test]
+fn default_lossy_quality_is_byte_exact_no_op_on_lossless_keyframe_path() {
+    // The Lossless mode is what `AnimFrame::new` defaults to. Whatever
+    // is set on `default_lossy_quality` must not perturb the emitted
+    // VP8L bytes — the API-shape stub guarantee.
+    let (w, h) = (32u32, 32u32);
+    let frames = vec![
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 0), 100),
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 1), 110),
+    ];
+    let baseline = build_animated_webp(&frames).expect("baseline");
+    for q in [Some(0u8), Some(50), Some(75), Some(100), Some(255), None] {
+        let opts = AnimEncoderOptions::default().with_default_lossy_quality(q);
+        let bytes = build_animated_webp_with_options(&frames, &opts)
+            .expect("lossy-default build on lossless frames");
+        assert_eq!(
+            bytes, baseline,
+            "default_lossy_quality = {q:?} must be a no-op on the Lossless emission path"
+        );
+    }
+}
+
+#[test]
+fn default_lossy_quality_is_byte_exact_no_op_on_delta_dirty_rect_path() {
+    // Same contract for the Delta / Auto dirty-rect path — the lossy
+    // default does not flow into the lossless dirty-rect bytes today.
+    let (w, h) = (32u32, 32u32);
+    let f0_px = make_noisy_rgba(w, h, 0);
+    let mut f1_px = f0_px.clone();
+    for row in 8..24 {
+        for col in 8..24 {
+            let off = (row * w as usize + col) * 4;
+            f1_px[off] ^= 0xff;
+            f1_px[off + 1] ^= 0xff;
+            f1_px[off + 2] ^= 0xff;
+        }
+    }
+    let mut f1 = AnimFrame::new(w, h, f1_px, 80);
+    f1.mode = AnimFrameMode::Delta;
+    let frames = vec![AnimFrame::new(w, h, f0_px, 80), f1];
+
+    let baseline = build_animated_webp(&frames).expect("baseline Delta");
+    for q in [Some(10u8), Some(50), Some(100), None] {
+        let opts = AnimEncoderOptions::default().with_default_lossy_quality(q);
+        let bytes = build_animated_webp_with_options(&frames, &opts)
+            .expect("lossy-default build on delta frames");
+        assert_eq!(
+            bytes, baseline,
+            "default_lossy_quality = {q:?} must be a no-op on the Delta emission path"
+        );
+    }
+}
+
+#[test]
+fn default_lossy_quality_does_not_perturb_near_lossless_path() {
+    // Combined: when the near-lossless default *does* take effect, the
+    // lossy default still adds nothing — the two channels stay
+    // independent, and the bytes equal the corresponding "near-lossless
+    // only" file byte-for-byte.
+    let (w, h) = (32u32, 32u32);
+    let frames = vec![
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 0), 100),
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 1), 110),
+    ];
+    let near_only = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+    let near_plus_lossy = AnimEncoderOptions::default()
+        .with_default_near_lossless_quality(Some(60))
+        .with_default_lossy_quality(Some(75));
+
+    let bytes_near = build_animated_webp_with_options(&frames, &near_only).expect("near-only");
+    let bytes_both = build_animated_webp_with_options(&frames, &near_plus_lossy).expect("both");
+    assert_eq!(
+        bytes_near, bytes_both,
+        "lossy default must be a no-op when overlaid on near-lossless = Some(60)"
+    );
+}

--- a/tests/published_anim_default_near_lossless_api.rs
+++ b/tests/published_anim_default_near_lossless_api.rs
@@ -1,0 +1,380 @@
+//! Round-141 integration tests for the **animation-wide near-lossless
+//! default** — the new [`oxideav_webp::AnimEncoderOptions::default_near_lossless_quality`]
+//! field that lets callers set the VP8L near-lossless preprocessing knob
+//! once for the whole animation instead of repeating it on every
+//! [`oxideav_webp::AnimFrame::near_lossless_quality`].
+//!
+//! Round-141 contract:
+//!
+//! * **Per-frame `Some(q)` always wins.** If a frame carries its own
+//!   `near_lossless_quality`, the options-level default is ignored for
+//!   that frame.
+//! * **Per-frame `None` falls back to the default.** If a frame leaves
+//!   its `near_lossless_quality` at the default `None`, the encoder
+//!   substitutes
+//!   [`AnimEncoderOptions::default_near_lossless_quality`].
+//! * **Both `None` = baseline.** When neither the frame nor the options
+//!   set a value, no quantization is applied; the per-frame VP8L
+//!   bitstream is byte-exact-equal to the pre-round-140 encoder output
+//!   (equivalent to `Some(100)` in either slot).
+//!
+//! All tests run under `--no-default-features`, the same shape as the
+//! other `published_*` suites.
+
+use oxideav_webp::{
+    build_animated_webp, build_animated_webp_with_options, decode_webp, near_lossless,
+    AnimEncoderOptions, AnimFrame, AnimFrameMode,
+};
+
+/// Deterministic xorshift32-driven noisy RGBA — the same helper the
+/// round-140 suite uses; copied here to keep this test file
+/// self-contained.
+fn make_noisy_rgba(width: u32, height: u32, seed: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((width * height * 4) as usize);
+    let mut s: u32 = 0x9e37_79b9 ^ seed.wrapping_mul(0x85eb_ca6b);
+    for _ in 0..(width * height) {
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+        buf.push((s & 0xff) as u8);
+        buf.push(((s >> 8) & 0xff) as u8);
+        buf.push(((s >> 16) & 0xff) as u8);
+        buf.push(0xff);
+    }
+    buf
+}
+
+fn rgba_to_argb(rgba: &[u8]) -> Vec<u32> {
+    rgba.chunks_exact(4)
+        .map(|px| {
+            (px[3] as u32) << 24 | (px[0] as u32) << 16 | (px[1] as u32) << 8 | (px[2] as u32)
+        })
+        .collect()
+}
+
+fn argb_to_rgba(argb: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(argb.len() * 4);
+    for &p in argb {
+        out.push((p >> 16) as u8);
+        out.push((p >> 8) as u8);
+        out.push(p as u8);
+        out.push((p >> 24) as u8);
+    }
+    out
+}
+
+/// Build the per-frame ANMF chunk-byte-length list from an encoded
+/// animation file. The encoder emits one ANMF per frame, in order, so
+/// this gives the same per-frame size deltas the round-140 suite would
+/// observe.
+fn per_frame_anmf_chunk_lengths(file: &[u8]) -> Vec<u32> {
+    // RIFF | u32 size | WEBP | chunks…  with each chunk being [fourcc | u32 size | payload | pad].
+    let mut out = Vec::new();
+    let mut i: usize = 12; // skip RIFF/size/WEBP
+    while i + 8 <= file.len() {
+        let fourcc = &file[i..i + 4];
+        let chunk_size = u32::from_le_bytes(file[i + 4..i + 8].try_into().unwrap());
+        let total = (chunk_size as usize) + 8 + (chunk_size as usize & 1);
+        if fourcc == b"ANMF" {
+            out.push(chunk_size);
+        }
+        i += total;
+    }
+    out
+}
+
+// ───────── Default fallback shrinks just like the per-frame knob ─────────
+
+#[test]
+fn options_default_60_matches_per_frame_60_byte_for_byte() {
+    // The contract: a 3-frame animation built with
+    // `default_near_lossless_quality = Some(60)` and no per-frame
+    // overrides must produce a file byte-for-byte identical to the same
+    // 3-frame animation built with `Some(60)` set explicitly on every
+    // frame. This is the central "set once instead of per frame" test.
+    let (w, h) = (64u32, 64u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 0),
+        make_noisy_rgba(w, h, 1),
+        make_noisy_rgba(w, h, 2),
+    ];
+
+    // (A) Default-only: every AnimFrame leaves its knob at None.
+    let frames_default = vec![
+        AnimFrame::new(w, h, srcs[0].clone(), 100),
+        AnimFrame::new(w, h, srcs[1].clone(), 110),
+        AnimFrame::new(w, h, srcs[2].clone(), 120),
+    ];
+    let opts_default = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+    let file_default = build_animated_webp_with_options(&frames_default, &opts_default)
+        .expect("default Some(60) build");
+
+    // (B) Per-frame Some(60) on every frame, no options-level default.
+    let frames_per_frame = vec![
+        AnimFrame::new(w, h, srcs[0].clone(), 100).with_near_lossless_quality(Some(60)),
+        AnimFrame::new(w, h, srcs[1].clone(), 110).with_near_lossless_quality(Some(60)),
+        AnimFrame::new(w, h, srcs[2].clone(), 120).with_near_lossless_quality(Some(60)),
+    ];
+    let file_per_frame = build_animated_webp(&frames_per_frame).expect("per-frame Some(60) build");
+
+    assert_eq!(
+        file_default, file_per_frame,
+        "options default Some(60) must produce byte-exact-equal output to per-frame Some(60)"
+    );
+
+    // Round-140 measured a ~−24 % drop versus the q=100 baseline; we
+    // re-confirm here on the same fixture to keep the "set once" path
+    // on the same compression curve.
+    let frames_baseline: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| AnimFrame::new(w, h, px.clone(), 100 + (i as u32) * 10))
+        .collect();
+    let baseline = build_animated_webp(&frames_baseline).expect("baseline");
+    assert!(
+        file_default.len() < baseline.len(),
+        "default Some(60) ({}) must shrink vs baseline ({})",
+        file_default.len(),
+        baseline.len()
+    );
+}
+
+#[test]
+fn options_default_none_matches_baseline_byte_for_byte() {
+    // The "both `None`" leg of the contract: a default-constructed
+    // `AnimEncoderOptions` (with `default_near_lossless_quality = None`)
+    // produces output byte-exact-equal to the bare `build_animated_webp`
+    // convenience entry, which itself is byte-exact-equal to the
+    // pre-round-140 baseline (per the round-140 suite).
+    let (w, h) = (16u32, 16u32);
+    let frames = vec![
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 0), 100),
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 1), 110),
+    ];
+    let file_convenience = build_animated_webp(&frames).expect("convenience baseline");
+    let file_default_opts =
+        build_animated_webp_with_options(&frames, &AnimEncoderOptions::default())
+            .expect("default opts baseline");
+    assert_eq!(
+        file_convenience, file_default_opts,
+        "default options must be a baseline pass-through"
+    );
+}
+
+#[test]
+fn options_default_above_100_clamps_to_baseline_no_op() {
+    // `near_lossless::apply` clamps `quality > 100` down to a no-op, so
+    // setting the default to a value above 100 must still produce the
+    // baseline bitstream.
+    let (w, h) = (16u32, 16u32);
+    let frames = vec![
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 0), 100),
+        AnimFrame::new(w, h, make_noisy_rgba(w, h, 1), 100),
+    ];
+    let baseline = build_animated_webp(&frames).expect("baseline");
+    let opts_above = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(255));
+    let above = build_animated_webp_with_options(&frames, &opts_above).expect("above-100 default");
+    assert_eq!(
+        baseline, above,
+        "Some(255) default must clamp to the baseline no-op"
+    );
+}
+
+// ───────── Per-frame override beats the default ─────────
+
+#[test]
+fn per_frame_some_overrides_options_default() {
+    // Mixed sequence: default = Some(60), frame 1 overridden to Some(100).
+    // Frames 0 and 2 (None per-frame) inherit the default 60; frame 1's
+    // explicit Some(100) wins and produces a baseline-equivalent ANMF.
+    let (w, h) = (64u32, 64u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 0),
+        make_noisy_rgba(w, h, 1),
+        make_noisy_rgba(w, h, 2),
+    ];
+
+    let frames_mixed = vec![
+        AnimFrame::new(w, h, srcs[0].clone(), 100),
+        AnimFrame::new(w, h, srcs[1].clone(), 110).with_near_lossless_quality(Some(100)),
+        AnimFrame::new(w, h, srcs[2].clone(), 120),
+    ];
+    let opts_mixed = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+    let file_mixed = build_animated_webp_with_options(&frames_mixed, &opts_mixed)
+        .expect("mixed default/override build");
+
+    // Reference: the "all Some(60)" file from the same sources — frames
+    // 0 and 2 must match those ANMFs byte-for-byte (same effective
+    // quality), while frame 1's ANMF must match the baseline (q=100)
+    // ANMF byte-for-byte instead.
+    let frames_all60: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| {
+            AnimFrame::new(w, h, px.clone(), 100 + (i as u32) * 10)
+                .with_near_lossless_quality(Some(60))
+        })
+        .collect();
+    let file_all60 = build_animated_webp(&frames_all60).expect("all-60 build");
+
+    let frames_all100: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| AnimFrame::new(w, h, px.clone(), 100 + (i as u32) * 10))
+        .collect();
+    let file_all100 = build_animated_webp(&frames_all100).expect("all-100 build");
+
+    let mixed_sizes = per_frame_anmf_chunk_lengths(&file_mixed);
+    let all60_sizes = per_frame_anmf_chunk_lengths(&file_all60);
+    let all100_sizes = per_frame_anmf_chunk_lengths(&file_all100);
+    assert_eq!(mixed_sizes.len(), 3);
+    assert_eq!(all60_sizes.len(), 3);
+    assert_eq!(all100_sizes.len(), 3);
+
+    // Frame 0 (default-applied) matches the all-60 size.
+    assert_eq!(
+        mixed_sizes[0], all60_sizes[0],
+        "frame 0 (None → default 60) must match the all-60 ANMF size"
+    );
+    // Frame 1 (overridden to 100) matches the all-100 size and differs
+    // from the all-60 size (the noisy fixture compresses better at q=60).
+    assert_eq!(
+        mixed_sizes[1], all100_sizes[1],
+        "frame 1 (override Some(100)) must match the all-100 ANMF size"
+    );
+    assert!(
+        mixed_sizes[1] > all60_sizes[1],
+        "frame 1's overridden q=100 ANMF ({}) must be larger than its q=60 counterpart ({})",
+        mixed_sizes[1],
+        all60_sizes[1]
+    );
+    // Frame 2 (default-applied) matches the all-60 size.
+    assert_eq!(
+        mixed_sizes[2], all60_sizes[2],
+        "frame 2 (None → default 60) must match the all-60 ANMF size"
+    );
+
+    // Overall: 2 of 3 frames shrink vs the baseline, the overridden one
+    // matches the baseline byte-for-byte.
+    assert!(
+        mixed_sizes[0] < all100_sizes[0],
+        "frame 0 shrinks vs baseline"
+    );
+    assert_eq!(
+        mixed_sizes[1], all100_sizes[1],
+        "frame 1 unchanged from baseline"
+    );
+    assert!(
+        mixed_sizes[2] < all100_sizes[2],
+        "frame 2 shrinks vs baseline"
+    );
+}
+
+#[test]
+fn per_frame_some_60_beats_options_default_some_100() {
+    // Inverse mix: default = Some(100) (baseline), one frame overridden
+    // to Some(60). Only that overridden frame shrinks; the other two
+    // remain at baseline size.
+    let (w, h) = (48u32, 48u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 10),
+        make_noisy_rgba(w, h, 11),
+        make_noisy_rgba(w, h, 12),
+    ];
+
+    let frames_mixed = vec![
+        AnimFrame::new(w, h, srcs[0].clone(), 100),
+        AnimFrame::new(w, h, srcs[1].clone(), 100).with_near_lossless_quality(Some(60)),
+        AnimFrame::new(w, h, srcs[2].clone(), 100),
+    ];
+    let opts = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(100));
+    let file_mixed = build_animated_webp_with_options(&frames_mixed, &opts).unwrap();
+
+    let frames_all100: Vec<AnimFrame> = srcs
+        .iter()
+        .map(|px| AnimFrame::new(w, h, px.clone(), 100))
+        .collect();
+    let file_all100 = build_animated_webp(&frames_all100).unwrap();
+
+    let mixed = per_frame_anmf_chunk_lengths(&file_mixed);
+    let all100 = per_frame_anmf_chunk_lengths(&file_all100);
+    assert_eq!(mixed[0], all100[0], "frame 0 stays at baseline");
+    assert!(
+        mixed[1] < all100[1],
+        "frame 1 (override Some(60)) must shrink vs baseline"
+    );
+    assert_eq!(mixed[2], all100[2], "frame 2 stays at baseline");
+}
+
+// ───────── Decode round-trip with options default applied ─────────
+
+#[test]
+fn options_default_round_trips_through_decoder() {
+    // Decoder side: the file produced with the options-level default of
+    // Some(60) decodes back to the same quantized pixels the still-image
+    // `near_lossless::quantize` would produce on the source — exactly
+    // like the round-140 per-frame test, just driven from the options
+    // default instead of per-frame.
+    let (w, h) = (32u32, 32u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 100),
+        make_noisy_rgba(w, h, 200),
+        make_noisy_rgba(w, h, 300),
+    ];
+    let frames: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| AnimFrame::new(w, h, px.clone(), 100 + (i as u32) * 10))
+        .collect();
+    let opts = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+    let file = build_animated_webp_with_options(&frames, &opts).expect("build");
+    let dec = decode_webp(&file).expect("decode");
+    assert_eq!(dec.frames.len(), 3, "one decoded frame per ANMF");
+    for (i, fr) in dec.frames.iter().enumerate() {
+        let expected_argb = near_lossless::quantize(&rgba_to_argb(&srcs[i]), 60);
+        let expected_rgba = argb_to_rgba(&expected_argb);
+        assert_eq!(
+            fr.rgba, expected_rgba,
+            "frame {i} decoded RGBA must equal quantize(src, 60) byte-for-byte"
+        );
+    }
+}
+
+// ───────── Delta/Auto interaction with the options default ─────────
+
+#[test]
+fn options_default_applies_to_delta_dirty_rect_path() {
+    // The default flows through to the dirty-rect sub-frame the same way
+    // the per-frame knob does. Two-frame fixture: frame 0 baseline,
+    // frame 1 (Delta mode) inherits the options default = Some(60),
+    // shrinking versus the same setup with default = Some(100).
+    let (w, h) = (32u32, 32u32);
+    let f0 = make_noisy_rgba(w, h, 0);
+    let mut f1 = f0.clone();
+    for row in 8..24 {
+        for col in 8..24 {
+            let off = (row * w as usize + col) * 4;
+            f1[off] ^= 0xff;
+            f1[off + 1] ^= 0xff;
+            f1[off + 2] ^= 0xff;
+        }
+    }
+
+    let mut f1_frame = AnimFrame::new(w, h, f1.clone(), 80);
+    f1_frame.mode = AnimFrameMode::Delta;
+    let f0_frame = AnimFrame::new(w, h, f0.clone(), 80);
+
+    let opts_baseline = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(100));
+    let opts_q60 = AnimEncoderOptions::default().with_default_near_lossless_quality(Some(60));
+
+    let baseline =
+        build_animated_webp_with_options(&[f0_frame.clone(), f1_frame.clone()], &opts_baseline)
+            .unwrap();
+    let q60 = build_animated_webp_with_options(&[f0_frame, f1_frame], &opts_q60).unwrap();
+    assert!(
+        q60.len() < baseline.len(),
+        "delta-mode with default Some(60) ({}) must shrink vs default Some(100) ({})",
+        q60.len(),
+        baseline.len()
+    );
+}

--- a/tests/published_anim_near_lossless_api.rs
+++ b/tests/published_anim_near_lossless_api.rs
@@ -1,0 +1,506 @@
+//! Round-140 integration tests for the **animated WebP** near-lossless
+//! preprocessing surface — the per-frame [`oxideav_webp::AnimFrame::near_lossless_quality`]
+//! knob extending the round-139 still-image preprocessor into the
+//! `build_animated_webp` path.
+//!
+//! Three round-140 guarantees are covered end-to-end:
+//!
+//! 1. **`None` (default) and `Some(100)` are byte-exact-equal to the
+//!    pre-change baseline** for every fixture in `published_anim_api.rs`.
+//!    The default-constructed `AnimFrame::new` keeps its
+//!    `near_lossless_quality` at `None`, so existing animated-WebP
+//!    fixtures encode bit-for-bit identically — callers opt in by
+//!    lowering the knob, nothing else.
+//! 2. **`Some(60)` produces a strictly smaller animation file than
+//!    `Some(100)`** on a 3-frame deterministic high-entropy fixture, with
+//!    every decoded per-frame PSNR ≥ 40 dB versus the original input.
+//!    The per-frame ANMF chunks shrink proportionally — the parent file
+//!    size delta is the sum of the per-frame deltas (the §2.7 VP8X / ANIM
+//!    headers are quality-invariant by construction).
+//! 3. **Decoder round-trip recovers the quantized RGBA exactly.** The
+//!    encoded animation is a perfectly normal sequence of `VP8L` chunks
+//!    — the preprocessing is an encoder choice, not a bitstream change —
+//!    so `decode_webp` returns the same pixels [`near_lossless::apply`]
+//!    would have produced on the input ARGB.
+//!
+//! All tests run under `--no-default-features` (no `registry` feature
+//! required), matching the rest of the published-shape suites.
+
+use oxideav_webp::{build_animated_webp, decode_webp, near_lossless, AnimFrame, AnimFrameMode};
+
+/// Build a deterministic `width * height` RGBA buffer with high per-pixel
+/// entropy — a noisy field driven by a seeded xorshift. The lossless
+/// encoder can't easily LZ77-collapse this fixture (no exact-pixel
+/// repeats), so dropping low-order bits via the near-lossless
+/// preprocessing creates the repeats the §5.2.2 / §5.2.3 entropy stages
+/// need to win.
+///
+/// Opaque (`alpha = 0xff`) in scan-line order.
+fn make_noisy_rgba(width: u32, height: u32, seed: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((width * height * 4) as usize);
+    let mut s: u32 = 0x9e37_79b9 ^ seed.wrapping_mul(0x85eb_ca6b);
+    for _ in 0..(width * height) {
+        // xorshift32
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+        buf.push((s & 0xff) as u8);
+        buf.push(((s >> 8) & 0xff) as u8);
+        buf.push(((s >> 16) & 0xff) as u8);
+        buf.push(0xff);
+    }
+    buf
+}
+
+/// Build a small natural-looking RGBA gradient with a tiny per-pixel
+/// perturbation — same idea as the still-image suite's
+/// `make_natural_argb`, but returning interleaved bytes for the
+/// `AnimFrame` constructor.
+fn make_natural_rgba(width: u32, height: u32, seed: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((width * height * 4) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            let base_r = (x * 255 / width.max(1)) as u8;
+            let base_g = (y * 255 / height.max(1)) as u8;
+            let base_b = ((x + y) * 255 / (width + height).max(1)) as u8;
+            let n = (x
+                .wrapping_mul(2654435761)
+                .wrapping_add(y.wrapping_mul(40503))
+                .wrapping_add(seed.wrapping_mul(0x9e37_79b9)))
+                & 0x07;
+            let r = base_r.saturating_add(n as u8);
+            let g = base_g.saturating_add((n ^ 0x3) as u8);
+            let b = base_b.saturating_add((n ^ 0x5) as u8);
+            buf.push(r);
+            buf.push(g);
+            buf.push(b);
+            buf.push(0xff);
+        }
+    }
+    buf
+}
+
+/// PSNR over the R/G/B channels of two equal-length interleaved RGBA
+/// buffers (alpha is excluded — the preprocessing preserves it
+/// bit-exactly, including it would only inflate the score).
+fn rgb_psnr(a: &[u8], b: &[u8]) -> f64 {
+    assert_eq!(a.len(), b.len(), "psnr buffers differ in length");
+    let mut sse: u64 = 0;
+    let mut n: u64 = 0;
+    for (pa, pb) in a.chunks_exact(4).zip(b.chunks_exact(4)) {
+        for c in 0..3 {
+            let d = pa[c] as i32 - pb[c] as i32;
+            sse += (d * d) as u64;
+            n += 1;
+        }
+    }
+    if sse == 0 {
+        return f64::INFINITY;
+    }
+    let mse = sse as f64 / n as f64;
+    20.0 * (255.0_f64).log10() - 10.0 * mse.log10()
+}
+
+/// Repack interleaved RGBA into packed ARGB so we can call the still-image
+/// near-lossless quantizer directly for the round-trip "decoded pixels ==
+/// quantized input" guarantee.
+fn rgba_to_argb(rgba: &[u8]) -> Vec<u32> {
+    rgba.chunks_exact(4)
+        .map(|px| {
+            (px[3] as u32) << 24 | (px[0] as u32) << 16 | (px[1] as u32) << 8 | (px[2] as u32)
+        })
+        .collect()
+}
+
+fn argb_to_rgba(argb: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(argb.len() * 4);
+    for &p in argb {
+        out.push((p >> 16) as u8);
+        out.push((p >> 8) as u8);
+        out.push(p as u8);
+        out.push((p >> 24) as u8);
+    }
+    out
+}
+
+// ───────── Guarantee 1: None / Some(100) is byte-exact baseline ─────────
+
+#[test]
+fn anim_default_none_is_byte_exact_to_baseline() {
+    // `AnimFrame::new` leaves `near_lossless_quality` at `None`. A
+    // three-frame animation built that way must be byte-for-byte
+    // identical to the pre-round-140 output — i.e. the existing
+    // `published_anim_api.rs` fixtures keep producing the same bytes.
+    let (w, h) = (8u32, 8u32);
+    let f0 = make_noisy_rgba(w, h, 0);
+    let f1 = make_noisy_rgba(w, h, 1);
+    let f2 = make_noisy_rgba(w, h, 2);
+    let frames = vec![
+        AnimFrame::new(w, h, f0.clone(), 100),
+        AnimFrame::new(w, h, f1.clone(), 100),
+        AnimFrame::new(w, h, f2.clone(), 100),
+    ];
+    // None vs explicit Some(100): both must produce the same bytes.
+    let none_file = build_animated_webp(&frames).expect("None build");
+    let explicit = {
+        let v: Vec<AnimFrame> = vec![
+            AnimFrame::new(w, h, f0, 100).with_near_lossless_quality(Some(100)),
+            AnimFrame::new(w, h, f1, 100).with_near_lossless_quality(Some(100)),
+            AnimFrame::new(w, h, f2, 100).with_near_lossless_quality(Some(100)),
+        ];
+        build_animated_webp(&v).expect("Some(100) build")
+    };
+    assert_eq!(
+        none_file, explicit,
+        "None and Some(100) must produce byte-exact-identical animations"
+    );
+}
+
+#[test]
+fn anim_some_100_is_byte_exact_on_small_natural_fixture() {
+    // Cover several small geometries to make sure the no-op fast path
+    // holds across the full per-frame encode pipeline (full keyframe,
+    // including the §2.7.1.1 ANMF wrapping).
+    for (w, h) in [(2u32, 2u32), (3, 5), (7, 4), (16, 16)] {
+        let frames_none = vec![
+            AnimFrame::new(w, h, make_natural_rgba(w, h, 0), 80),
+            AnimFrame::new(w, h, make_natural_rgba(w, h, 1), 80),
+        ];
+        let frames_100 = vec![
+            AnimFrame::new(w, h, make_natural_rgba(w, h, 0), 80)
+                .with_near_lossless_quality(Some(100)),
+            AnimFrame::new(w, h, make_natural_rgba(w, h, 1), 80)
+                .with_near_lossless_quality(Some(100)),
+        ];
+        let a = build_animated_webp(&frames_none).expect("None");
+        let b = build_animated_webp(&frames_100).expect("Some(100)");
+        assert_eq!(a, b, "Some(100) byte-exact baseline at {w}x{h}");
+    }
+}
+
+#[test]
+fn anim_value_above_100_is_also_byte_exact_baseline() {
+    // The preprocessing clamps `quality > 100` down to 100, so 255 (or
+    // any value above 100) must also be a no-op.
+    let (w, h) = (16u32, 16u32);
+    let none = build_animated_webp(&[
+        AnimFrame::new(w, h, make_natural_rgba(w, h, 0), 100),
+        AnimFrame::new(w, h, make_natural_rgba(w, h, 1), 100),
+    ])
+    .expect("None");
+    let above = build_animated_webp(&[
+        AnimFrame::new(w, h, make_natural_rgba(w, h, 0), 100).with_near_lossless_quality(Some(255)),
+        AnimFrame::new(w, h, make_natural_rgba(w, h, 1), 100).with_near_lossless_quality(Some(255)),
+    ])
+    .expect("Some(255)");
+    assert_eq!(none, above, "Some(255) must clamp to a no-op baseline");
+}
+
+// ───────── Guarantee 2: Some(60) shrinks + bounded per-frame PSNR ─────────
+
+#[test]
+fn anim_near_lossless_quality_60_shrinks_3_frame_noisy_fixture() {
+    // Use the noisy fixture: smooth gradients are so easy for the
+    // baseline LZ77/predictor stages that any near-lossless preprocessing
+    // simply *adds* header overhead. The noisy fixture is the realistic
+    // case where dropping low-order bits collapses many distinct colors
+    // onto the same value and the entropy stages can take advantage.
+    let (w, h) = (64u32, 64u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 0),
+        make_noisy_rgba(w, h, 1),
+        make_noisy_rgba(w, h, 2),
+    ];
+
+    let frames_baseline: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| {
+            AnimFrame::new(w, h, px.clone(), 100 + i as u32 * 10)
+                .with_near_lossless_quality(Some(100))
+        })
+        .collect();
+    let baseline = build_animated_webp(&frames_baseline).expect("baseline q=100");
+
+    let frames60: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| {
+            AnimFrame::new(w, h, px.clone(), 100 + i as u32 * 10)
+                .with_near_lossless_quality(Some(60))
+        })
+        .collect();
+    let near60 = build_animated_webp(&frames60).expect("near-lossless q=60");
+
+    // Compression: q=60 must produce *strictly* smaller output than q=100.
+    assert!(
+        near60.len() < baseline.len(),
+        "q=60 ({}) must shrink vs q=100 ({}) on a 3-frame noisy fixture",
+        near60.len(),
+        baseline.len()
+    );
+
+    // PSNR: every decoded frame must stay above the 40 dB floor.
+    let dec = decode_webp(&near60).expect("decode near-lossless animation");
+    assert_eq!(dec.frames.len(), 3, "one decoded frame per ANMF");
+    for (i, fr) in dec.frames.iter().enumerate() {
+        let psnr = rgb_psnr(&fr.rgba, &srcs[i]);
+        assert!(
+            psnr >= 40.0,
+            "frame {i} PSNR {psnr:.2} dB must be ≥ 40 dB at q=60 (step=4 ⇒ ≥ 42 dB typical)"
+        );
+    }
+}
+
+#[test]
+fn anim_per_frame_anmf_chunk_shrinks_at_lower_quality() {
+    // Single-frame animation lets us measure the per-frame ANMF chunk
+    // size cleanly (no inter-frame structure). The q=60 file must be
+    // strictly smaller than the q=100 baseline; the q=0 file smaller
+    // still.
+    let (w, h) = (48u32, 48u32);
+    let src = make_noisy_rgba(w, h, 17);
+
+    let base = build_animated_webp(&[
+        AnimFrame::new(w, h, src.clone(), 100).with_near_lossless_quality(Some(100))
+    ])
+    .unwrap();
+    let q80 = build_animated_webp(&[
+        AnimFrame::new(w, h, src.clone(), 100).with_near_lossless_quality(Some(80))
+    ])
+    .unwrap();
+    let q60 = build_animated_webp(&[
+        AnimFrame::new(w, h, src.clone(), 100).with_near_lossless_quality(Some(60))
+    ])
+    .unwrap();
+    let q40 = build_animated_webp(&[
+        AnimFrame::new(w, h, src.clone(), 100).with_near_lossless_quality(Some(40))
+    ])
+    .unwrap();
+    let q0 =
+        build_animated_webp(&[AnimFrame::new(w, h, src, 100).with_near_lossless_quality(Some(0))])
+            .unwrap();
+
+    assert!(
+        q80.len() < base.len(),
+        "q=80 ({}) < q=100 ({})",
+        q80.len(),
+        base.len()
+    );
+    assert!(
+        q60.len() < q80.len(),
+        "q=60 ({}) < q=80 ({})",
+        q60.len(),
+        q80.len()
+    );
+    assert!(
+        q40.len() < q60.len(),
+        "q=40 ({}) < q=60 ({})",
+        q40.len(),
+        q60.len()
+    );
+    assert!(
+        q0.len() < q40.len(),
+        "q=0 ({}) < q=40 ({})",
+        q0.len(),
+        q40.len()
+    );
+}
+
+// ───────── Guarantee 3: round-trip recovers the quantized pixels exactly ─────────
+
+#[test]
+fn anim_near_lossless_round_trip_matches_still_image_quantize() {
+    // The animated-frame preprocessing must produce *exactly* the same
+    // pixels per-frame as the still-image quantizer would on the same
+    // input — i.e. the bit pattern is identical to running
+    // `near_lossless::apply` on the caller's RGBA before encoding.
+    let (w, h) = (32u32, 32u32);
+    let srcs = [
+        make_noisy_rgba(w, h, 100),
+        make_noisy_rgba(w, h, 200),
+        make_noisy_rgba(w, h, 300),
+    ];
+
+    let frames: Vec<AnimFrame> = srcs
+        .iter()
+        .enumerate()
+        .map(|(i, px)| {
+            AnimFrame::new(w, h, px.clone(), 100 + i as u32 * 10)
+                .with_near_lossless_quality(Some(60))
+        })
+        .collect();
+    let file = build_animated_webp(&frames).expect("build");
+    let dec = decode_webp(&file).expect("decode");
+    assert_eq!(dec.frames.len(), 3);
+
+    for (i, fr) in dec.frames.iter().enumerate() {
+        // Expected pixels: apply the still-image preprocessor to the
+        // source ARGB, then repack to interleaved RGBA. These bytes are
+        // exactly what the encoder fed to VP8L, and a normal lossless
+        // decode must round-trip them.
+        let expected_argb = near_lossless::quantize(&rgba_to_argb(&srcs[i]), 60);
+        let expected_rgba = argb_to_rgba(&expected_argb);
+        assert_eq!(
+            fr.rgba, expected_rgba,
+            "frame {i} decoded RGBA must equal the quantized source RGBA bit-for-bit"
+        );
+        assert_eq!(fr.duration_ms, 100 + i as u32 * 10);
+    }
+}
+
+#[test]
+fn anim_near_lossless_preserves_alpha_through_round_trip() {
+    // Non-opaque pixels must round-trip with their alpha channel exactly
+    // preserved — the preprocessing never touches the A byte.
+    let (w, h) = (16u32, 16u32);
+    let mut src = make_noisy_rgba(w, h, 42);
+    // Splatter a deterministic alpha pattern across every pixel.
+    for (i, px) in src.chunks_exact_mut(4).enumerate() {
+        px[3] = (i & 0xff) as u8;
+    }
+    let frames = vec![AnimFrame::new(w, h, src.clone(), 100).with_near_lossless_quality(Some(40))];
+    let file = build_animated_webp(&frames).expect("build");
+    let dec = decode_webp(&file).expect("decode");
+    assert_eq!(dec.frames.len(), 1);
+    let decoded = &dec.frames[0].rgba;
+    for (orig_px, dec_px) in src.chunks_exact(4).zip(decoded.chunks_exact(4)) {
+        assert_eq!(
+            orig_px[3], dec_px[3],
+            "alpha byte must round-trip unchanged at q=40"
+        );
+    }
+}
+
+#[test]
+fn anim_near_lossless_per_frame_psnr_at_quality_40_within_documented_floor() {
+    // q=40 → n=3 (step=8). The documented PSNR for that bucket is
+    // ≈ 42 dB typical; the test holds the line at the 40 dB floor.
+    let (w, h) = (48u32, 48u32);
+    let srcs = [make_noisy_rgba(w, h, 7), make_noisy_rgba(w, h, 11)];
+    let frames: Vec<AnimFrame> = srcs
+        .iter()
+        .map(|px| AnimFrame::new(w, h, px.clone(), 100).with_near_lossless_quality(Some(40)))
+        .collect();
+    let file = build_animated_webp(&frames).unwrap();
+    let dec = decode_webp(&file).unwrap();
+    for (i, fr) in dec.frames.iter().enumerate() {
+        let psnr = rgb_psnr(&fr.rgba, &srcs[i]);
+        assert!(
+            psnr >= 40.0,
+            "frame {i} q=40 PSNR {psnr:.2} dB must be ≥ 40 dB"
+        );
+    }
+}
+
+// ───────── Per-frame mixed-quality + Delta/Auto interactions ─────────
+
+#[test]
+fn anim_per_frame_quality_can_be_mixed_across_frames() {
+    // Frame 0 q=100 (no-op), frame 1 q=60 (quantize). The first frame's
+    // decoded pixels equal the source bit-exactly; the second equals the
+    // still-image quantize of its source.
+    let (w, h) = (32u32, 32u32);
+    let f0_src = make_noisy_rgba(w, h, 0);
+    let f1_src = make_noisy_rgba(w, h, 1);
+
+    let frames = vec![
+        AnimFrame::new(w, h, f0_src.clone(), 100).with_near_lossless_quality(Some(100)),
+        AnimFrame::new(w, h, f1_src.clone(), 100).with_near_lossless_quality(Some(60)),
+    ];
+    let file = build_animated_webp(&frames).unwrap();
+    let dec = decode_webp(&file).unwrap();
+    assert_eq!(dec.frames.len(), 2);
+
+    assert_eq!(
+        dec.frames[0].rgba, f0_src,
+        "frame 0 (q=100) is lossless byte-for-byte"
+    );
+    let expected_f1 = argb_to_rgba(&near_lossless::quantize(&rgba_to_argb(&f1_src), 60));
+    assert_eq!(
+        dec.frames[1].rgba, expected_f1,
+        "frame 1 (q=60) matches still-image quantize byte-for-byte"
+    );
+}
+
+#[test]
+fn anim_near_lossless_applies_to_delta_dirty_rect_path() {
+    // A two-frame fixture in Delta mode where frame 1 changes a 16×16
+    // sub-rectangle of a 32×32 noisy frame 0. With q=60 on frame 1, the
+    // delta ANMF chunk must shrink relative to q=100, and the decoded
+    // frame 1 must equal the still-image-quantized source (the dirty
+    // rect is the entire content delta — overwriting the canvas
+    // bit-exactly produces the same end pixels as a full-frame emit).
+    let (w, h) = (32u32, 32u32);
+    let f0 = make_noisy_rgba(w, h, 0);
+    let mut f1 = f0.clone();
+    // Mutate a 16×16 block at (8, 8).
+    for row in 8..24 {
+        for col in 8..24 {
+            let off = (row * w as usize + col) * 4;
+            f1[off] ^= 0xff;
+            f1[off + 1] ^= 0xff;
+            f1[off + 2] ^= 0xff;
+        }
+    }
+
+    let baseline = {
+        let mut f1_frame = AnimFrame::new(w, h, f1.clone(), 80);
+        f1_frame.mode = AnimFrameMode::Delta;
+        f1_frame.near_lossless_quality = Some(100);
+        let f0_frame = AnimFrame::new(w, h, f0.clone(), 80);
+        build_animated_webp(&[f0_frame, f1_frame]).unwrap()
+    };
+    let near60 = {
+        let mut f1_frame = AnimFrame::new(w, h, f1.clone(), 80);
+        f1_frame.mode = AnimFrameMode::Delta;
+        f1_frame.near_lossless_quality = Some(60);
+        let f0_frame = AnimFrame::new(w, h, f0.clone(), 80);
+        build_animated_webp(&[f0_frame, f1_frame]).unwrap()
+    };
+
+    assert!(
+        near60.len() < baseline.len(),
+        "delta-mode q=60 ({}) must shrink vs delta-mode q=100 ({})",
+        near60.len(),
+        baseline.len()
+    );
+
+    // Decoded frame 1: the dirty-rect sub-frame is the bounding box of
+    // changed pixels (here exactly (8,8)..(24,24), a 16×16 block whose
+    // top-left is already even). Inside that box the encoder emits the
+    // *quantized* pixels; outside, the decoder's compositor keeps frame
+    // 0's pixels untouched. So the per-pixel expectation is:
+    //
+    //   inside  rect:  quantize(f1) at that position
+    //   outside rect:  f0 (decoded losslessly since f0 is q=100)
+    let dec = decode_webp(&near60).unwrap();
+    assert_eq!(dec.frames.len(), 2);
+    let f1_quant = argb_to_rgba(&near_lossless::quantize(&rgba_to_argb(&f1), 60));
+    let mut expected = f0.clone();
+    for row in 8..24 {
+        for col in 8..24 {
+            let off = (row * w as usize + col) * 4;
+            expected[off..off + 4].copy_from_slice(&f1_quant[off..off + 4]);
+        }
+    }
+    assert_eq!(
+        dec.frames[1].rgba, expected,
+        "delta-mode frame 1: sub-rect is quantized, rest comes from f0"
+    );
+}
+
+#[test]
+fn with_near_lossless_quality_builder_round_trips_field() {
+    let (w, h) = (2u32, 2u32);
+    let src = vec![0u8; (w * h * 4) as usize];
+    let f = AnimFrame::new(w, h, src.clone(), 0).with_near_lossless_quality(Some(60));
+    assert_eq!(f.near_lossless_quality, Some(60));
+    let f2 = AnimFrame::new(w, h, src.clone(), 0).with_near_lossless_quality(None);
+    assert_eq!(f2.near_lossless_quality, None);
+    let f3 = AnimFrame::new(w, h, src, 0);
+    assert_eq!(
+        f3.near_lossless_quality, None,
+        "default near_lossless_quality is None"
+    );
+}

--- a/tests/published_encode_api.rs
+++ b/tests/published_encode_api.rs
@@ -138,3 +138,132 @@ fn encode_vp8l_argb_rejects_dimension_mismatch() {
     let err = encode_vp8l_argb(&argb, 2, 2).expect_err("mismatch rejected");
     assert_eq!(err, WebpError::InvalidData);
 }
+
+// ─────────── Per-kind metadata round-trips (round 138) ───────────
+//
+// The round-115 encoder pre-existed `encode_vp8l_argb_with_metadata`
+// with all-three-set / all-three-absent coverage. Round 138 adds the
+// per-kind isolation tests that verify each of ICC / Exif / XMP can
+// be set on its own and round-trip through `extract_metadata` /
+// `decode_webp` without the other two leaking into the output. These
+// guard the §2.7.1 flag-octet's `I` / `E` / `X` bits against a stray
+// OR that would mis-declare features the file doesn't carry.
+
+#[test]
+fn encode_vp8l_argb_with_metadata_icc_only_round_trips() {
+    let (w, h) = (3u32, 3u32);
+    let argb = make_argb(w, h, true);
+    let icc = b"icc-only-profile-bytes-with-odd-length".to_vec();
+    let meta = WebpMetadata {
+        icc: Some(&icc),
+        exif: None,
+        xmp: None,
+    };
+    let file = encode_vp8l_argb_with_metadata(w, h, &argb, false, &meta).expect("icc-only .webp");
+    let read = extract_metadata(&file).expect("extract_metadata");
+    assert_eq!(read.icc.as_deref(), Some(&icc[..]));
+    assert_eq!(read.exif, None);
+    assert_eq!(read.xmp, None);
+    // Pixels survive.
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames[0].rgba, argb_to_rgba(&argb));
+}
+
+#[test]
+fn encode_vp8l_argb_with_metadata_exif_only_round_trips() {
+    let (w, h) = (3u32, 3u32);
+    let argb = make_argb(w, h, true);
+    let exif = b"Exif\x00\x00MM\x00*\x00\x00\x00\x08".to_vec();
+    let meta = WebpMetadata {
+        icc: None,
+        exif: Some(&exif),
+        xmp: None,
+    };
+    let file = encode_vp8l_argb_with_metadata(w, h, &argb, false, &meta).expect("exif-only .webp");
+    let read = extract_metadata(&file).expect("extract_metadata");
+    assert_eq!(read.icc, None);
+    assert_eq!(read.exif.as_deref(), Some(&exif[..]));
+    assert_eq!(read.xmp, None);
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames[0].rgba, argb_to_rgba(&argb));
+}
+
+#[test]
+fn encode_vp8l_argb_with_metadata_xmp_only_round_trips() {
+    let (w, h) = (3u32, 3u32);
+    let argb = make_argb(w, h, true);
+    let xmp = b"<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>".to_vec();
+    let meta = WebpMetadata {
+        icc: None,
+        exif: None,
+        xmp: Some(&xmp),
+    };
+    let file = encode_vp8l_argb_with_metadata(w, h, &argb, false, &meta).expect("xmp-only .webp");
+    let read = extract_metadata(&file).expect("extract_metadata");
+    assert_eq!(read.icc, None);
+    assert_eq!(read.exif, None);
+    assert_eq!(read.xmp.as_deref(), Some(&xmp[..]));
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames[0].rgba, argb_to_rgba(&argb));
+}
+
+#[test]
+fn encode_vp8l_argb_with_metadata_absent_kinds_round_trip_as_absent() {
+    // Asymmetric coverage: set only Exif, confirm ICC / XMP read back
+    // as None (not just empty Vecs or a stale slice from a previous
+    // call).
+    let (w, h) = (2u32, 2u32);
+    let argb = make_argb(w, h, true);
+    let exif = b"only-exif-set".to_vec();
+    let meta = WebpMetadata {
+        icc: None,
+        exif: Some(&exif),
+        xmp: None,
+    };
+    let file = encode_vp8l_argb_with_metadata(w, h, &argb, false, &meta).unwrap();
+    let read = extract_metadata(&file).unwrap();
+    assert!(
+        read.icc.is_none(),
+        "ICC must round-trip as None when absent"
+    );
+    assert!(
+        read.xmp.is_none(),
+        "XMP must round-trip as None when absent"
+    );
+    assert_eq!(read.exif.as_deref(), Some(&exif[..]));
+}
+
+// ─────────── build::build_webp_file_with_metadata published surface ───────────
+
+#[test]
+fn build_webp_file_with_metadata_round_trips_through_decoder() {
+    // Hand the build:: writer a real VP8L bitstream + metadata, parse
+    // the produced container, and confirm both the bitstream and the
+    // metadata payloads recover byte-for-byte.
+    use oxideav_webp::build::{build_webp_file_with_metadata, ImageKind, MetadataPayloads};
+
+    let (w, h) = (4u32, 4u32);
+    let argb = make_argb(w, h, true);
+    let bare = encode_vp8l_argb(&argb, w, h).expect("bare VP8L");
+
+    let icc = b"build_with_metadata_icc".to_vec();
+    let exif = b"build_with_metadata_exif".to_vec();
+    let xmp = b"build_with_metadata_xmp".to_vec();
+    let meta = MetadataPayloads {
+        icc: Some(&icc),
+        exif: Some(&exif),
+        xmp: Some(&xmp),
+    };
+    let file = build_webp_file_with_metadata(&bare, ImageKind::Lossless, w, h, meta)
+        .expect("build_webp_file_with_metadata");
+
+    // Pixels still decode through the published decoder.
+    let img = decode_webp(&file).expect("decode");
+    assert_eq!(img.frames[0].rgba, argb_to_rgba(&argb));
+
+    // Metadata reads back through the published extract_metadata.
+    let read = extract_metadata(&file).expect("extract_metadata");
+    assert_eq!(read.icc.as_deref(), Some(&icc[..]));
+    assert_eq!(read.exif.as_deref(), Some(&exif[..]));
+    assert_eq!(read.xmp.as_deref(), Some(&xmp[..]));
+}

--- a/tests/published_encode_api.rs
+++ b/tests/published_encode_api.rs
@@ -267,3 +267,287 @@ fn build_webp_file_with_metadata_round_trips_through_decoder() {
     assert_eq!(read.exif.as_deref(), Some(&exif[..]));
     assert_eq!(read.xmp.as_deref(), Some(&xmp[..]));
 }
+
+// ─────────── build → extract → re-build canonical-inverse round-trip ───────────
+//
+// `build_webp_file_with_metadata` is a deterministic §2.7 writer: §2.7's
+// "may appear out of order" carve-out for EXIF / XMP is collapsed by the
+// writer to a single canonical EXIF-before-XMP order, even-length pads are
+// always zero, and the §2.7.1 flag octet declares exactly the chunks that
+// follow. `extract_metadata` is its left-inverse on the metadata payloads.
+// These tests pin the canonical-inverse identity:
+//
+//     build(payload, meta) == build(payload, extract(build(payload, meta)))
+//
+// i.e. round-tripping through extract + re-build yields **byte-identical**
+// container bytes. Any change to the writer's emission order, pad
+// handling, or flag-octet computation would surface here as a byte-diff.
+
+#[test]
+fn build_with_metadata_extract_rebuild_is_byte_identical_all_three_kinds() {
+    // All-three-set canonical-inverse round trip.
+    use oxideav_webp::build::{build_webp_file_with_metadata, ImageKind, MetadataPayloads};
+
+    let (w, h) = (4u32, 4u32);
+    let argb = make_argb(w, h, true);
+    let bare = encode_vp8l_argb(&argb, w, h).expect("bare VP8L");
+
+    let icc = b"canonical-inverse-icc".to_vec();
+    let exif = b"canonical-inverse-exif".to_vec();
+    let xmp = b"canonical-inverse-xmp".to_vec();
+    let first = build_webp_file_with_metadata(
+        &bare,
+        ImageKind::Lossless,
+        w,
+        h,
+        MetadataPayloads {
+            icc: Some(&icc),
+            exif: Some(&exif),
+            xmp: Some(&xmp),
+        },
+    )
+    .expect("first build");
+
+    // Recover the metadata payloads through the published extract path …
+    let extracted = extract_metadata(&first).expect("extract");
+    assert_eq!(extracted.icc.as_deref(), Some(&icc[..]));
+    assert_eq!(extracted.exif.as_deref(), Some(&exif[..]));
+    assert_eq!(extracted.xmp.as_deref(), Some(&xmp[..]));
+
+    // … and feed them back through the writer. The §2.7 chunk-emission
+    // order is canonical (EXIF before XMP), the §2.7.1 flag octet is
+    // recomputed from the same Some-ness, and the §2.3 pad bytes are
+    // deterministic, so the second build's bytes must equal the first's.
+    let second = build_webp_file_with_metadata(
+        &bare,
+        ImageKind::Lossless,
+        w,
+        h,
+        MetadataPayloads {
+            icc: extracted.icc.as_deref(),
+            exif: extracted.exif.as_deref(),
+            xmp: extracted.xmp.as_deref(),
+        },
+    )
+    .expect("second build");
+
+    assert_eq!(
+        first, second,
+        "build_with_metadata is the canonical inverse of extract_metadata: \
+         round-tripping must produce byte-identical container bytes"
+    );
+}
+
+#[test]
+fn build_with_metadata_extract_rebuild_is_byte_identical_per_kind() {
+    // Per-kind canonical-inverse: each of ICC / Exif / XMP, on its own,
+    // must round-trip byte-identical through extract + re-build. Guards
+    // against a writer change that happens to be byte-identical only
+    // when all three are present (e.g. a flag-octet OR that depends on
+    // sibling chunks).
+    use oxideav_webp::build::{build_webp_file_with_metadata, ImageKind, MetadataPayloads};
+
+    let (w, h) = (3u32, 3u32);
+    let argb = make_argb(w, h, true);
+    let bare = encode_vp8l_argb(&argb, w, h).expect("bare VP8L");
+
+    let icc = b"per-kind-icc-payload".to_vec();
+    let exif = b"per-kind-exif-payload".to_vec();
+    let xmp = b"per-kind-xmp-payload".to_vec();
+
+    for (label, meta) in [
+        (
+            "icc-only",
+            MetadataPayloads {
+                icc: Some(&icc),
+                exif: None,
+                xmp: None,
+            },
+        ),
+        (
+            "exif-only",
+            MetadataPayloads {
+                icc: None,
+                exif: Some(&exif),
+                xmp: None,
+            },
+        ),
+        (
+            "xmp-only",
+            MetadataPayloads {
+                icc: None,
+                exif: None,
+                xmp: Some(&xmp),
+            },
+        ),
+        (
+            "icc+exif",
+            MetadataPayloads {
+                icc: Some(&icc),
+                exif: Some(&exif),
+                xmp: None,
+            },
+        ),
+        (
+            "icc+xmp",
+            MetadataPayloads {
+                icc: Some(&icc),
+                exif: None,
+                xmp: Some(&xmp),
+            },
+        ),
+        (
+            "exif+xmp",
+            MetadataPayloads {
+                icc: None,
+                exif: Some(&exif),
+                xmp: Some(&xmp),
+            },
+        ),
+    ] {
+        let first = build_webp_file_with_metadata(&bare, ImageKind::Lossless, w, h, meta)
+            .unwrap_or_else(|e| panic!("{label}: first build: {e:?}"));
+        let extracted =
+            extract_metadata(&first).unwrap_or_else(|e| panic!("{label}: extract: {e:?}"));
+        // Absent kinds must extract as None (not Some(empty)).
+        assert_eq!(extracted.icc.is_some(), meta.icc.is_some(), "{label}: icc");
+        assert_eq!(
+            extracted.exif.is_some(),
+            meta.exif.is_some(),
+            "{label}: exif"
+        );
+        assert_eq!(extracted.xmp.is_some(), meta.xmp.is_some(), "{label}: xmp");
+
+        let second = build_webp_file_with_metadata(
+            &bare,
+            ImageKind::Lossless,
+            w,
+            h,
+            MetadataPayloads {
+                icc: extracted.icc.as_deref(),
+                exif: extracted.exif.as_deref(),
+                xmp: extracted.xmp.as_deref(),
+            },
+        )
+        .unwrap_or_else(|e| panic!("{label}: second build: {e:?}"));
+        assert_eq!(
+            first, second,
+            "{label}: build is canonical inverse of extract; \
+             round-trip must be byte-identical"
+        );
+    }
+}
+
+#[test]
+fn build_with_metadata_extract_rebuild_is_byte_identical_odd_length_payloads() {
+    // §2.3 pad-byte canonical handling: a chunk with an odd-length
+    // payload gets a single trailing 0x00 pad that is NOT counted in
+    // Size. Re-extracting that chunk recovers ONLY the declared
+    // odd-length payload (the pad is dropped), so feeding the extracted
+    // bytes back through the writer must regenerate the same odd-length
+    // payload plus the same trailing zero pad. Pin this canonical inverse.
+    use oxideav_webp::build::{build_webp_file_with_metadata, ImageKind, MetadataPayloads};
+
+    let (w, h) = (4u32, 4u32);
+    let argb = make_argb(w, h, true);
+    let bare = encode_vp8l_argb(&argb, w, h).expect("bare VP8L");
+
+    // Three payloads with all-odd lengths so every metadata chunk
+    // produces a §2.3 pad byte.
+    let icc = vec![0xA5u8; 13];
+    let exif = vec![0x5Au8; 7];
+    let xmp = vec![0x3Cu8; 19];
+
+    let first = build_webp_file_with_metadata(
+        &bare,
+        ImageKind::Lossless,
+        w,
+        h,
+        MetadataPayloads {
+            icc: Some(&icc),
+            exif: Some(&exif),
+            xmp: Some(&xmp),
+        },
+    )
+    .expect("first build (odd-length)");
+
+    let extracted = extract_metadata(&first).expect("extract (odd-length)");
+    // Extracted payloads carry exactly the odd-length original — no pad.
+    assert_eq!(extracted.icc.as_deref(), Some(&icc[..]));
+    assert_eq!(extracted.exif.as_deref(), Some(&exif[..]));
+    assert_eq!(extracted.xmp.as_deref(), Some(&xmp[..]));
+    assert_eq!(extracted.icc.as_ref().map(|b| b.len()), Some(13));
+    assert_eq!(extracted.exif.as_ref().map(|b| b.len()), Some(7));
+    assert_eq!(extracted.xmp.as_ref().map(|b| b.len()), Some(19));
+
+    let second = build_webp_file_with_metadata(
+        &bare,
+        ImageKind::Lossless,
+        w,
+        h,
+        MetadataPayloads {
+            icc: extracted.icc.as_deref(),
+            exif: extracted.exif.as_deref(),
+            xmp: extracted.xmp.as_deref(),
+        },
+    )
+    .expect("second build (odd-length)");
+    assert_eq!(
+        first, second,
+        "odd-length payloads: build is canonical inverse of extract, \
+         §2.3 pad bytes must be regenerated identically"
+    );
+}
+
+#[test]
+fn build_with_metadata_extract_rebuild_is_byte_identical_lossy_kind() {
+    // The canonical-inverse identity is independent of which bitstream
+    // FourCC the writer emits. Run the same round-trip against the
+    // ExtendedLossy kind with a small synthetic VP8 chunk body so it
+    // also exercises the Lossy → ExtendedLossy promotion path.
+    use oxideav_webp::build::{build_webp_file_with_metadata, ImageKind, MetadataPayloads};
+
+    // The writer never inspects the bitstream payload; any non-empty
+    // byte sequence within §2.4 chunk-size limits is acceptable for
+    // this round-trip test. Use a deterministic 32-byte filler.
+    let bitstream: Vec<u8> = (0..32u8).collect();
+    let (w, h) = (16u32, 16u32);
+    let icc = b"lossy-icc".to_vec();
+    let xmp = b"lossy-xmp".to_vec();
+
+    let first = build_webp_file_with_metadata(
+        &bitstream,
+        ImageKind::ExtendedLossy,
+        w,
+        h,
+        MetadataPayloads {
+            icc: Some(&icc),
+            exif: None,
+            xmp: Some(&xmp),
+        },
+    )
+    .expect("first build (lossy kind)");
+
+    let extracted = extract_metadata(&first).expect("extract (lossy kind)");
+    assert_eq!(extracted.icc.as_deref(), Some(&icc[..]));
+    assert_eq!(extracted.exif, None);
+    assert_eq!(extracted.xmp.as_deref(), Some(&xmp[..]));
+
+    let second = build_webp_file_with_metadata(
+        &bitstream,
+        ImageKind::ExtendedLossy,
+        w,
+        h,
+        MetadataPayloads {
+            icc: extracted.icc.as_deref(),
+            exif: extracted.exif.as_deref(),
+            xmp: extracted.xmp.as_deref(),
+        },
+    )
+    .expect("second build (lossy kind)");
+    assert_eq!(
+        first, second,
+        "ExtendedLossy: build is canonical inverse of extract, \
+         lossy bitstream FourCC must round-trip byte-identical"
+    );
+}

--- a/tests/published_near_lossless_api.rs
+++ b/tests/published_near_lossless_api.rs
@@ -1,0 +1,357 @@
+//! Round-139 integration tests for the **near-lossless** encoder
+//! preprocessing surface:
+//!
+//! * [`oxideav_webp::encode_vp8l_argb_with_near_lossless`] — the public
+//!   entry point that runs the `near_lossless::apply` preprocessing pass
+//!   in front of the VP8L encoder.
+//! * [`oxideav_webp::near_lossless`] — the standalone preprocessor + the
+//!   `quality → bits-to-drop` mapping.
+//!
+//! Three round-139 guarantees are covered end-to-end:
+//!
+//! 1. **`quality = 100` is byte-exact-equal to the baseline encoder** for
+//!    every fixture we test. This is the no-op safety net: callers can
+//!    pass the near-lossless variant unconditionally and only opt into
+//!    quantization by lowering the knob.
+//! 2. **`quality = 60` produces a smaller bitstream than `quality = 100`**
+//!    on a natural-image fixture, with bounded PSNR loss (≥ 40 dB). This
+//!    demonstrates the compression win the preprocessing exists to
+//!    produce.
+//! 3. **Decoder round-trip recovers the quantized ARGB exactly.** The
+//!    encoded `.webp` is a perfectly normal lossless chunk — the
+//!    preprocessing is an encoder choice, not a bitstream change — so
+//!    `decode_webp` returns the same pixels [`near_lossless::apply`]
+//!    produced.
+//!
+//! All tests run under `--no-default-features` (no `registry` feature
+//! required), matching the rest of `tests/published_encode_api.rs`.
+
+use oxideav_webp::{
+    decode_webp, encode_vp8l_argb_with, encode_vp8l_argb_with_near_lossless, near_lossless,
+};
+
+/// Build a `width * height` natural-looking ARGB image: a smooth 2-D
+/// gradient with a small per-pixel deterministic perturbation. The
+/// perturbation prevents the gradient from collapsing into a handful of
+/// identical neighbours (which would let the baseline lossless encoder
+/// trivially capture everything via LZ77 + color-cache and leave no
+/// headroom for the near-lossless preprocessing to win on).
+///
+/// The output is opaque ARGB (`alpha = 0xff`) in scan-line order.
+fn make_natural_argb(width: u32, height: u32) -> Vec<u32> {
+    let mut buf = Vec::with_capacity((width * height) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            // Smooth gradient base.
+            let base_r = (x * 255 / width.max(1)) as u8;
+            let base_g = (y * 255 / height.max(1)) as u8;
+            let base_b = ((x + y) * 255 / (width + height).max(1)) as u8;
+            // Small deterministic perturbation, channel-decorrelated.
+            let n = (x
+                .wrapping_mul(2654435761)
+                .wrapping_add(y.wrapping_mul(40503)))
+                & 0x07;
+            let r = base_r.saturating_add(n as u8);
+            let g = base_g.saturating_add((n ^ 0x3) as u8);
+            let b = base_b.saturating_add((n ^ 0x5) as u8);
+            buf.push(0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32));
+        }
+    }
+    buf
+}
+
+/// Build a `width * height` ARGB image with high per-pixel entropy — a
+/// noisy field driven by a deterministic xorshift sequence — as the
+/// natural-image analogue. The baseline lossless encoder cannot easily
+/// LZ77-collapse this (no exact-pixel repeats), so dropping low-order
+/// bits via near-lossless preprocessing creates the repeats the entropy
+/// stages need to win.
+///
+/// Opaque (`alpha = 0xff`) in scan-line order. The PRNG is seeded
+/// per-call so the fixture is reproducible.
+fn make_noisy_argb(width: u32, height: u32) -> Vec<u32> {
+    let mut buf = Vec::with_capacity((width * height) as usize);
+    let mut s: u32 = 0x9e37_79b9;
+    for _ in 0..(width * height) {
+        // xorshift32
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+        let r = s & 0xff;
+        let g = (s >> 8) & 0xff;
+        let b = (s >> 16) & 0xff;
+        buf.push(0xff00_0000 | (r << 16) | (g << 8) | b);
+    }
+    buf
+}
+
+/// Repack ARGB → interleaved RGBA bytes for comparison against a decoded
+/// frame's pixel buffer.
+fn argb_to_rgba(argb: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(argb.len() * 4);
+    for &p in argb {
+        out.push((p >> 16) as u8);
+        out.push((p >> 8) as u8);
+        out.push(p as u8);
+        out.push((p >> 24) as u8);
+    }
+    out
+}
+
+/// PSNR (peak signal-to-noise ratio) in dB between two equal-length ARGB
+/// pixel buffers, computed over the R/G/B channels only (alpha excluded —
+/// the preprocessing preserves it bit-exactly, so it would just inflate
+/// the score with zero error).
+///
+/// Returns `f64::INFINITY` when the two buffers are identical (MSE = 0).
+fn rgb_psnr(a: &[u32], b: &[u32]) -> f64 {
+    assert_eq!(a.len(), b.len(), "psnr buffers differ in length");
+    let mut sse: u64 = 0;
+    let mut n: u64 = 0;
+    for (&pa, &pb) in a.iter().zip(b.iter()) {
+        for shift in [0u32, 8, 16] {
+            let ca = ((pa >> shift) & 0xff) as i32;
+            let cb = ((pb >> shift) & 0xff) as i32;
+            let d = ca - cb;
+            sse += (d * d) as u64;
+            n += 1;
+        }
+    }
+    if sse == 0 {
+        return f64::INFINITY;
+    }
+    let mse = sse as f64 / n as f64;
+    20.0 * (255.0_f64).log10() - 10.0 * mse.log10()
+}
+
+// ───────── Guarantee 1: quality=100 is byte-exact-equal to baseline ─────────
+
+#[test]
+fn near_lossless_quality_100_is_byte_exact_baseline_on_natural_fixture() {
+    let (w, h) = (64u32, 64u32);
+    let argb = make_natural_argb(w, h);
+
+    let baseline = encode_vp8l_argb_with(&argb, w, h, false).expect("baseline encode");
+    let near = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 100)
+        .expect("near-lossless q=100 encode");
+
+    assert_eq!(
+        baseline, near,
+        "quality=100 must produce byte-exact-identical output to baseline encoder"
+    );
+}
+
+#[test]
+fn near_lossless_quality_100_is_byte_exact_baseline_on_small_fixtures() {
+    // Cover several geometries to make sure the no-op fast path holds
+    // across the encoder's whole input shape range: degenerate (1x1),
+    // non-power-of-two, and a small square that exercises every encode
+    // path candidate.
+    for (w, h) in [(1u32, 1u32), (3, 5), (7, 4), (16, 16)] {
+        let argb = make_natural_argb(w, h);
+        let baseline = encode_vp8l_argb_with(&argb, w, h, false).expect("baseline");
+        let near = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 100)
+            .expect("near-lossless q=100");
+        assert_eq!(baseline, near, "byte-exact mismatch for {w}x{h}");
+    }
+}
+
+#[test]
+fn near_lossless_quality_above_100_is_also_byte_exact_baseline() {
+    let (w, h) = (16u32, 16u32);
+    let argb = make_natural_argb(w, h);
+    let baseline = encode_vp8l_argb_with(&argb, w, h, false).expect("baseline");
+    let near = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 255)
+        .expect("near-lossless q=255 (clamped to 100)");
+    assert_eq!(baseline, near, "values above 100 must clamp to no-op");
+}
+
+// ───────── Guarantee 2: quality=60 shrinks + bounded PSNR ─────────
+
+#[test]
+fn near_lossless_quality_60_shrinks_noisy_image_with_bounded_psnr() {
+    // Use the noisy-natural fixture: smooth-gradient input is so easy for
+    // the baseline LZ77 + predictor stages that any near-lossless
+    // preprocessing simply *adds* header overhead without unlocking new
+    // repeats. The noisy fixture is the realistic case where dropping
+    // low-order bits collapses many distinct colors onto the same value
+    // and the entropy stages can take advantage.
+    let (w, h) = (96u32, 96u32);
+    let argb = make_noisy_argb(w, h);
+
+    let baseline =
+        encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 100).expect("baseline (q=100)");
+    let near60 =
+        encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 60).expect("near-lossless q=60");
+
+    // Compression: q=60 must produce *strictly* smaller output than q=100
+    // on a noisy natural-image fixture. The preprocessing exists
+    // precisely to make this true.
+    assert!(
+        near60.len() < baseline.len(),
+        "q=60 output ({}) must be smaller than q=100 ({}) on noisy image",
+        near60.len(),
+        baseline.len()
+    );
+
+    // PSNR: the quantized pixels (what a decoder actually recovers) must
+    // stay above 40 dB vs the original input. q=60 is n=2 (step=4); the
+    // worst-case ±2 per-channel error puts the floor at ~42 dB by the
+    // formula 20·log10(255 / (step/2)). Our deterministic fixture lands
+    // well above that.
+    let quantized = near_lossless::quantize(&argb, 60);
+    let psnr = rgb_psnr(&argb, &quantized);
+    assert!(
+        psnr >= 40.0,
+        "PSNR floor violated at q=60: {psnr:.2} dB (need ≥ 40 dB)"
+    );
+}
+
+#[test]
+fn near_lossless_quality_lowers_psnr_monotonically_in_expectation() {
+    // The PSNR vs the original should never *improve* as quality drops
+    // (more bits get dropped at lower quality). Equality is allowed for
+    // adjacent buckets that map to the same n value.
+    let (w, h) = (32u32, 32u32);
+    let argb = make_natural_argb(w, h);
+
+    // Sample one representative quality per documented bucket boundary.
+    let qualities = [100u8, 99, 80, 79, 60, 59, 40, 39, 20, 19, 0];
+    let mut last_psnr = f64::INFINITY;
+    for &q in &qualities {
+        let quantized = near_lossless::quantize(&argb, q);
+        let psnr = rgb_psnr(&argb, &quantized);
+        assert!(
+            psnr <= last_psnr + 1e-9,
+            "PSNR went up as quality fell: q={q} psnr={psnr:.4} prev={last_psnr:.4}"
+        );
+        last_psnr = psnr;
+    }
+}
+
+// ───────── Guarantee 3: decoder roundtrip recovers quantized ARGB ─────────
+
+#[test]
+fn near_lossless_quality_60_roundtrip_recovers_quantized_pixels() {
+    // The encoded chunk is a perfectly normal VP8L bitstream — the
+    // preprocessing is encoder-side only — so the decoder must recover
+    // the *quantized* ARGB (not the original) bit-exactly.
+    let (w, h) = (32u32, 32u32);
+    let argb = make_natural_argb(w, h);
+
+    // Build a complete .webp around the bare bitstream so decode_webp
+    // (which walks RIFF) can read it. Wrap manually so this test stays
+    // a pure exercise of the near-lossless path without depending on
+    // encode_vp8l_argb_with_metadata's specifics.
+    use oxideav_webp::build::{build_webp_file, ImageKind};
+    let bare = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 60)
+        .expect("near-lossless q=60 bare bitstream");
+    let file = build_webp_file(&bare, ImageKind::Lossless, w, h).expect("RIFF wrap");
+
+    let img = decode_webp(&file).expect("decode .webp");
+    assert_eq!(img.frames.len(), 1);
+    assert_eq!(img.frames[0].width, w);
+    assert_eq!(img.frames[0].height, h);
+
+    // The decoder must reproduce the quantized pixels, *not* the
+    // original. Compare against `near_lossless::quantize(&argb, 60)`.
+    let quantized = near_lossless::quantize(&argb, 60);
+    let expected_rgba = argb_to_rgba(&quantized);
+    assert_eq!(
+        img.frames[0].rgba, expected_rgba,
+        "decoder round trip must recover quantized ARGB exactly"
+    );
+}
+
+#[test]
+fn near_lossless_quality_0_max_quantization_still_round_trips() {
+    // Even at the maximum quantization (n=5, step=32) the bitstream is
+    // still a perfectly normal VP8L chunk and round-trips bit-exact.
+    let (w, h) = (16u32, 16u32);
+    let argb = make_natural_argb(w, h);
+
+    use oxideav_webp::build::{build_webp_file, ImageKind};
+    let bare = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 0)
+        .expect("near-lossless q=0 bare bitstream");
+    let file = build_webp_file(&bare, ImageKind::Lossless, w, h).expect("RIFF wrap");
+
+    let img = decode_webp(&file).expect("decode");
+    let quantized = near_lossless::quantize(&argb, 0);
+    let expected_rgba = argb_to_rgba(&quantized);
+    assert_eq!(img.frames[0].rgba, expected_rgba);
+}
+
+#[test]
+fn near_lossless_preserves_alpha_through_encode_decode() {
+    // Build a non-opaque image; alpha must round-trip the *full* encode +
+    // decode cycle bit-exactly because near-lossless does not quantize
+    // alpha.
+    let (w, h) = (8u32, 8u32);
+    let mut argb = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let a = (x * 32 + y * 4) as u8;
+            let r = (x * 30) as u8;
+            let g = (y * 30) as u8;
+            let b = ((x + y) * 15) as u8;
+            argb.push(((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32));
+        }
+    }
+
+    use oxideav_webp::build::{build_webp_file, ImageKind};
+    let bare =
+        encode_vp8l_argb_with_near_lossless(&argb, w, h, true, 40).expect("alpha + near-lossless");
+    let file = build_webp_file(&bare, ImageKind::Lossless, w, h).expect("RIFF wrap");
+    let img = decode_webp(&file).expect("decode");
+
+    // Each decoded pixel's alpha byte (index 3 of every RGBA quad) must
+    // equal the input alpha byte — the quantization touches only R/G/B.
+    for (i, px) in argb.iter().enumerate() {
+        let want_a = (px >> 24) as u8;
+        let got_a = img.frames[0].rgba[i * 4 + 3];
+        assert_eq!(got_a, want_a, "alpha changed at pixel {i}");
+    }
+}
+
+#[test]
+fn near_lossless_dimension_mismatch_is_published_error() {
+    // The wrapper validates dimensions the same way the underlying encoder
+    // does — a 1-pixel buffer claimed as 2x2 is rejected, *before* the
+    // quantization pass runs.
+    let argb = vec![0xff00_0000u32];
+    let err =
+        encode_vp8l_argb_with_near_lossless(&argb, 2, 2, false, 60).expect_err("dim mismatch");
+    assert_eq!(err, oxideav_webp::WebpError::InvalidData);
+}
+
+// ───────── Measurement helper (prints sizes/PSNR under --nocapture) ─────────
+
+#[test]
+fn near_lossless_measurement_table() {
+    // Not a strict assert beyond "every entry encodes successfully" — exists
+    // so the round can capture a numeric table by running
+    // `cargo test --test published_near_lossless_api -- --nocapture
+    //  near_lossless_measurement_table`. The size/PSNR numbers in the
+    // round-139 README + CHANGELOG come from this.
+    let (w, h) = (96u32, 96u32);
+    let argb = make_noisy_argb(w, h);
+    println!("\nnoisy {w}x{h} ARGB measurement table:");
+    println!("  quality  bytes    delta   PSNR(dB)");
+    let baseline = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, 100)
+        .expect("baseline")
+        .len();
+    for q in [100u8, 95, 80, 60, 40, 20, 0] {
+        let bytes = encode_vp8l_argb_with_near_lossless(&argb, w, h, false, q)
+            .expect("encode")
+            .len();
+        let delta = (bytes as i64) - (baseline as i64);
+        let quantized = near_lossless::quantize(&argb, q);
+        let psnr = rgb_psnr(&argb, &quantized);
+        let psnr_s = if psnr.is_finite() {
+            format!("{:7.2}", psnr)
+        } else {
+            "    inf".to_string()
+        };
+        println!("  {q:3}      {bytes:6}  {delta:+6}   {psnr_s}");
+    }
+}

--- a/tests/published_vp8_lossy_api.rs
+++ b/tests/published_vp8_lossy_api.rs
@@ -1,0 +1,357 @@
+//! Round-131 published-API surface tests for the **VP8 lossy encode**
+//! path — the published-0.1.5 names per `API-COMPAT.md`, currently
+//! implemented as API-shape stubs that return `WebpError::Unsupported`
+//! at call time.
+//!
+//! What we assert:
+//!
+//! 1. Every published entry point exists with the documented signature.
+//! 2. Length / dimension validation runs **before** the
+//!    Unsupported gate, so a caller bug (wrong buffer length, wrong
+//!    plane stride, qindex out of range) surfaces as the published
+//!    `WebpError::InvalidData` rather than masquerading as Unsupported.
+//! 3. No call ever returns `Ok(bytes)` — the round-131 directive
+//!    explicitly forbids producing garbage VP8 bytes from
+//!    `oxideav-vp8`'s constant-grey-frame `encode_silent_keyframe`.
+//!    The day `oxideav-vp8` lands the §13/§14 pixel-driven encode round
+//!    these tests start failing — that failure is the cue to flip the
+//!    bodies of the entry points from stubs to real wiring (a
+//!    deliberate change-detector).
+//! 4. `quality_to_qindex` is a stable mapping callers can pre-compute
+//!    against without instantiating an encoder.
+//!
+//! Standalone (`--no-default-features`) builds get the free-function
+//! coverage; the registry block exercises the `webp_vp8` codec id +
+//! `WebpVp8LossyEncoder` trait impl.
+
+use oxideav_webp::{
+    encode_vp8_lossy_rgb24, encode_vp8_lossy_rgba, encode_vp8_lossy_yuv420p,
+    encode_vp8_lossy_yuva420p,
+    encoder_vp8::{
+        compute_psy_stats, freq_deltas_for_qindex, quality_to_qindex, Vp8FreqDeltas, Vp8PsyStats,
+        DEFAULT_QUALITY, QINDEX_MAX, QUALITY_MAX, QUALITY_MIN,
+    },
+    WebpError, WebpMetadata,
+};
+
+#[test]
+fn quality_to_qindex_endpoints() {
+    // libwebp convention: 100 = best (qindex 0), 0 = worst (qindex 127).
+    assert_eq!(quality_to_qindex(QUALITY_MAX), 0);
+    assert_eq!(quality_to_qindex(QUALITY_MIN), 127);
+    // Default sits roughly in the middle of the band.
+    let mid = quality_to_qindex(DEFAULT_QUALITY);
+    assert!(
+        mid > 10 && mid < 80,
+        "default qindex {mid} should be mid-band"
+    );
+}
+
+#[test]
+fn quality_to_qindex_clamps_out_of_range() {
+    assert_eq!(quality_to_qindex(-1.0), QINDEX_MAX);
+    assert_eq!(quality_to_qindex(101.0), 0);
+    assert_eq!(quality_to_qindex(f32::INFINITY), 0);
+    assert_eq!(quality_to_qindex(f32::NEG_INFINITY), QINDEX_MAX);
+    // NaN folds to the DEFAULT_QUALITY mapping, not a random value.
+    assert_eq!(
+        quality_to_qindex(f32::NAN),
+        quality_to_qindex(DEFAULT_QUALITY)
+    );
+}
+
+#[test]
+fn freq_deltas_default_and_zero_match() {
+    let d: Vp8FreqDeltas = Default::default();
+    assert_eq!(d, Vp8FreqDeltas::zero());
+    // freq_deltas_for_qindex returns the all-zero stub today (per the
+    // encoder_vp8 module-level note); the round wiring the real pixel
+    // encoder will flip this.
+    assert_eq!(freq_deltas_for_qindex(0), Vp8FreqDeltas::zero());
+    assert_eq!(freq_deltas_for_qindex(QINDEX_MAX), Vp8FreqDeltas::zero());
+}
+
+#[test]
+fn compute_psy_stats_validates_length_and_returns_stub() {
+    let stats = compute_psy_stats(4, 4, &[0u8; 4 * 4 * 4]).expect("4x4 rgba ok");
+    assert_eq!(stats, Vp8PsyStats::default());
+
+    // Wrong buffer length surfaces a caller error, not an Unsupported.
+    assert_eq!(
+        compute_psy_stats(4, 4, &[0u8; 4 * 4 * 4 - 1]),
+        Err(WebpError::InvalidData)
+    );
+}
+
+#[test]
+fn encode_vp8_lossy_rgba_validates_then_unsupported() {
+    let (w, h) = (8u32, 4u32);
+    // Wrong length first — must be InvalidData, not Unsupported.
+    let bad = encode_vp8_lossy_rgba(
+        w,
+        h,
+        &vec![0u8; (w * h * 4 - 1) as usize],
+        DEFAULT_QUALITY,
+        &WebpMetadata::default(),
+    );
+    assert_eq!(bad, Err(WebpError::InvalidData));
+
+    // Correct length — stub returns Unsupported, never garbage bytes.
+    let rgba = vec![0u8; (w * h * 4) as usize];
+    let out = encode_vp8_lossy_rgba(w, h, &rgba, DEFAULT_QUALITY, &WebpMetadata::default());
+    assert_eq!(
+        out,
+        Err(WebpError::Unsupported),
+        "stub must not emit bytes — see encoder_vp8 module note"
+    );
+}
+
+#[test]
+fn encode_vp8_lossy_rgb24_validates_then_unsupported() {
+    let (w, h) = (3u32, 2u32);
+    assert_eq!(
+        encode_vp8_lossy_rgb24(
+            w,
+            h,
+            &vec![0u8; (w * h * 3 + 1) as usize],
+            DEFAULT_QUALITY,
+            &WebpMetadata::default()
+        ),
+        Err(WebpError::InvalidData)
+    );
+    let rgb = vec![0u8; (w * h * 3) as usize];
+    assert_eq!(
+        encode_vp8_lossy_rgb24(w, h, &rgb, DEFAULT_QUALITY, &WebpMetadata::default()),
+        Err(WebpError::Unsupported)
+    );
+}
+
+#[test]
+fn encode_vp8_lossy_yuv420p_validates_then_unsupported() {
+    let (w, h) = (4u32, 4u32);
+    let y_len = (w as usize) * (h as usize);
+    let c_len = w.div_ceil(2) as usize * h.div_ceil(2) as usize;
+    // Mismatched chroma plane size first.
+    assert_eq!(
+        encode_vp8_lossy_yuv420p(
+            w,
+            h,
+            &vec![128u8; y_len],
+            &vec![128u8; c_len - 1],
+            &vec![128u8; c_len],
+            &WebpMetadata::default()
+        ),
+        Err(WebpError::InvalidData)
+    );
+    // Correctly-sized planes — stub returns Unsupported.
+    let y = vec![128u8; y_len];
+    let u = vec![128u8; c_len];
+    let v = vec![128u8; c_len];
+    assert_eq!(
+        encode_vp8_lossy_yuv420p(w, h, &y, &u, &v, &WebpMetadata::default()),
+        Err(WebpError::Unsupported)
+    );
+}
+
+#[test]
+fn encode_vp8_lossy_yuva420p_validates_then_unsupported() {
+    let (w, h) = (4u32, 4u32);
+    let y_len = (w as usize) * (h as usize);
+    let c_len = w.div_ceil(2) as usize * h.div_ceil(2) as usize;
+    let y = vec![128u8; y_len];
+    let u = vec![128u8; c_len];
+    let v = vec![128u8; c_len];
+    // Wrong alpha plane size first.
+    assert_eq!(
+        encode_vp8_lossy_yuva420p(
+            w,
+            h,
+            &y,
+            &u,
+            &v,
+            &vec![255u8; y_len - 2],
+            &WebpMetadata::default()
+        ),
+        Err(WebpError::InvalidData)
+    );
+    // Correctly-sized — stub returns Unsupported.
+    let a = vec![255u8; y_len];
+    assert_eq!(
+        encode_vp8_lossy_yuva420p(w, h, &y, &u, &v, &a, &WebpMetadata::default()),
+        Err(WebpError::Unsupported)
+    );
+}
+
+#[test]
+fn encode_vp8_lossy_rgba_with_alpha_still_unsupported() {
+    // Even a non-opaque image — which API-COMPAT.md says should
+    // auto-promote to extended-lossy + ALPH — must stay Unsupported
+    // until real pixel encode lands. We mainly want to be sure no
+    // garbage bytes ever return.
+    let (w, h) = (2u32, 2u32);
+    let mut rgba = Vec::new();
+    for i in 0..(w * h) as usize {
+        rgba.extend_from_slice(&[i as u8 * 50, 100, 200, 0x80]);
+    }
+    assert_eq!(
+        encode_vp8_lossy_rgba(w, h, &rgba, DEFAULT_QUALITY, &WebpMetadata::default()),
+        Err(WebpError::Unsupported)
+    );
+}
+
+// ─────────────────────── registry-side coverage ───────────────────────
+
+#[cfg(feature = "registry")]
+mod registry_side {
+    use oxideav_core::{
+        CodecId, CodecParameters, Error as CoreError, Frame, PixelFormat, RuntimeContext,
+        VideoFrame, VideoPlane,
+    };
+    use oxideav_webp::{
+        encoder_vp8::{
+            self, make_encoder_with_qindex, make_encoder_with_quality,
+            make_encoder_with_target_size,
+        },
+        register, WebpMetadataOwned, CODEC_ID_VP8,
+    };
+
+    fn vp8_params(width: u32, height: u32, pix: PixelFormat) -> CodecParameters {
+        let mut p = CodecParameters::video(CodecId::new(CODEC_ID_VP8));
+        p.width = Some(width);
+        p.height = Some(height);
+        p.pixel_format = Some(pix);
+        p
+    }
+
+    fn rgba_frame(w: u32, h: u32) -> Frame {
+        let data = vec![0x42u8; (w * h * 4) as usize];
+        Frame::Video(VideoFrame {
+            pts: Some(0),
+            planes: vec![VideoPlane {
+                stride: (w * 4) as usize,
+                data,
+            }],
+        })
+    }
+
+    #[test]
+    fn webp_vp8_codec_id_is_registered() {
+        let mut ctx = RuntimeContext::new();
+        register(&mut ctx);
+        let id = CodecId::new(CODEC_ID_VP8);
+        assert!(
+            ctx.codecs.has_encoder(&id),
+            "webp_vp8 encoder factory not installed"
+        );
+        assert!(
+            ctx.codecs.has_decoder(&id),
+            "webp_vp8 decoder factory not installed"
+        );
+    }
+
+    #[test]
+    fn webp_vp8_factory_builds_encoder_with_qindex() {
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let enc = make_encoder_with_qindex(&params, 32).expect("ctor");
+        assert_eq!(enc.codec_id().as_str(), CODEC_ID_VP8);
+    }
+
+    #[test]
+    fn webp_vp8_factory_rejects_qindex_out_of_range() {
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let res = make_encoder_with_qindex(&params, 128);
+        let Err(err) = res else {
+            panic!("qindex 128 > 127 should have rejected");
+        };
+        assert!(matches!(err, CoreError::InvalidData(_)));
+    }
+
+    #[test]
+    fn webp_vp8_factory_rejects_missing_dimensions() {
+        let mut p = CodecParameters::video(CodecId::new(CODEC_ID_VP8));
+        p.pixel_format = Some(PixelFormat::Rgba);
+        let res = make_encoder_with_qindex(&p, 32);
+        let Err(err) = res else {
+            panic!("missing width should have rejected");
+        };
+        assert!(matches!(err, CoreError::InvalidData(_)));
+    }
+
+    #[test]
+    fn webp_vp8_factory_accepts_quality_path() {
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let enc = make_encoder_with_quality(&params, encoder_vp8::DEFAULT_QUALITY).expect("ctor");
+        assert_eq!(enc.codec_id().as_str(), CODEC_ID_VP8);
+    }
+
+    #[test]
+    fn webp_vp8_factory_accepts_target_size_path() {
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let _enc = make_encoder_with_target_size(&params, 1024).expect("ctor");
+    }
+
+    #[test]
+    fn webp_vp8_send_frame_returns_unsupported_not_garbage() {
+        // The crux: the encoder builds, the frame validates against
+        // dimensions, but `send_frame` returns `Error::Unsupported`
+        // rather than a constant-grey VP8 stream wrapped in WebP RIFF.
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let mut enc = make_encoder_with_qindex(&params, 32).expect("ctor");
+        let frame = rgba_frame(16, 16);
+        let err = enc
+            .send_frame(&frame)
+            .expect_err("stub must not pretend to encode");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, CoreError::Unsupported(_)),
+            "expected Unsupported, got {err:?}"
+        );
+        assert!(
+            msg.contains("oxideav-vp8") || msg.contains("encoder_vp8"),
+            "Unsupported message should point at the gap: {msg}"
+        );
+        // receive_packet has nothing to give us either.
+        let rx = enc.receive_packet();
+        assert!(matches!(rx, Err(CoreError::NeedMore)));
+    }
+
+    #[test]
+    fn webp_vp8_rejects_wrong_plane_stride() {
+        // The encoder validates plane stride up-front so caller bugs
+        // surface as InvalidData rather than (silently) Unsupported.
+        let params = vp8_params(16, 16, PixelFormat::Rgba);
+        let mut enc = make_encoder_with_qindex(&params, 32).expect("ctor");
+        // Stride too small for the declared width.
+        let bad = Frame::Video(VideoFrame {
+            pts: Some(0),
+            planes: vec![VideoPlane {
+                stride: 16, // would need 16*4=64
+                data: vec![0u8; 16 * 16 * 4],
+            }],
+        });
+        let err = enc.send_frame(&bad).expect_err("stride mismatch");
+        assert!(matches!(err, CoreError::InvalidData(_)));
+    }
+
+    #[test]
+    fn webp_vp8_with_metadata_round_trips_through_accessor() {
+        // The encoder retains the configured metadata so a caller can
+        // round-trip its `WebpMetadataOwned` through the factory.
+        let params = vp8_params(8, 8, PixelFormat::Rgba);
+        let meta = WebpMetadataOwned {
+            icc: Some(b"icc".to_vec()),
+            exif: None,
+            xmp: Some(b"<x:xmpmeta/>".to_vec()),
+        };
+        let enc = encoder_vp8::make_encoder_with_quality_and_metadata(
+            &params,
+            encoder_vp8::DEFAULT_QUALITY,
+            meta.clone(),
+        )
+        .expect("ctor");
+        // Downcast via the published trait to read back the qindex /
+        // freq_deltas / metadata accessors on `WebpVp8LossyEncoder`.
+        // For now we just assert the codec id stays stable.
+        assert_eq!(enc.codec_id().as_str(), CODEC_ID_VP8);
+    }
+}


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-26

### Other

- canonical-inverse round-trip test for build/extract metadata (round 144)
- AnimEncoderOptions::default_lossy_quality / with_default_lossy_quality (round 143)
- AnimFrame::with_blend / with_dispose chainable builders (round 142)
- animation-wide near-lossless default (round 141)
- wire per-frame near-lossless preprocessing into build_animated_webp
- add near-lossless encoder preprocessing pass
- Round 138: build::build_webp_file_with_metadata (ICCP/EXIF/XMP)
- optimal length-limited Huffman via Package-Merge
- emit §3.7.2.1.1 simple code length code for 1-2 symbol codes
- add §4.4 color-indexing (palette) transform encoding
- add §4.2 color (cross-channel) transform encoding
- round-133 §4.1 predictor (spatial) transform encoding
- round-132 §5.2.3 color-cache size-selection chooser
- published VP8 lossy encoder API surface (API-shape stub)
- round 130 — §5.2.2 width-aware distance-code chooser
- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
- wire lossy decode against published DecodeError (not unpublished Vp8Error)
- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
- §5.2.1 / §5.2.3 color-cache writer (round 121)
- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
- §5.2.2 LZ77 backward-reference matching (round 119)
- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
- round 117 — restore published VP8L lossless-encode public names
- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
- add API-COMPAT.md — public API shape the rebuild must reproduce
- round 115 — first VP8L lossless encoder (literal-only round trip)
- register oxideav_core::Decoder into RuntimeContext (round 112)
- wire top-level decode_webp to RGBA for VP8L (round 111)
- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
- round 7: typed §2.6 `VP8L` chunk routing handle
- round 6: typed §2.5 `VP8 ` chunk routing handle
- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
- round 4: ANMF §2.7.1.1 typed per-frame header parse
- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
- in-crate copies of fixture inputs for standalone CI checkout
- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
- orphan rebuild: clean-room scaffold post 2026-05-20 audit

### Added

* **Clean-room round 144 (2026-05-26).** **Canonical-inverse round-trip
  tests pinning `build_webp_file_with_metadata` as the byte-exact left
  inverse of `extract_metadata` over the §2.7 metadata chunks.** §2.7's
  "may appear out of order" carve-out for `EXIF` / `XMP ` is collapsed by
  the writer to a single canonical `EXIF` → `XMP ` order, the §2.3 pad
  bytes are always zero, and the §2.7.1 flag octet is recomputed from
  the input's `Some`-ness. These three deterministic-emission properties
  together make the round trip
  `build(payload, meta) == build(payload, extract(build(payload, meta)))`
  byte-identical. The new tests pin that identity so any future change
  to the writer's emission order, pad handling, or flag-octet
  computation surfaces as a byte-diff in CI.

  No new public API. Four new integration tests in
  [`tests/published_encode_api.rs`](tests/published_encode_api.rs) cover
  (a) the all-three-set case, (b) every single-kind and pair-kind
  subset (six combinations) under one parametric harness, (c) the
  odd-length-payload case (every metadata chunk gets a §2.3 pad byte
  that must be regenerated identically on re-build), and (d) the
  `ImageKind::ExtendedLossy` bitstream-FourCC variant. One new inline
  unit test in [`src/build.rs`](src/build.rs) anchors the same
  property at the writer level via the `container::parse` walker
  (i.e. without depending on the `extract_metadata` public path).

  Total: **500** tests green (was 495: +5 from this round). Default and
  `--no-default-features` builds both clippy + fmt clean.

* **Clean-room round 143 (2026-05-26).** **Chainable
  `AnimEncoderOptions::with_default_lossy_quality(Option<u8>) -> Self`
  builder and matching `default_lossy_quality: Option<u8>` field,
  symmetric to the round-141
  `AnimEncoderOptions::with_default_near_lossless_quality` /
  `default_near_lossless_quality` pair.** Lets callers configure their
  full encoder shape (lossy + near-lossless animation-wide defaults)
  through one chainable builder surface today, ahead of the VP8 lossy
  encode body landing.

  **API-shape stub.** The VP8 lossy encode path is blocked on the
  `oxideav-vp8` per-MB driver (workspace task #1041); the existing
  `AnimFrameMode::Lossless` / `Delta` / `Auto` emission paths are
  lossless-only and ignore this field. The contract pinned by the new
  tests: setting `default_lossy_quality` to any value (`Some(0)` …
  `Some(255)` / `None`) produces output **byte-exact-equal** to the
  baseline `None` bytes, on both the full-keyframe and dirty-rect
  Delta paths, and does not perturb the round-141 near-lossless
  default's existing behaviour when both knobs are set together.

  Six new integration tests in
  [`tests/published_anim_default_lossy_api.rs`](tests/published_anim_default_lossy_api.rs)
  cover (a) field defaults to `None`, (b) builder round-trips
  `Some(80)` / `None` and composes with `with_default_near_lossless_quality`
  in either order, (c) the two defaults are stored in independent
  fields (struct-literal + dual-builder equivalence), (d) lossy
  default is byte-exact no-op on the Lossless keyframe path across
  `Some(0)`/`50`/`75`/`100`/`255`/`None`, (e) byte-exact no-op on
  the Delta dirty-rect path, (f) byte-exact no-op when overlaid on a
  `default_near_lossless_quality = Some(60)` baseline. Four new inline
  unit tests confirm the default, the builder round-trip, independence
  from the near-lossless default (copy-paste-swap guard), and the
  encoder no-op contract on a 4×4 fixture. Total: **495** tests green
  (was 485: +10 from this round). Default and `--no-default-features`
  builds both clippy + fmt clean.

* **Clean-room round 142 (2026-05-26).** **Chainable
  `AnimFrame::with_blend(BlendingMethod)` and
  `AnimFrame::with_dispose(DisposalMethod)` builders for the §2.7.1.1
  `B` (blending) and `D` (disposal) info-byte bits.** The underlying
  fields were already public on `AnimFrame` since round 118, but the
  published-0.1.5 surface only exposed the literal-construction path;
  the new helpers complete the chainable-builder pattern alongside
  `with_near_lossless_quality` (r140) and the `AnimFrame::new(…)`
  constructor. Both helpers consume the receiver and return `Self`, so
  they compose with each other and with the existing builders in any
  order. No new public fields; no behavioural change to existing
  encoder output (the literal-construction path was already wired).

  Six new integration tests in
  [`tests/published_anim_blend_dispose_api.rs`](tests/published_anim_blend_dispose_api.rs)
  pin the end-to-end semantics through `decode_webp`'s §2.7.1.1
  compositor: (a) opaque-source alpha-blend short-circuits to byte-
  exact round-trip; (b) a 2×2 translucent (alpha=128) BLUE sub-frame
  over an 8×8 opaque RED keyframe blends to the spec-formula bit-
  exact `(127, 0, 128, 255)`; (c) the same setup with Overwrite blits
  the translucent source verbatim into the canvas; (d) a 2×2 GREEN
  frame with dispose=Background between RED keyframe and 2×2 BLUE
  frame produces a third-frame snapshot whose `(2..4, 2..4)` rect is
  the ANIM bg, not GREEN; (e) the mirror case with dispose=None leaves
  GREEN on the canvas under the next frame; (f) the integrated case
  where AlphaBlend + Background dispose compose on the same frame
  produces the blended pixels in the f1 snapshot and the bg-cleared
  rect in the f2 snapshot.

  Six new inline unit tests confirm the `new()` blend/dispose
  defaults (`Overwrite` / `None`), the per-method builder round-trip
  for each, the chaining behaviour against `with_near_lossless_quality`,
  and the §2.7.1.1 Figure 9 info-byte emission for each `B` and `D`
  bit. Total: **485** tests green (was 473: +12 from this round).
  Default and `--no-default-features` builds both clippy + fmt clean.

* **Clean-room round 141 (2026-05-26).** **Animation-wide near-lossless
  default in `AnimEncoderOptions`.** The new
  `AnimEncoderOptions::default_near_lossless_quality: Option<u8>` field
  lets callers set the VP8L near-lossless preprocessing knob **once for
  the whole animation** instead of repeating it on every
  [`AnimFrame::near_lossless_quality`]. Resolution order at encode time:
  per-frame `Some(q)` always wins; per-frame `None` falls back to the
  options-level default; both `None` is the pre-round-140 baseline
  (no quantization, byte-exact-equal to the baseline encoder, identical
  to `Some(100)` in either slot). A builder helper
  `AnimEncoderOptions::with_default_near_lossless_quality(Option<u8>) -> Self`
  matches the rest of the chainable options surface.

  The default is threaded through to *both* the full-keyframe
  ([`AnimFrameMode::Lossless`]) and dirty-rect
  ([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths
  via a single `effective_quality = frame.q.or(opts.default_q)`
  resolution in `build_animated_webp_with_options`'s per-frame loop, so
  the round-140 per-frame-knob behaviour and the round-141
  options-default behaviour share the exact same downstream quantization
  call and produce bit-identical per-frame ANMFs given the same
  effective quality.

  **Measured deltas (3-frame 64×64 noisy fixture, deterministic
  xorshift32 seeds 0/1/2):** baseline (default `None`) 37,364 B (ANMFs
  ~12,432 each). Options default `Some(60)` with no per-frame
  overrides: 28,180 B (**−24.58 %** overall), each ANMF ~9,368 B
  (**−24.66 %** / **−24.58 %** / **−24.63 %**) — byte-for-byte
  equivalent to the round-140 per-frame `Some(60)` output. Mixed
  (default `Some(60)`, frame 1 overridden to `Some(100)`): 31,236 B
  (**−16.40 %** overall); frames 0 and 2 shrink to 9,368 B each
  (default applied), frame 1 stays at 12,432 B exactly (override wins,
  matches baseline ANMF byte-for-byte). The per-frame chunk sizes are
  cross-checked against the corresponding "all `Some(60)`" and "all
  `Some(100)`" files inside the test.

  Seven new integration tests in
  [`tests/published_anim_default_near_lossless_api.rs`](tests/published_anim_default_near_lossless_api.rs)
  cover (a) default-only equals per-frame-only byte-for-byte, (b)
  default `None` equals the convenience baseline, (c) default `Some(255)`
  clamps to the baseline no-op, (d) per-frame `Some(q)` overrides the
  default in either direction, (e) decoder round-trip recovers
  `near_lossless::quantize(src, q)` exactly when the default supplies
  the quality, and (f) the default flows through to the Delta
  dirty-rect path the same way the per-frame knob does. Two new inline
  unit tests confirm the new field defaults to `None` and the
  `with_default_near_lossless_quality` builder round-trips. Default +
  `--no-default-features` builds clippy + fmt clean.

* **Clean-room round 140 (2026-05-26).** **Per-frame near-lossless
  preprocessing in the animated-WebP encoder.** The round-139 still-image
  `near_lossless::apply` preprocessor is now wired into the
  [`build_animated_webp`](src/anim_encode.rs) /
  [`build_animated_webp_with_options`](src/anim_encode.rs) path via a new
  optional `AnimFrame::near_lossless_quality: Option<u8>` field
  (defaulting to `None`, the no-op identity). A builder helper
  `AnimFrame::with_near_lossless_quality(Option<u8>) -> Self` matches the
  rest of the per-frame chainable construction. The preprocessing is
  applied identically to the full-keyframe
  ([`AnimFrameMode::Lossless`]) and dirty-rect
  ([`AnimFrameMode::Delta`] / [`AnimFrameMode::Auto`]) emission paths —
  each frame's quality knob feeds into its per-frame VP8L bitstream
  independently, so an animation can mix lossless (`None` / `Some(100)`)
  and near-lossless frames freely.

  **Three round-140 guarantees** are pinned by integration tests in
  [`tests/published_anim_near_lossless_api.rs`](tests/published_anim_near_lossless_api.rs):
  (a) `None` (default) and `Some(100)` produce byte-exact-equal output
  to the pre-round-140 baseline encoder on every tested fixture, so
  existing animated-WebP test fixtures keep their bit pattern; the
  `None | Some(q ≥ 100)` no-op short-circuit lives in
  `apply_near_lossless_if_requested` and delegates to
  `near_lossless::apply`. (b) `Some(60)` produces a strictly smaller
  3-frame animated WebP than `Some(100)` on a deterministic 64×64
  high-entropy fixture (37,364 B → 28,180 B, **−24.58 %**) with every
  decoded per-frame PSNR ≥ 46.25 dB — well above the ≥ 40 dB floor the
  test enforces. (c) The decoded RGBA matches the still-image
  `near_lossless::quantize` of the source byte-for-byte (full-keyframe
  path) and matches the f0-with-quantized-sub-rect composite for the
  dirty-rect path; alpha round-trips unchanged at q=40 on a
  non-opaque-alpha fixture. Per-frame chunk-size monotonicity at
  q=80 < q=60 < q=40 < q=0 is verified on a single-frame 48×48 fixture.
  Mixed-quality test confirms that a per-frame knob is honoured frame
  by frame.

  11 new integration tests + 1 inline builder-round-trip test. Default
  + `--no-default-features` builds both clippy + fmt clean.

* **Clean-room round 139 (2026-05-26).** **VP8L lossless encoder
  *near-lossless* preprocessing.** A new
  [`near_lossless`](src/near_lossless.rs) module exposes the in-place
  RGB-channel quantizer `near_lossless::apply(&mut [u32], quality)` plus
  its out-of-place sibling `near_lossless::quantize`; both round each
  color channel to the nearest multiple of `2^n` where
  `n = bits_to_drop_for_quality(quality)` per the documented mapping
  `n = clamp((100 - q + 19) / 20, 0, 5)` — `q = 100` → 0 (no-op),
  `q ∈ 80..=99` → 1, `q ∈ 60..=79` → 2, `q ∈ 40..=59` → 3,
  `q ∈ 20..=39` → 4, `q ∈ 0..=19` → 5. Alpha is preserved bit-exactly
  (the preprocessing never touches it). The new public entry point
  [`encode_vp8l_argb_with_near_lossless(argb, w, h, has_alpha, quality)`](src/lib.rs)
  runs the preprocessing pass and hands the (quantized) pixels to the
  existing VP8L encoder — no decoder-side change is needed, the result
  is a perfectly normal `VP8L` chunk that decodes back through
  [`decode_webp`](src/lib.rs) to the quantized pixels bit-exactly.
  RFC 9649 does not normatively define the near-lossless formula
  (it is an encoder choice); the chosen mapping + per-channel
  round-half-up-with-clamp rounding rule is documented in the module-
  level docstring so reproducibility is a property of *our* encoder
  rather than a portable cross-encoder guarantee.

  **Three round-139 guarantees** are pinned by integration tests in
  [`tests/published_near_lossless_api.rs`](tests/published_near_lossless_api.rs):
  (a) `quality = 100` is byte-exact-equal to the baseline encoder on
  every tested fixture (1×1, 3×5, 7×4, 16×16, 64×64 natural-gradient,
  96×96 noisy); the no-op fast path returns from
  `encode_vp8l_argb_with` directly. (b) `quality = 60` produces a
  strictly smaller bitstream than `quality = 100` on a deterministic
  96×96 high-entropy fixture (27,770 B → 20,860 B, **−24.9 %**) with
  PSNR 46.25 dB — well above the test's ≥ 40 dB floor. (c) Decoder
  round-trip recovers the quantized ARGB exactly at q=60 and q=0; alpha
  round-trips unchanged through the full encode-decode cycle at q=40 on
  a non-opaque image. Quality table on the noisy fixture: q=100 →
  27,770 B (identity); q=95 / q=80 → 24,327 B / 51.20 dB; q=60 →
  20,860 B / 46.25 dB; q=40 → 17,394 B / 40.43 dB; q=20 → 13,916 B /
  34.09 dB; q=0 → 10,451 B / 27.45 dB.

  Twelve new inline tests cover: the `bits_to_drop_for_quality` bucket
  table, monotonic non-decreasing behaviour as quality drops, the
  `quantize_channel` identity at `n = 0`, round-to-nearest behaviour at
  `n = 1` and `n = 2`, the `255 → largest multiple of step ≤ 255` clamp
  rule (`n = 1` → 254, `n = 2` → 252, `n = 5` → 224), the documented
  error bounds (`step - 1` worst case across the upper clamp window,
  `step / 2` tighter bound outside it), and `result % step == 0` over
  every byte value × `n` combination. ARGB-level tests cover the
  byte-for-byte identity at `q = 100` and `q > 100`, alpha preservation
  across every quality level, the `q = 60 → multiples of 4` invariant,
  per-channel error bound across `[0..255]` for every quality, and
  apply/quantize equivalence at every quality step. Nine integration
  tests + 1 measurement helper exercise the three guarantees end-to-end
  plus dimension-mismatch error propagation and the alpha-through-the-
  full-decode-cycle case. Total: **453** tests green (+20 from round
  138).

* **Clean-room round 138 (2026-05-26).** **`build::build_webp_file_with_metadata`
  — typed §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / §2.7.1.5 `XMP ` writer at
  the container-builder layer.** The high-level
  `encode_vp8l_argb_with_metadata` (round 115) already framed metadata
  inline for the VP8L pixel path; round 138 lifts the same logic into
  the standalone `build::` module so external encoders can wrap any
  `VP8 ` / `VP8L` bitstream payload with the §2.7 metadata chunks
  without re-implementing the chunk-ordering rule. A new
  [`build::MetadataPayloads`] borrowed bag carries the three optional
  payloads; the writer picks the simple §2.5 / §2.6 layout when the bag
  is empty (byte-for-byte identical to `build::build_webp_file`) and
  auto-promotes to the §2.7 extended layout when any kind is present.
  The emitted chunk order matches RFC 9649 §2.7 verbatim: `VP8X` first,
  `ICCP` before the bitstream, the `VP8 ` / `VP8L` bitstream, then
  `EXIF` and `XMP ` after — and the §2.7.1 flag octet (`I` / `E` / `X`
  bits) declares exactly the kinds that follow, never an extra
  unconditional OR. Twelve new tests in `build::tests` cover: empty
  metadata + simple kind = byte-for-byte equivalence to
  `build_webp_file`; simple kind + metadata auto-promotes to extended
  with the right flag set; all-three-set emits in §2.7 order; per-kind
  isolation (each of ICC / Exif / XMP individually sets only its own
  flag and emits only its own chunk); odd-length payloads trigger the
  §2.3 pad byte; empty metadata payloads (zero-length) still emit the
  chunk + set the flag; extended kind + empty metadata matches
  `build_webp_file`; canvas-validation errors propagate. Five new
  integration tests in `tests/published_encode_api.rs` cover the
  per-kind isolation at the published-API level
  (`encode_vp8l_argb_with_metadata` + `extract_metadata`) plus a
  round-trip through `build::build_webp_file_with_metadata` with a real
  VP8L bitstream.

* **Clean-room round 137 (2026-05-26).** **Optimal length-limited Huffman
  via Package-Merge.** The round-136 encoder built canonical Huffman from
  histograms, then post-passed with a heuristic depth-limiter ("lengthen
  the deepest leaf, shorten a short one to keep the Kraft sum at 1") when
  the unconstrained tree depth exceeded the spec's 15-bit cap. On
  cap-triggering histograms the heuristic is only *locally* optimal; the
  globally-optimal length assignment under the depth cap is given by the
  Package-Merge algorithm (Larmore–Hirschberg 1990) applied to the
  coin-collector reformulation of length-limited Huffman. `build_code_lengths`
  now invokes a from-scratch Package-Merge implementation when (and only
  when) the unconstrained tree exceeds [`MAX_CODE_LENGTH`]; histograms whose
  unconstrained tree already fits under the cap continue to use the
  unconstrained build (which is itself optimal). The result is a
  weakly-smaller bit cost ∑ freq[s]·len[s] on every input that triggers the
  cap, and identical output on every input that does not — so the
  round-trip stays bit-exact on every existing fixture (414/414 tests
  green, including all seven lossless fixtures). Headline measurement on
  a pathological Fibonacci(25) frequency vector (unconstrained tree depth
  24, well past the 15-bit cap): **−759 bits (~95 bytes) vs the round-136
  heuristic**, with both forms remaining complete (Kraft sum 1) and
  cap-honouring. The earlier Fibonacci(20) case yields a smaller but real
  −26-bit win. The heuristic limiter is retained as `#[cfg(test)]`-only
  scaffolding so the comparison tests can demonstrate the strict-win
  delta. Eight new inline tests cover: single-symbol / two-symbol
  short-circuit, Kraft completeness over four histograms (uniform, mild
  skew, ramp, Fibonacci), agreement with unconstrained Huffman when the
  cap is not triggered, the strict-win pathological cases (Fibonacci(20)
  and Fibonacci(25)), the `build_code_lengths` fallback dispatch, and a
  bit-exact round trip through the round-104 prefix reader.

* **Clean-room round 136 (2026-05-25).** §3.7.2.1.1 **simple code length
  code** emission for the VP8L lossless encoder. The encoder previously
  always wrote each of the five prefix codes' length tables with the
  §3.7.2.1.2 *normal code length code* (a 19-symbol code-length-code plus
  per-symbol lengths). It now dispatches to the cheaper §3.7.2.1.1
  *simple* form whenever the length table describes 1 or 2 symbols at
  code length 1, all in the `[0..255]` range the simple form admits —
  exactly the form `build_code_lengths` produces for single-color
  channels and the empty distance code. The simple form encodes the
  whole table in 3–11 bits (`%b1` flag + 1-bit `num_symbols-1` + 1-bit
  `is_first_8bits` + a 1- or 8-bit `symbol0` + an optional 8-bit
  `symbol1`), versus the normal form's ≥18-bit header, and picks the
  narrow 1-bit `symbol0` field for the very common single-symbol-0
  (empty) distance code. Both forms describe the identical length table,
  so per-symbol code emission and the decoder's reconstruction are
  unaffected; the choice only shrinks the meta-block header. Bit-exact
  round trip holds on every fixture. Headline measurement: re-encoding
  the seven lossless fixtures totals **1634 B with the simple path vs
  2658 B normal-only — a 1024 B (38.5 %) header reduction**, ranging
  from −81.6 % on `lossless-1x1` (174 → 32 B) and −75.6 % on
  `lossless-32x32-rgb` (328 → 80 B) down to −16.8 % on the natural
  128×128 image (1038 → 864 B). Six new inline tests cover the
  `simple_code_symbols` classifier (1-symbol / 2-symbol eligible;
  length≠1, 3-symbol, symbol>255, all-zero ineligible), the 1- and
  2-symbol round trips through the round-104 prefix reader, and the
  measured byte win over the normal form for the empty distance code.

* **Clean-room round 135 (2026-05-25).** §3.5.4 / §4.4 **color-indexing
  (palette) transform encoding** for the VP8L lossless encoder — the
  last unimplemented VP8L transform on the encode side. When the image
  has ≤ 256 distinct ARGB colors, the encoder builds the palette (in
  first-appearance order), writes the §3.8.2 `color-indexing-tx` header
  (`%b1` present, transform type 3, 8-bit `color_table_size - 1`), the
  palette as a `color_table_size × 1` `entropy-coded-image` that is
  per-channel subtraction-coded (the exact inverse of the decoder's
  `inverse_color_table`), then replaces every pixel with its palette
  index packed into the green channel and emits that index image as a
  §3.8.3 `spatially-coded-image` at the subsampled width. For palettes
  ≤ 16 colors it applies the spec's §4.4 pixel-bundling per Table 3 —
  bundling 2 / 4 / 8 indices LSB-first into one green byte at
  `width_bits` 1 / 2 / 3 (palette ≤ 16 / ≤ 4 / ≤ 2), subsampling the
  main-image width by `DIV_ROUND_UP(width, 1 << width_bits)`. The
  forward bundling field layout is bit-identical to the decoder's
  `inverse_color_indexing` un-bundler, and the trailing partial bundle
  on non-multiple widths round-trips exactly. The color-indexing path
  is a new candidate in `encode_argb_literals_with_width_selected`
  alongside the round-134 color, round-133 predictor, and round-132
  subtract-green × cache cross-product; it returns `None` (and the
  chooser skips it) on images with > 256 distinct colors, and only
  wins on low-color images where the single-index-byte representation
  beats the literal/LZ77 paths. Headline measurement: a 64×64
  8-color image (`width_bits = 1`, two indices per byte) shrinks from
  1982 B (best non-palette path) to 1858 B (palette) — a 6.3 % size
  reduction; spatially-coherent palette art shrinks far more. Five
  new inline tests cover the Table-3 `width_bits` mapping, the palette
  build + > 256-color rejection, the forward/inverse subtraction-coding
  round trip, the bundled size win + chooser selection + bit-exact
  round trip, an unbundled (17..256-color) round trip, the partial-row
  bundle on non-power-of-two widths, and the > 256-color rejection
  through the production chooser.

* **Clean-room round 134 (2026-05-25).** §4.2 **color (cross-channel
  decorrelation) transform encoding** for the VP8L lossless encoder.
  The encoder tiles the image into `1 << size_bits` square blocks
  (`size_bits = 4`, 16×16) and, for each block, picks the three
  signed-8-bit `ColorTransformElement` coefficients (`green_to_red` /
  `green_to_blue` / `red_to_blue`) by a coordinate-descent search over
  a coarse 3.5-fixed-point grid, scored with the same wrap-aware
  sum-of-absolute-residuals proxy the predictor uses; the all-zero
  (identity) element is always the search origin so a block with no
  usable correlation keeps the no-transform residual. It writes the
  §3.8.2 `color-tx` header (`%b1` present, transform type 1, 3-bit
  `size_bits - 2`), the sub-resolution color image as an
  `entropy-coded-image` (the §4.2 layout: alpha 255, red =
  `red_to_blue`, green = `green_to_blue`, blue = `green_to_red`), then
  the residual main image as a §3.8.3 `spatially-coded-image`. The
  forward `ColorTransform` (subtract the three deltas, using the
  *original* red for the `red_to_blue` term) is the exact inverse of
  the decoder's `inverse_color`, which restores red before re-adding
  the blue delta — bit-exact across the modulo-256 wrap. The color
  path is a new candidate in `encode_argb_literals_with_width_selected`
  alongside the round-133 predictor and round-132 subtract-green ×
  cache cross-product; the chooser emits whichever candidate is
  smallest and never regresses. Headline measurement: a 64×64 image
  with high-entropy green and fractional-slope red/blue shrinks from
  7904 B (best non-color path) to 7026 B (color) — an 11 % size
  reduction. Five new inline tests cover the forward/inverse per-pixel
  round trip (including the signed [128..255] coefficient range), the
  sub-image layout, the correlated-image size win + round trip, a noisy
  non-power-of-two round trip, and a no-regression check on
  uncorrelated noise.

* **Clean-room round 133 (2026-05-25).** §3.5.1 / §4.1 **predictor
  (spatial) transform encoding** for the VP8L lossless encoder. The
  encoder tiles the image into `1 << size_bits` square blocks
  (`size_bits = 4`, 16×16) and, for each block, scores all 14
  prediction modes `[0..13]` by a per-channel sum-of-absolute-residuals
  proxy (folding the modulo-256 wrap so small negative residuals score
  low) and picks the cheapest. It writes the §3.8.2 `predictor-tx`
  header (`%b1` present, transform type 0, 3-bit `size_bits - 2`), the
  sub-resolution predictor image as an `entropy-coded-image` (mode in
  the green channel, no meta-prefix per the §3.8.2 grammar), then the
  residual main image as a §3.8.3 `spatially-coded-image`. The forward
  predictor primitives (`Average2` / `Select` / `ClampAddSubtractFull`
  / `ClampAddSubtractHalf` and the §4.1 left-topmost / top-row /
  left-column / rightmost-column border rules) are bit-identical to the
  decoder's `inverse_predictor`, so `residual = actual − pred` is the
  exact inverse of the decoder's `final = residual + pred`. The
  predictor path is a new candidate in
  `encode_argb_literals_with_width_selected` alongside the round-132
  subtract-green × cache cross-product; the chooser emits whichever
  candidate is smallest and never regresses. Headline measurement:
  64×64 smooth 2-D gradient goes from 10377 B (no-predictor) to 308 B
  (predictor) — a 97 % size reduction. The residual main image and the
  predictor sub-image each run their own §5.2.3 color-cache evaluation.
  Round trip stays bit-exact through `decode_lossless_image`, validated
  on smooth, noisy, and non-power-of-two (partial-block) fixtures. Four
  new inline tests cover (a) `sub_pred`/`add_pred` inverse across the
  wrap; (b) every selected mode ∈ `0..=13`; (c) the gradient shrinks
  and round-trips; (d) the predictor path round-trips on noise +
  non-power-of-two dimensions.

* **Clean-room round 132 (2026-05-25).** §5.2.3 **color-cache
  size-selection chooser** for the VP8L lossless encoder. The
  round-121 chooser evaluated a single `code_bits = 8` candidate
  alongside the no-cache path; the round-132 chooser evaluates a
  five-size slate `{5, 7, 8, 9, 11}` (exposed as
  `CANDIDATE_COLOR_CACHE_BITS`) cross-producted with the §3.8.2
  subtract-green transform axis, and emits the smallest of the 2 × 6
  = 12 candidates. The §5.2.3 GREEN alphabet width is `256 + 24 +
  (1 << code_bits)`, so the prefix-code header overhead scales with
  the chosen size — picking the smallest cache that captures the
  image's color recurrence avoids paying for an over-sized cache.
  New public entry point `encode_argb_literals_with_width_selected`
  returns `(bytes, chosen_code_bits)`; the existing
  `encode_argb_literals_with_width` keeps its `Vec<u8>` signature
  (the `.webp` production path calls into the selected variant and
  drops the chosen-size scalar). Headline measurement: 32×32
  palette-heavy pseudo-random goes from 661 B (round-121, fixed
  `code_bits=8`) to 645 B (round-132, chosen `code_bits=7`) — a
  2.4 % saving on top of the round-121 cache writer. Noise /
  row-correlated / solid fixtures match the round-121 size byte-for-
  byte (the chooser correctly falls back to `code_bits=0`). The
  §5.2.3 header read on the decoder side is unchanged (it already
  accepted the full `[1, 11]` range per RFC 9649); round-trip stays
  bit-exact through `decode_lossless_image`. 6 new inline tests
  (slate-spec-legal, palette → non-zero, noise → zero, chosen-size-
  in-slate, per-decision round-trip, never-regress vs round 121).
  Total: 386 tests (was 380).

* **Clean-room round 131 (2026-05-25).** Published §2.5 `VP8 ` (lossy)
  **encoder API surface** — the `encode_vp8_lossy_rgba` /
  `encode_vp8_lossy_rgb24` / `encode_vp8_lossy_yuv420p` /
  `encode_vp8_lossy_yuva420p` free functions, the new `encoder_vp8`
  module with `make_encoder_with_quality` / `_with_qindex` /
  `_with_target_size` (and `_and_metadata` / `_and_freq_deltas`
  variants), `Vp8FreqDeltas`, `Vp8PsyStats`, `compute_psy_stats`,
  `freq_deltas_for_qindex`, `quality_to_qindex`,
  `DEFAULT_QUALITY` / `QUALITY_MIN..=QUALITY_MAX` / `QINDEX_MIN..=QINDEX_MAX`,
  and the registry-side `CODEC_ID_VP8 = "webp_vp8"` codec id with the
  `WebpVp8LossyEncoder` `Encoder` trait impl + `make_vp8_lossy_encoder`
  factory. **Status:** API-shape stubs. Every entry point validates
  input dims / buffer length and then returns
  `WebpError::Unsupported` (free functions) /
  `oxideav_core::Error::Unsupported` (trait impl). The wiring to a
  real VP8 lossy bitstream is blocked on the §13 / §14 pixel-driven
  encode round on the `oxideav-vp8` sibling crate: the current
  `oxideav-vp8 = "0.2"` encoder ships Phase 1
  ([`oxideav_vp8::encode_silent_keyframe`]) which emits a structurally
  valid VP8 keyframe but **ignores the caller's pixels** (every MB is
  `mb_skip_coeff = 1` with `DC_PRED` → constant-grey picture). Wiring
  that through to a WebP RIFF wrapper would produce garbage bytes —
  the exact failure mode the round-131 directive forbids — so this
  round lands the API shape only and reports the gap. The
  `encoder_vp8` module-level doc-comment enumerates the precise
  missing primitives on `oxideav-vp8` (forward WHT / forward DCT /
  forward quantization / per-MB pixel-driven encode driver / top-level
  I420 → keyframe driver). Once those land, the function bodies become
  a thin call into the new vp8 encoder + the existing
  `build::build_webp_file` RIFF wrapper — no API churn. 18 new
  published-API tests + 4 new inline unit tests; total 380 (was 347).

* **Clean-room round 130 (2026-05-25).** §5.2.2 **width-aware distance-code
  chooser** for the VP8L lossless encoder. Each backward reference now
  picks the smaller of the scan-line code (`D + 120`, the round-119
  default) and any §5.2.2 distance-map code `c ∈ 1..=120` whose
  `(xi, yi)` entry reconstructs to `D` for the image width — so a row-
  distance match (D = W) on a 256-wide image collapses from scan-line
  code 376 (prefix 16, 7 extra bits per emission) to map code 1
  (prefix 0, 0 extra bits). The reconstruction in
  `vp8l_decode::distance_code_to_pixel_distance` is identical for both
  forms, so the round trip stays bit-exact. New public helper
  `pixel_distance_to_distance_code(distance, image_width)`; new internal
  `encode_argb_literals_with_width(pixels, image_width)` that threads
  the actual image width into the chooser (wired by `encode_vp8l_payload`
  → `encode_webp_lossless` / `encode_vp8l_argb` / animation encoders).
  The legacy width-less `encode_argb_literals` is retained for test
  callers that exercise the entropy stage without spatial structure;
  it defaults to width = 1, which disables the chooser (no distance-map
  entry reconstructs typical distances at a single-pixel-wide row).
  Headline: a 256×256 row-repeating fixture shrinks from 972 B to 958 B
  (~1.4 % reduction); a 128×128 row-correlated fixture from 522 B to
  519 B (~0.6 %). Eight new tests cover chooser correctness
  (`distance_chooser_reconstructs_each_distance_map_entry`,
  `distance_chooser_picks_map_code_for_row_distance`,
  `distance_chooser_falls_back_to_scan_line_when_no_map_match`,
  `distance_chooser_width_one_uses_scan_line_for_large_distances`),
  per-prefix non-regression (`chooser_never_picks_larger_prefix_than_scan_line`),
  measured size-reduction
  (`width_aware_distance_beats_scan_line_only_on_row_correlated_image`,
  `width_aware_distance_compounds_on_many_short_row_offset_matches`,
  `width_aware_distance_headline_256x256_row_repeating`,
  `width_aware_distance_beats_scan_line_only_on_photo_like_image`,
  `width_aware_re_encode_of_real_fixture_is_smaller`), and round-trip
  bit-exactness across widths
  (`width_aware_round_trip_across_assorted_widths`). 356 tests total.

* **Clean-room round 127 (2026-05-25).** `AnimFrameMode::Auto` and
  `AnimFrameMode::Delta` are no longer `WebpError::Unsupported` — both
  now encode the caller's frames against the previous canvas using a
  **lossless dirty-rectangle delta** path on top of the existing VP8L
  encoder. `Delta` always emits the dirty-rect sub-frame (or, for the
  first frame / a frame whose dirty rect spans the whole canvas, a full
  keyframe); `Auto` evaluates both candidates and emits the smaller
  bitstream. Both honour the §2.7.1.1 `B = 1` / `D = 0`
  (overwrite, no dispose) ANMF semantics so the encoded file round-trips
  byte-for-byte through `decode_webp`'s canvas compositor. The
  even-offset constraint of §2.7.1.1 is preserved by aligning the dirty
  rect's top-left down to the nearest even coordinate. Identical
  consecutive frames emit a degenerate 2×2 sub-frame so duration timing
  is preserved without re-encoding. Headline: a 128×128 frame pair with
  an 8×8 changed block compresses from 87 476 B (all-Lossless) to
  43 986 B (Delta or Auto) — ~50 % size reduction with a byte-exact
  round trip. The original lossy-keyframe-vs-inter-frame-delta `Auto`
  semantics will return once `oxideav-vp8` ships a real lossy encoder;
  the dirty-rect path remains useful on lossless input regardless. New
  tests: `auto_and_delta_modes_emit_valid_files_round_127`,
  `dirty_rect_shrinks_anmf_payload_for_localised_change`,
  `auto_mode_picks_dirty_rect_on_localised_change`,
  `dirty_rect_canvas_coords_covers_only_the_changed_pixels`,
  `dirty_rect_is_none_on_identical_frames` (lib unit), and
  `auto_and_delta_modes_round_trip_byte_exact`,
  `delta_mode_three_frames_round_trip_byte_exact`,
  `auto_mode_picks_dirty_rect_on_small_localised_change`
  (`published_anim_api.rs`). 345 tests total.

* **Clean-room round 127 (2026-05-25).** Decoder-side §2.7.1.1
  **canvas compositing**. `decode_webp` / `decode_animation` now sizes
  a canvas from the §2.7.1 `VP8X` chunk, initialises it to the
  §2.7.1.1 `ANIM` `Background Color`, applies the previous frame's
  disposal method (`None` or `Background`) to its sub-rectangle, then
  draws the current frame at its `(x, y)` offset using its blending
  method: `Overwrite` copies the sub-rect pixels verbatim onto the
  canvas; `AlphaBlend` runs the §2.7.1.1 8-bit integer approximation
  of `blend.A = src.A + dst.A * (1 - src.A / 255)` /
  `blend.RGB = (src.RGB * src.A + dst.RGB * dst.A *
  (1 - src.A / 255)) / blend.A` (sRGB space, no gamma
  linearisation — matching the spec's stated 8-bit formula). Each
  returned `WebpFrame.rgba` is the full canvas snapshot after that
  frame is rendered, sized `canvas_w × canvas_h` (replacing the prior
  per-sub-rect-only convention). Frames whose declared rect overflows
  the canvas are rejected as `InvalidData`. The libwebp-encoded
  `animated-with-alpha.webp` fixture (all three ANMFs at offset (0,0)
  spanning the full 64×64 canvas) keeps decoding to the same per-frame
  RGBA buffers as before. New helpers: `lib::fill_canvas_rect`,
  `lib::blit_rect_overwrite`, `lib::blit_rect_alpha_blend`.

* **Clean-room round 127 (2026-05-25).** `AnimFrame::new` default
  `blend` switched from `BlendingMethod::AlphaBlend` to
  `BlendingMethod::Overwrite` so a full-canvas frame round-trips
  byte-for-byte through the new canvas compositor. Callers that need
  alpha-blending of a translucent sub-frame onto the existing canvas
  must build the struct literally and set `blend:
  BlendingMethod::AlphaBlend`. This is a behavioural change vs prior
  rounds (the existing `published_anim_api.rs` tests against varying-
  alpha frames updated to use the new semantics).

* **Clean-room round 124 (2026-05-25).** §2.5 `VP8 ` (lossy) **decode**
  path, routed through the `oxideav-vp8` sibling crate. Re-added the
  `oxideav-vp8 = "0.2"` dependency (vp8 0.2 now exposes a public
  `Vp8Error` at its crate root) with `default-features = false`, so it
  does not pull `oxideav-core` into the standalone build. New
  `vp8_decode` module routes a `WebpLossyChunk` payload to
  `oxideav_vp8::decode_vp8` (reconstructed, loop-filtered I420 key-frame)
  and converts it to interleaved RGBA via nearest-neighbour chroma
  up-sampling and the RFC 6386 §9.2 ITU-R BT.601 full-range YCbCr→RGB
  matrix. `decode_webp` / `decode_webp_image` now decode simple-lossy and
  `VP8X`-extended-lossy still images (with optional `ALPH`-over-`VP8 `
  alpha) instead of the previous `Unsupported(LossyVp8)` refusal. Added
  the `impl From<oxideav_vp8::DecodeError> for WebpError` adapter (a VP8
  inter-frame maps to `Unsupported`; every other decode failure to
  `InvalidData`) and the internal `Error::Vp8(DecodeError)` variant.
  Verified against the cwebp-encoded `lossy-1x1.webp` (simple) and
  `lossy-with-alpha-128x128.webp` (`VP8X` + `ALPH` + `VP8 `) fixtures;
  +13 tests (5 `vp8_decode` unit + rewired lossy-fixture/registry tests),
  339 total.

  *Deferred:* API-COMPAT.md specifies a
  `From<oxideav_vp8::Vp8Error> for WebpError` adapter against vp8's
  `Vp8Error` umbrella type. That type is on vp8 **master** (commit
  `d85d244`) but **not yet on crates.io** — it landed after the v0.2.0
  tag. The live decode path is wired against the published 0.2.0
  `DecodeError`; the `Vp8Error` adapter is a follow-up for once vp8
  publishes a release carrying it.

* **Clean-room round 121 (2026-05-25).** §5.2.1 / §5.2.3 **color-cache
  writer** in the VP8L encoder. `encode_argb_literals` now evaluates a
  256-entry color cache (`color_cache_code_bits = 8`) alongside the
  no-cache path and emits whichever is smaller; combined with the
  round-120 subtract-green chooser the encoder now picks the smallest of
  all four `(no-tx | subtract-green) × (no-cache | cache)` candidates.
  When the cache is enabled, the §3.8.3 `color-cache-info` header
  becomes `%b1 8` (1-bit flag + 4-bit `code_bits`), the GREEN alphabet
  grows to `256 + 24 + 256 = 536` symbols per §6.2.3, and a literal
  repeat is written as a single §5.2.3 cache code (`256 + 24 + index`)
  instead of four channel literals. New `EncoderColorCache` helper
  mirrors the decoder's `vp8l_decode::ColorCache` semantics bit-for-bit
  (hash formula `(0x1e35a7bd * argb) >> (32 - code_bits)`,
  zero-initialised entries, every emitted pixel re-inserted in stream
  order — both literals and every pixel covered by a §5.2.2
  backward-reference copy). A new `cacheify_tokens` 2nd-pass walks the
  LZ77 token stream and rewrites any `Literal(argb)` whose hashed slot
  already holds `argb` to a `Token::CacheRef { index }`. Cache state
  stays in sync with the decoder by inserting every covered pixel of a
  `Copy` token. New test-only `encode_argb_literals_color_cache`
  forces the cache path for the round-121 size-reduction comparison;
  production callers stay on the chooser. Headline: a 32×32
  pseudo-random small-palette (8 distinct ARGB colors) image compresses
  from 1131 B (no-cache LZ77) to 622 B (color-cache on), a ~45 % size
  reduction. Uncorrelated-noise images stay on the no-cache no-tx path
  (the chooser never regresses). Round-trip is bit-exact through
  `decode_lossless_image` on every existing fixture + the new
  color-cache round-trip + meta-prefix-header read-back tests. New
  tests: `encoder_color_cache_hash_matches_decoder_hash`,
  `encoder_color_cache_starts_zero_initialized`,
  `encoder_color_cache_insert_then_contains_round_trips`,
  `cacheify_tokens_collapses_repeat_literal_into_cache_ref`,
  `cacheify_tokens_copy_updates_cache_for_subsequent_literal`,
  `color_cache_path_round_trips_via_public_entry_points`,
  `color_cache_beats_no_cache_on_small_palette_image`,
  `color_cache_chooser_does_not_regress_on_uncorrelated_noise`,
  `color_cache_header_round_trips_through_meta_prefix_reader`. The
  crate still builds + tests under `--no-default-features` (the cache
  uses only the existing `oxideav-core`-free decode helpers).

* **Clean-room round 120 (2026-05-24).** §3.5.3 / §3.8.2 **subtract-green
  transform** forward path in the VP8L encoder. New `apply_subtract_green`
  helper subtracts the green channel from red and blue per pixel
  (`r := (r - g) & 0xff`, `b := (b - g) & 0xff`), the exact inverse of
  the decoder's existing `vp8l_transform::inverse_subtract_green`.
  `encode_argb_literals` now evaluates both the no-transform and the
  subtract-green paths and emits whichever is smaller — the §3.8.2
  transform header costs only three bits (`%b1 %b10`, transform type 2
  with no body), so on green-correlated natural-image-like content the
  per-channel red/blue entropy drops sharply for a near-free win;
  uncorrelated noise falls back to no-transform (the chooser never
  regresses). The literal-only and subtract-green-forced paths stay
  available as `encode_argb_literals_only` and
  `encode_argb_literals_subtract_green` for the round-119/120 size
  comparison tests. Headline: a 32×32 synthetic green-correlated image
  (red and blue track green plus small noise) compresses from 3243 B
  (no-transform) to 2211 B (subtract-green) — a ~32 % size reduction.
  Round-trip is bit-exact through `decode_lossless_image` because the
  decoder's §4 inverse pass undoes the encoded transform. New tests:
  `apply_subtract_green_is_inverse_of_inverse_subtract_green`,
  `apply_subtract_green_only_touches_red_and_blue`,
  `subtract_green_beats_no_transform_on_green_correlated_image`,
  `encode_argb_literals_chooses_smaller_path`,
  `subtract_green_path_round_trips_via_public_entry_points`,
  `encode_argb_literals_does_not_regress_on_uncorrelated_noise`.
  The crate still builds + tests under `--no-default-features` (the
  forward transform uses no `oxideav-core` surface).

* **Clean-room round 119 (2026-05-24).** §5.2.2 **LZ77 backward-reference
  matching** in the VP8L encoder. `encode_argb_literals` now runs a
  hash-chain matcher (`Lz77Matcher`) over the ARGB pixel buffer before
  the entropy stage: every repeated run of `>= MIN_MATCH` (3) pixels at
  scan-line distance `D` becomes a §5.2.2 length + distance backward
  reference instead of `length` separate ARGB literals. Length values
  flow through the GREEN alphabet's `256 + length_prefix` symbols;
  distances use prefix code #5 with the §3.6.2.2.1 scan-line form
  `distance_code = D + 120` (always valid per the spec's `> 120` branch
  — the §3.6.2.2.1 distance map is an optional decoder convenience the
  encoder declines to use). The new `value_to_prefix` helper is the
  exact inverse of the decoder's `read_lz77_value` prefix-value
  transform, round-tripped through the live decoder at a spread of
  values and at every length `1..=MAX_MATCH` (4096). The previous
  literal-only emit path stays available as `encode_argb_literals_only`
  for the size-reduction comparison test. Headline: a 64×64 image whose
  rows repeat an 8-color palette compresses from 4758 B (literal-only)
  to 163 B (LZ77), a ~97 % reduction; pixels with no exploitable
  repetition (xorshift noise) come out the same size. New tests:
  `value_to_prefix_small_values_have_no_extra_bits`,
  `value_to_prefix_round_trips_length_range`,
  `value_to_prefix_round_trips_through_decoder`,
  `round_trip_solid_color_uses_lz77_copy`,
  `round_trip_periodic_pattern_uses_overlapping_copy`,
  `lz77_beats_literal_only_on_repetitive_image`,
  `lz77_round_trips_incompressible_pixels`,
  `round_trip_splits_match_at_max_length`. The crate still builds under
  `--no-default-features` (the matcher uses only the existing
  `oxideav-core`-free decode helpers).

* **Clean-room round 118 (2026-05-24).** Re-exposed the
  **published-0.1.5 animation-encode API** for the VP8L-lossless path, on
  top of the round-115 VP8L encoder + the §2.7.1.1 `ANIM` / `ANMF` framing
  (see `API-COMPAT.md`). Standalone (no `oxideav-core` dep):
  * `build_animated_webp(frames) -> Result<Vec<u8>, WebpError>` and
    `build_animated_webp_with_options(frames, opts)` — assemble a
    multi-frame `.webp` (`RIFF`/`WEBP` + `VP8X(A[,L][,I][,E][,X])` +
    [`ICCP`] + `ANIM` + `ANMF…ANMF` + [`EXIF`] + [`XMP `]). The `VP8X`
    canvas is sized to cover every frame; each frame's pixels become a
    §2.6 `VP8L` chunk inside the `ANMF` Frame Data.
  * `AnimFrame { pixels, width, height, x, y, duration, blend, dispose,
    mode }` (flat RGBA `pixels`; even `x`/`y`; `AnimFrame::new` helper),
    `AnimFrameMode { Auto, Delta, Lossless }` (`Lossless` wired;
    `Auto`/`Delta` → `WebpError::Unsupported`, blocked on `oxideav-vp8`
    #1041), `AnimEncoderOptions { loop_count, background_rgba, metadata,
    delta }`, `DeltaConfig` (`max_components_override` /
    `auto_inner_threshold_bytes` / `msssim_downsample_kernel` builders),
    `DownsampleKernel { Box, Gaussian }`.
  * `decode_webp` now assembles an animated file into N `WebpFrame`s
    (per-frame `VP8L` decode + optional `ALPH` alpha override), populating
    `WebpImage::anim_background_rgba` / `anim_loop_count`.
  * Standalone test `tests/published_anim_api.rs` (runs under
    `--no-default-features`): 3-frame round trip, options + metadata,
    blend/dispose/offset carry, `Auto`/`Delta` `Unsupported`, and the
    `DeltaConfig` builder chain.

* **Clean-room round 117 (2026-05-24).** Re-exposed the
  **published-0.1.5 lossless-encode public names** on top of the round-115
  in-crate VP8L encoder (see `API-COMPAT.md`). All available standalone
  (no `oxideav-core` dep):
  * `encode_vp8l_argb(argb, width, height) -> Result<Vec<u8>, WebpError>`
    — a **bare** §2.6 / §3.4 `VP8L` bitstream (image-header + image
    stream), **no** RIFF wrapper. `argb` is `width * height` packed ARGB
    (`(a<<24)|(r<<16)|(g<<8)|b`); the §3.4 `alpha_is_used` header bit is
    auto-detected.
  * `encode_vp8l_argb_with(argb, width, height, has_alpha)` — the fixed
    (non-RDO) form: `has_alpha` sets the header bit explicitly.
  * `encode_vp8l_argb_with_metadata(w, h, &argb, has_alpha, &meta) ->
    Result<Vec<u8>, WebpError>` — a complete `.webp`. Emits the simple
    `VP8L` layout when opaque and metadata-free, else auto-promotes to the
    §2.7 extended `VP8X` layout (`VP8X` + [`ICCP`] + `VP8L` + [`EXIF`] +
    [`XMP `], chunks in §2.7 order, flag octet declaring exactly the
    present features). Round-trips through `decode_webp`; embedded metadata
    reads back via `extract_metadata`.
  * `WebpMetadata<'a> { icc/exif/xmp: Option<&'a [u8]> }` (borrowed encode
    input, `::default()` = embed nothing) and
    `WebpMetadataOwned { icc/exif/xmp: Option<Vec<u8>> }` (owned,
    registry-side; `as_borrowed()` + `From<WebpMetadataOwned> for
    WebpFileMetadata`).
  * `pub const CODEC_ID_VP8L = "webp_vp8l"`.
* **Registry `webp_vp8l` encoder (dual-API).** `register` now also
  installs a VP8L encoder codec under `CODEC_ID_VP8L` (alongside a decoder
  for symmetry). It accepts `Rgba` / `Rgb24` input (the `Rgb24` path
  streams as fully opaque, no 3→4 expansion) and emits a `.webp` per
  frame. Direct factories `registry::make_encoder(&params)`,
  `registry::make_encoder_with_metadata(&params, WebpMetadataOwned)`, and
  the `VideoFrame`-flavoured `registry::encode_vp8l_frame(...)` keep the
  registry path + direct factory dual-API convention.
* **New tests.** `tests/published_encode_api.rs` (standalone, runs under
  `--no-default-features`): bare-bitstream shape, simple/extended layout
  selection, metadata embed + read-back, forced-alpha round trip,
  dimension-mismatch rejection. Plus in-crate unit tests for the bare
  encode helpers (`vp8l_encode`) and the registry encoder
  (round-trip RGBA, Rgb24-as-opaque, VP8X-on-metadata, NeedMore/Eof).

* **Clean-room round 116 (2026-05-24).** First step of restoring the
  **published-0.1.5 public decode API shape** so downstream consumers
  compile again (see `API-COMPAT.md`). New published-shape decode types
  (all available standalone, no `oxideav-core` dep):
  * `WebpImage { frames: Vec<WebpFrame>, metadata: WebpFileMetadata,
    anim_background_rgba: Option<[u8; 4]>, anim_loop_count: Option<u16> }`.
  * `WebpFrame { rgba: Vec<u8>, width: u32, height: u32, duration_ms: u32 }`
    — `rgba.len() == width * height * 4`, tightly packed `[R, G, B, A]`,
    no stride padding (drops straight into `image::ImageBuffer::from_raw`).
  * `WebpFileMetadata { icc: Option<Vec<u8>>, exif: Option<Vec<u8>>,
    xmp: Option<Vec<u8>> }`.
  * `WebpError { InvalidData, Unsupported, Eof, NeedMore }`, with
    `From<Error>` mapping the rich internal error onto the coarse
    published shape.

### Changed

* **`decode_webp` restored to the published shape.** It now returns
  `Result<WebpImage, WebpError>` (was the rebuild's own unpublished
  `Result<Vec<u8>, Error>`). Built on the already-rebuilt §4–§6 VP8L
  decoder: a simple/extended-lossless file yields a single-frame
  `WebpImage`. VP8 lossy and animation paths are reported
  `WebpError::Unsupported` (never faked) until those decoders are
  rebuilt. The flat-`Vec<u8>` behaviour is preserved via
  `decode_webp(..).frames[0].rgba`; the low-level
  `decode_webp_image -> DecodedWebp` and `decode_lossless_image` helpers
  are unchanged and remain as additional API.
* New `extract_metadata(bytes) -> Result<WebpFileMetadata, WebpError>` —
  metadata-only walk (ICC / Exif / XMP), decodes no pixels.
* New standalone integration test `tests/published_decode_api.rs`
  (runs under `--no-default-features`): builds an in-memory RGBA buffer,
  encodes via the VP8L lossless encoder, decodes via `decode_webp`, and
  asserts the round-tripped `WebpFrame.rgba` is byte-exact with
  `len == w * h * 4` — proving the flat `image`-crate buffer shape.

* **Clean-room round 115 (2026-05-24).** First **VP8L lossless encoder**.
  New `vp8l_encode` module (compiles standalone, no `oxideav-core` dep):
  * `encode_webp_lossless(rgba, width, height)` — encodes an interleaved
    8-bit RGBA image (`[R, G, B, A]` scan order, the `DecodedWebp::rgba`
    layout) to a complete RIFF/WEBP file carrying a §2.6 simple-lossless
    `VP8L` chunk. Re-exported at the crate root as
    `oxideav_webp::encode_webp_lossless`. The encoded file decodes back to
    the exact input bytes through `decode_webp` — a pixel-exact round trip.
  * Simplest spec-conformant path: §3.8.2 `optional-transform` = `%b0`
    (no transform / pass-through), §3.8.3 `color-cache-info` = `%b0`
    (no color cache), §3.7.2.2 `meta-prefix` = `%b0` (single prefix-code
    group), and a literal-only §3.8.3 image (every pixel a §3.7.3 ARGB
    literal, no LZ77 backward references). The distance prefix code (#5)
    is the §3.7.2.1.1 single-symbol-0 form ("empty prefix codes can be
    coded as those containing a single symbol 0").
  * §3.7.2 canonical prefix-code construction: per-channel symbol
    frequencies → length-limited (≤ 15-bit) Huffman code lengths
    (`build_code_lengths`, min-heap build + length-limiting rebalance) →
    `(length, value)`-ordered canonical codes (`canonical_codes`) — the
    identical assignment the round-104 `vp8l_prefix::PrefixCode` reader
    consumes. Code lengths are written with the §3.7.2.1.2 *normal code
    length code* (or the trivial single-leaf form for constant channels).
  * `BitWriter` — the LSB-first inverse of `vp8l_stream::BitReader`.
  * `EncodeError` (`PixelBufferMismatch` / `InvalidDimensions` / `Build`)
    with a `From<EncodeError>` into the crate-wide `Error`.
  * 15 unit tests + 4 integration round trips: encode→decode is pixel-exact
    on synthetic 1×1 / gradient / solid / 16×16-pseudo-random images and on
    the real `lossless-1x1`, `lossless-32x32-rgba`, and
    `lossless-color-indexing-paletted` fixtures (decoded by the independent
    decode path, re-encoded, re-decoded, compared byte-for-byte).
  * Encoder scope is decode-only-validated for now: no §3.8.2 transform
    encoding, no LZ77 / color-cache compression. Files are larger than a
    libwebp-encoded equivalent but spec-valid and round-trip-exact.

* **Clean-room round 112 (2026-05-24).** The codec is now registered into
  `oxideav_core::RuntimeContext` — `register()` is no longer a no-op. New
  `registry` module (gated behind the default-on `registry` feature):
  * `registry::WebpDecoder` — an `oxideav_core::Decoder` impl over
    `decode_webp_image`. Each `send_packet` carries one whole
    `RIFF/WEBP` file; `receive_frame` returns a single-planar
    `Frame::Video` of interleaved 8-bit RGBA (`PixelFormat::Rgba`,
    stride `width * 4`). Covers §2.6 / §3.4 `VP8L` lossless (simple or
    `VP8X`-extended) with optional §2.7.1.2 `ALPH`-over-`VP8L` alpha
    override. A §2.5 `VP8 ` lossy file, and any animation / header-only
    file with no `VP8L`/`VP8 ` image-data chunk, surface as
    `oxideav_core::Error::Unsupported` (lossy callers route the chunk
    via `extract_lossy_chunk`).
  * `register()` / `registry::register_codecs` install one `CodecInfo`
    under the `webp` codec id with the decoder factory and a `WEBP`
    FourCC tag claim; `registry::register_containers` installs the
    `.webp` file-extension hint. No encoder factory is registered.
  * The decoder's `CodecParameters` carry the decoded `width` /
    `height` / `PixelFormat::Rgba` after the first `receive_frame`
    (read via `WebpDecoder::params`).
  * `registry::decode_webp_to_frame(bytes, pts)` — a direct
    `VideoFrame`-flavoured wrapper around `decode_webp_image`.
  * `From<Error> for oxideav_core::Error` — `Unsupported` maps to the
    core `Unsupported`; every other variant flows through `InvalidData`
    carrying the sub-module's `Display` text.
  * 10 unit tests in `registry::tests` cover the RuntimeContext install,
    FourCC resolution, an end-to-end lossless decode through the
    registered factory, the `VP8 ` lossy `Unsupported` refusal, the
    params dim/format surfacing, the one-packet/one-frame contract, the
    post-flush `Eof`, and the error conversion.

* **Clean-room round 111 (2026-05-24).** Top-level still-image decode is
  wired up — `decode_webp` no longer returns `NotImplemented` for the
  cases the crate can decode. New surface:
  * `decode_webp_image(bytes) -> DecodedWebp` — walks the `RIFF/WEBP`
    container, decodes a §2.6 / §3.4 `VP8L` lossless image (simple **or**
    `VP8X`-extended) through the full §4–§6 chain, and returns the
    `DecodedWebp { width, height, rgba }` struct. `rgba` is
    `width*height*4` interleaved `[R, G, B, A]` bytes in scan order — the
    `oxideav_core::PixelFormat::Rgba` layout the workspace's image crates
    share. When a (spec-discouraged, per §2.7.1.2 "SHOULD NOT") `ALPH`
    chunk accompanies the `VP8L` image, its decoded alpha plane overrides
    the per-pixel alpha.
  * `decode_webp(bytes) -> Vec<u8>` — the flat-buffer shorthand: same
    decode, returns just the packed RGBA bytes.
  * `Error::Unsupported(UnsupportedKind)` — a §2.5 `VP8 ` lossy file is a
    clean `Unsupported(LossyVp8)` (route it onward with
    `extract_lossy_chunk`); a file with no `VP8L`/`VP8 ` image-data chunk
    (animation / header-only) is `Unsupported(NoImageData)`. Lossy is
    **not** stub-decoded.
  * End-to-end tests decode the `lossless-1x1`,
    `lossless-color-indexing-paletted`, and `lossless-32x32-rgba`
    fixtures all the way to RGBA (dims + pixel spot-checks against the
    round-109 ARGB ground truth, including the RGBA alpha-channel
    repack), a synthesized `VP8X`+`VP8L` extended file, and a
    hand-assembled `VP8X`+`VP8L`+`ALPH` file proving the `ALPH` alpha
    override.

* **Clean-room round 110 (2026-05-24).** §2.7.1.2 `ALPH` alpha-channel
  bitstream decode — the alpha plane is now produced end-to-end. New
  surface in `alph`:
  * `alph::decode_alpha(payload, width, height)` — decodes a whole
    `ALPH` chunk payload to a `width * height` plane of 8-bit alpha
    values. Covers both compression methods: method 0 (raw 8-bit
    values, length `width*height`) and method 1 (a *headerless* §3 VP8L
    image-stream of implicit dimensions, decoded via the new
    `vp8l_transform::decode_lossless_headerless`, with the alpha lifted
    from the **green** channel per §2.7.1.2). Then applies the
    §2.7.1.2 inverse filter — none / horizontal (A) / vertical (B) /
    gradient (`clip(A+B-C)`) — as `alpha = (predictor + X) % 256`, with
    the documented top-left (predictor 0), left-most (use pixel above),
    and top-most (use pixel left) edge cases.
  * `decode_alpha_plane(bytes)` — container-level entry point: walks the
    `RIFF/WEBP` file, takes the alpha-plane dimensions from the `VP8X`
    canvas (or the `VP8 ` keyframe header when no `VP8X` is present),
    locates the `ALPH` chunk, and decodes. Returns `Ok(None)` when the
    file carries no `ALPH` chunk.
  * `AlphError` gained `DimensionsOverflow`, `RawLengthMismatch`,
    `UnsupportedCompression`, and `Vp8l` variants.
  * `vp8l_transform::decode_lossless_headerless(payload, width, height)`
    — the headerless §3 image-stream decode (no 5-byte image header)
    that the compressed alpha path reuses; the existing
    `decode_lossless` now delegates to a shared driver.
  * Verified bit-exact against the black-box `dwebp -alpha` validator on
    the `lossy-with-alpha-128x128` fixture (all 16384 alpha bytes
    identical); filter inverses are unit-tested against hand-computed
    §2.7.1.2 vectors for all four methods.

* **Clean-room round 109 (2026-05-24).** VP8L §4 inverse-transform
  passes — the layer that consumes round-108's `decode_argb` ARGB buffer
  and produces final pixels, closing the lossless decode path
  end-to-end. New module `vp8l_transform` exposes:
  * `vp8l_transform::decode_lossless(payload, width, height)` — the
    top-level driver. Reads the §4 / §7.2 `optional-transform` list
    (each transform's fixed fields **and** its §5-encoded
    `entropy-coded-image` body), tracks §4.4 width subsampling, decodes
    the main §5.1 ARGB image at the (subsampled) width via `decode_argb`,
    then applies the inverse transforms in reverse read order (§4: "last
    one first").
  * `vp8l_transform::inverse_predictor` — §4.1: 14 prediction modes
    (`Average2` / `Select` / `ClampAddSubtractFull` /
    `ClampAddSubtractHalf`) over the TL/T/TR/L block grid, with the
    border rules (top-left → `0xff000000`, top row → L, left column → T,
    rightmost column uses the row's leftmost pixel as TR) and the
    per-channel residual add.
  * `vp8l_transform::inverse_color` — §4.2: per-block
    `ColorTransformElement` add-back (`ColorTransformDelta(t,c) =
    (t*c) >> 5` with signed-8-bit `t`/`c`), green→red / green→blue /
    red→blue, on the red and blue channels only.
  * `vp8l_transform::inverse_subtract_green` — §4.3: add green into red
    and blue (`& 0xff`).
  * `vp8l_transform::inverse_color_table` (§4.4 subtraction-decode of the
    palette) + `vp8l_transform::inverse_color_indexing` (palette lookup;
    ≤16-color pixel un-bundling of 2/4/8 indices per green byte; the
    width un-subsample back to the canvas width; out-of-range indices →
    transparent black `0x00000000`).
  * `vp8l_decode::decode_entropy_coded_image(reader, width, height)` —
    a generalized §7.3 `entropy-coded-image` decoder (color-cache-info +
    one prefix-code group + §5.2 data, no meta-prefix layer) used to
    decode each transform's sub-resolution body. `decode_entropy_image`
    now delegates to it.
  * `vp8l_decode::DecodedImage::pixels_mut` / `from_parts` (used by the
    in-place inverse passes and the color-indexing re-size) and a new
    `DecodeError::DuplicateTransform` variant.
  * `decode_lossless_image(bytes)` — container-level entry point: walks
    the file, extracts the `VP8L` chunk, and decodes it to a
    `DecodedImage`. Returns `Ok(None)` for `VP8 `-only files.
* 18 new unit tests in `vp8l_transform::tests` (each predictor
  primitive; predictor border rules for the top-left / top-row / left-
  column cases; the §4.2 signed delta + forward↔inverse round-trip + in-
  place block use; §4.3 green add-back with wrap; §4.4 subtraction
  decode + no-bundling lookup + out-of-range → transparent black +
  width_bits-1/3 bundling + the threshold table) + 4 integration tests
  in `fixture_walks` that decode three real fixtures *bit-exactly*
  against their `expected.png` ARGB ground truth:
  * `round109_lossless_1x1_color_indexing_decodes_end_to_end` →
    `0xFFB43C5A`.
  * `round109_lossless_color_indexing_paletted_decodes_end_to_end`
    (32×32, 8-color palette, width_bits=1 bundling).
  * `round109_lossless_32x32_rgba_full_transform_chain_decodes_end_to_end`
    (SUBTRACT_GREEN + PREDICTOR + CROSS_COLOR + level-1 color cache,
    real alpha).
  * `round109_decode_lossless_image_returns_none_for_lossy_file`.
  New in-crate fixture `tests/data/lossless-color-indexing-paletted.webp`
  (byte-for-byte copy of the docs corpus). Test count: **229** (was
  207).
* The decoder is **standalone-friendly** — `vp8l_transform` compiles
  under `--no-default-features` with no `oxideav-core` dependency.

### Notes (round 109)

The VP8L lossless decode path is now **complete end-to-end**: container
walk → §4 transform list (with bodies) → §5/§6 entropy decode → §4
inverse-transform chain → final ARGB pixels, validated bit-exact on the
`lossless-1x1`, `lossless-color-indexing-paletted`, and
`lossless-32x32-rgba` fixtures. `decode_webp` itself still returns
`Error::NotImplemented` (it would need ARGB→output-format packing +
the VP8 lossy + ALPH alpha paths); callers wanting lossless pixels use
`decode_lossless_image`.

* **Clean-room round 108 (2026-05-24).** VP8L §6.2.2 entropy-image
  multi-group ARGB decode — the piece that turns the round-106
  meta-prefix dispatch and the round-107 single-group §5.2 loop into a
  full multi-group ARGB decode. New `vp8l_decode` surface:
  * `vp8l_decode::decode_argb(reader, width, height)` — the full
    ARGB-role decode. Reads the round-106 `MetaPrefixHeader` for the
    `Argb` role and dispatches: `meta-prefix = %b0` runs the
    single-group `decode_image` path; `meta-prefix = %b1` decodes the
    §6.2.2 entropy image, derives `num_prefix_groups = max(entropy
    image) + 1`, reads that many `PrefixCodeGroup`s, and runs the
    §6.2.3 loop selecting a group per pixel block.
  * `vp8l_decode::decode_entropy_image(reader, prefix_bits,
    prefix_image_width, prefix_image_height)` — decodes the §6.2.2
    entropy image (itself a §5 `entropy-coded-image`