### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-26
+
+### Other
+
+- drop decorative attribution from round-154 module banner
+- round 154 — published §2.5 VP8 lossy encode entry points
+- round 152 — histogram-distance per-region clusterer
+- round 151 — §6.2.2 multi-meta-prefix encoder
+- round 150 — §4.4 color-indexing forward pass
+- round 149 — §3.7.2.1.1 simple code length code chooser
+- round 148 — §5.2.3 color_cache_code_bits sweep
+- round 147 — §3.5.2 / §4.2 color-transform forward pass
+- round 146 — §4.1 spatial-predictor forward transform
+- round 145 — §2.7 metadata-aware container writer
+- round 130 — §5.2.2 width-aware distance-code chooser
+- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
+- wire lossy decode against published DecodeError (not unpublished Vp8Error)
+- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
+- §5.2.1 / §5.2.3 color-cache writer (round 121)
+- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
+- §5.2.2 LZ77 backward-reference matching (round 119)
+- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
+- round 117 — restore published VP8L lossless-encode public names
+- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
+- add API-COMPAT.md — public API shape the rebuild must reproduce
+- round 115 — first VP8L lossless encoder (literal-only round trip)
+- register oxideav_core::Decoder into RuntimeContext (round 112)
+- wire top-level decode_webp to RGBA for VP8L (round 111)
+- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
+- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
+- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
+- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
+- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
+- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
+- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
+- round 7: typed §2.6 `VP8L` chunk routing handle
+- round 6: typed §2.5 `VP8 ` chunk routing handle
+- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
+- round 4: ANMF §2.7.1.1 typed per-frame header parse
+- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
+- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
+- in-crate copies of fixture inputs for standalone CI checkout
+- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
+- orphan rebuild: clean-room scaffold post 2026-05-20 audit
+
 ### Added
 
 * **Clean-room round 154 (2026-05-26).** Published-shape §2.5 `VP8 ` lossy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ### Added
 
+* **Clean-room round 154 (2026-05-26).** Published-shape §2.5 `VP8 ` lossy
+  encode entry points landed, completing the `API-COMPAT.md` four-pixel-
+  layout surface (`encode_vp8_lossy_yuv420p` / `_yuva420p` / `_rgba` /
+  `_rgb24`) plus the `CODEC_ID_VP8` registry-ID constant. All four route
+  through the `oxideav-vp8` sibling crate's `encode_keyframe` driver and
+  wrap the emitted VP8 bitstream into a complete `.webp` file: simple
+  layout (`RIFF` + `VP8 `) when no alpha plane is present and the
+  `WebpMetadata` is empty; extended layout (`RIFF` + `VP8X` + `ICCP?` +
+  `ALPH?` + `VP8 ` + `EXIF?` + `XMP ?`) otherwise. The `ALPH` chunk is
+  emitted in §2.7.1.2 method-0 (raw, no filter) form (one `0x00` info
+  byte followed by `width * height` raw alpha bytes), interoperable with
+  the existing `decode_alpha_plane` round-trip. RGB/RGBA inputs are
+  converted to a tightly-packed I420 source via the full-range
+  ITU-R BT.601 forward matrix — the inverse of the §2.5 decode path's
+  YCbCr→RGB conversion — with 2×2 box-averaged chroma. The
+  published-shape `quality: f32` knob in `0..=100.0` (default 75.0)
+  maps to RFC 6386 §9.6's `y_ac_qi: u8` in `0..=127` via the linear
+  inversion `qi = round(127 * (1 - q / 100))`, so `quality = 75` lands
+  on the `KeyframeParams::default()` `y_ac_qi = 32`. The RGBA path
+  auto-promotes to the extended `ALPH`-bearing layout iff any pixel's
+  alpha is non-opaque; the Rgb24 path is always treated as opaque per
+  the published 0.1.5 contract. Nine standalone integration tests
+  (`tests/published_vp8_lossy_encode_api.rs`) plus ten in-module unit
+  tests cover the layout-promotion rules, the alpha plane round-trip,
+  the simple/extended decision, the I420 chroma down-sample arithmetic,
+  the NaN/clamp behaviour on `quality`, and the dimension-mismatch
+  refusals. Spec sources consulted: RFC 9649 (WebP container) §2.5,
+  §2.7, §2.7.1.2 mirrored under `docs/image/webp/`; RFC 6386 (VP8)
+  §9.1, §9.2, §9.6; ITU-R BT.601 (full-range forward matrix). No
+  external implementation source was consulted.
+
 * **Clean-room round 152 (2026-05-26).** Histogram-distance per-region
   clusterer for the §6.2.2 multi-meta-prefix encoder, replacing the
   round-151 mean-green bucketiser. The new

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,65 @@
 
 Pure-Rust WebP image codec (RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF).
 
+## Status — 2026-05-26 (clean-room round 154)
+
+**Round 154 lands the published-shape §2.5 `VP8 ` lossy encode surface
+from `API-COMPAT.md`.** Four entry points
+([`encode_vp8_lossy_yuv420p`](src/vp8_encode.rs),
+[`encode_vp8_lossy_yuva420p`](src/vp8_encode.rs),
+[`encode_vp8_lossy_rgba`](src/vp8_encode.rs),
+[`encode_vp8_lossy_rgb24`](src/vp8_encode.rs)) plus the registry
+[`CODEC_ID_VP8`](src/lib.rs) constant. All four route through the
+`oxideav-vp8` sibling crate's `encode_keyframe` driver (single-keyframe
+RD intra mode pick) and wrap the emitted VP8 bitstream into a complete
+`.webp` file via the existing §2.7 chunk builders:
+
+* **Simple layout** (`RIFF` + `VP8 `) when no alpha plane is supplied
+  and the supplied `WebpMetadata` is empty.
+* **Extended layout** (`RIFF` + `VP8X` + `ICCP?` + `ALPH?` + `VP8 ` +
+  `EXIF?` + `XMP ?`) when metadata is present or alpha is non-opaque.
+  The `VP8X` flag byte declares exactly the features present (`L` for
+  alpha, `I` for ICC, `E` for Exif, `X` for XMP).
+
+The §2.7.1.2 `ALPH` chunk is emitted in method-0 (raw, no filter) form
+— one `0x00` info byte followed by `width * height` raw alpha bytes —
+which the existing `decode_alpha_plane` reader round-trips byte-for-
+byte. RGB/RGBA inputs are converted to a tightly-packed I420 source
+via the full-range ITU-R BT.601 forward matrix (the inverse of the
+§2.5 decode path's YCbCr→RGB conversion, so encode + decode share a
+single colourspace model), with 2×2 box-averaged chroma at the chroma-
+plane boundary.
+
+The published-shape `quality: f32` knob in `0..=100.0` (default 75.0,
+higher = better) maps to RFC 6386 §9.6's `y_ac_qi: u8` in `0..=127`
+via the linear inversion `qi = round(127 * (1 - q / 100))`, so
+`quality = 75` lands on `KeyframeParams::default()` `y_ac_qi = 32`.
+NaN inputs fall back to the default; out-of-range values clamp into
+the table.
+
+Nine standalone integration tests
+([`tests/published_vp8_lossy_encode_api.rs`](tests/published_vp8_lossy_encode_api.rs))
+plus ten in-module unit tests cover layout promotion (simple →
+extended on alpha / metadata), the §2.7.1.2 `ALPH` round trip, the
+I420 chroma down-sample arithmetic on grey content, the
+`quality_to_qindex` mapping at the bounds and default, the
+dimension-mismatch refusals, and the published `CODEC_ID_VP8` /
+`CODEC_ID_VP8L` constants. Build is green on default features and on
+`--no-default-features` (the standalone surface ships these without
+`oxideav-core`).
+
+Spec sources consulted: RFC 9649 (WebP container) §2.5, §2.7,
+§2.7.1.2; RFC 6386 (VP8) §9.1, §9.2, §9.6; ITU-R BT.601 (full-range
+forward matrix). No external implementation source was consulted.
+
+Still lacks (post-round-154): all four entry points pick the
+`KeyframeParams::default()` loop-filter level (0 = whole-frame skip)
+and 1-partition layout; tuning these against quality / fixture-size
+trade-offs is the natural follow-up. VP8 lossy *animation* (ANMF + VP8
+sub-chunks) remains gated on a multi-frame encode driver; the
+`build_animated_webp` `Auto` / `Delta` paths still return
+`WebpError::Unsupported` for non-VP8L modes pending that work.
+
 ## Status — 2026-05-26 (clean-room round 152)
 
 **Round 152 swapped the round-151 mean-green bucketiser inside the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ pub mod meta_prefix;
 pub mod registry;
 pub mod vp8_chunk;
 pub mod vp8_decode;
+pub mod vp8_encode;
 pub mod vp8l_chunk;
 pub mod vp8l_decode;
 pub mod vp8l_encode;
@@ -1434,9 +1435,30 @@ pub use anim_encode::{
     AnimFrameMode, DeltaConfig, DownsampleKernel,
 };
 
+// ─────────────────────── Published-shape VP8 lossy encode API ───────────────────────
+//
+// The published-0.1.5 lossy-encode public names, layered over the `oxideav-vp8`
+// sibling crate's `encode_keyframe`. Four entry points, accepting the four
+// pixel layouts API-COMPAT.md names: I420 (planar `yuv420p`), I420 + alpha
+// (`yuva420p`), interleaved RGBA, and interleaved RGB24. All accept a libwebp-
+// style `quality: f32` in `0..=100.0` (default 75.0) and the same
+// `WebpMetadata` borrowed-form the VP8L `_with_metadata` path consumes.
+// See `API-COMPAT.md` + `vp8_encode` module docs.
+
+#[doc(inline)]
+pub use vp8_encode::{
+    encode_vp8_lossy_rgb24, encode_vp8_lossy_rgba, encode_vp8_lossy_yuv420p,
+    encode_vp8_lossy_yuva420p, DEFAULT_QUALITY,
+};
+
 /// Stable codec identifier the VP8L lossless encoder registers under in the
 /// codec registry — the published `"webp_vp8l"` name.
 pub const CODEC_ID_VP8L: &str = "webp_vp8l";
+
+/// Stable codec identifier the VP8 lossy encoder registers under in the
+/// codec registry — the published `"webp_vp8"` name. Symmetric with
+/// [`CODEC_ID_VP8L`] for the lossless path.
+pub const CODEC_ID_VP8: &str = "webp_vp8";
 
 /// Repack a scan-line-order ARGB pixel buffer (`(a<<24)|(r<<16)|(g<<8)|b`)
 /// into interleaved 8-bit `[R, G, B, A]` bytes — the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1440,8 +1440,8 @@ pub use anim_encode::{
 // The published-0.1.5 lossy-encode public names, layered over the `oxideav-vp8`
 // sibling crate's `encode_keyframe`. Four entry points, accepting the four
 // pixel layouts API-COMPAT.md names: I420 (planar `yuv420p`), I420 + alpha
-// (`yuva420p`), interleaved RGBA, and interleaved RGB24. All accept a libwebp-
-// style `quality: f32` in `0..=100.0` (default 75.0) and the same
+// (`yuva420p`), interleaved RGBA, and interleaved RGB24. All accept a
+// published-shape `quality: f32` in `0..=100.0` (default 75.0) and the same
 // `WebpMetadata` borrowed-form the VP8L `_with_metadata` path consumes.
 // See `API-COMPAT.md` + `vp8_encode` module docs.
 

--- a/src/vp8_encode.rs
+++ b/src/vp8_encode.rs
@@ -1,0 +1,632 @@
+//! Published-shape §2.5 `VP8 ` lossy encode entry points — the
+//! `encode_vp8_lossy_yuv420p` / `_yuva420p` / `_rgba` / `_rgb24` surface
+//! described in `API-COMPAT.md`, routed through the `oxideav-vp8` sibling
+//! crate's [`oxideav_vp8::encode_keyframe`] driver.
+//!
+//! These functions wrap a single-keyframe VP8 bitstream into a complete
+//! `.webp` file. Three §2.7 layouts are emitted:
+//!
+//! * **Simple lossy** (`RIFF` + `VP8 `) — when no alpha plane is supplied
+//!   and the [`WebpMetadata`] is empty.
+//! * **Extended lossy** (`RIFF` + `VP8X` + `ICCP?` + `VP8 ` + `EXIF?` +
+//!   `XMP ?`) — when ICC / Exif / XMP metadata is present (still no
+//!   alpha).
+//! * **Extended lossy + alpha** (`RIFF` + `VP8X` + `ICCP?` + `ALPH` +
+//!   `VP8 ` + `EXIF?` + `XMP ?`) — when the input carries a per-pixel
+//!   alpha plane. The `VP8X` flag byte declares the `L` (alpha) bit; the
+//!   `ALPH` chunk is emitted in §2.7.1.2 *method 0* (raw, uncompressed)
+//!   form with the *None* filter — one byte of info (`0x00`) followed by
+//!   `width * height` raw alpha bytes.
+//!
+//! ### Quality → quantiser mapping
+//!
+//! All four entry points take a published-shape `quality: f32` in
+//! `0.0..=100.0` (default 75.0) — higher is better. RFC 6386 §9.6's
+//! `y_ac_qi` runs the other way (`0..=127`, lower is better), so the
+//! mapping is the linear inversion
+//!
+//! ```text
+//!   q   = clamp(quality, 0, 100)
+//!   qi  = round(127 * (1 - q / 100))
+//! ```
+//!
+//! Special-cased so `quality = 100` lands at the minimum-quantiser
+//! `y_ac_qi = 0` and `quality = 0` lands at the maximum `y_ac_qi = 127`,
+//! with `quality = 75` ≈ `y_ac_qi = 32` (the [`KeyframeParams`] default).
+//!
+//! ### Colourspace conversion (RGB / RGBA entry points)
+//!
+//! The RGB / RGBA paths convert the source bytes to a tightly-packed
+//! I420 plane in scan-line order via the **full-range ITU-R BT.601**
+//! forward matrix (the inverse of the matrix the §2.5 decode path uses
+//! to convert YCbCr back to RGB — see [`crate::vp8_decode`]). RFC 6386
+//! §9.2 / RFC 9649 §10 specify BT.601 as VP8's colourspace; the full-
+//! range (no 16..235 luma head-room) form matches the decode-side
+//! conversion so a round-trip is consistent.
+//!
+//! Chroma subsampling is 4:2:0 with **2×2 box averaging** at the chroma-
+//! plane boundaries: each chroma sample averages the four (or fewer, on
+//! a partial right / bottom row) luma-resolution Cb / Cr values that
+//! cover its 2×2 footprint. This is the encode-side mirror of the
+//! decode-side §9.2 nearest-neighbour upsample (the encoder picks a
+//! reasonable downsample; the decoder's upsample is fixed by RFC 6386).
+//!
+//! Spec sources consulted: RFC 9649 (WebP container) §2.5, §2.7,
+//! §2.7.1.2; RFC 6386 (VP8) §9.1, §9.2, §9.6; ITU-R BT.601.
+
+use crate::{build, container, Error, WebpError, WebpMetadata};
+
+// `Error` is used inside `frame_lossy` to convert `build::BuildError` into
+// the published `WebpError`.
+use oxideav_vp8::{encode_keyframe, EncodeError, I420Frame, KeyframeParams};
+
+/// Default published-shape quality knob the entry points fall back to when
+/// the caller passes a sentinel out-of-range value. Matches the
+/// published-0.1.5 default of `75.0`.
+pub const DEFAULT_QUALITY: f32 = 75.0;
+
+/// Map a published-shape `quality: f32` in `0..=100` onto RFC 6386 §9.6's
+/// `y_ac_qi: u8` in `0..=127` (lower = better).
+///
+/// `NaN` or out-of-range inputs fall back to [`DEFAULT_QUALITY`].
+fn quality_to_qindex(quality: f32) -> u8 {
+    let q = if quality.is_nan() {
+        DEFAULT_QUALITY
+    } else {
+        quality.clamp(0.0, 100.0)
+    };
+    // 0..=100 (good) → 127..=0 (bad). The rounding is round-half-to-even
+    // via `(x + 0.5).floor()`; `0` → 127, `100` → 0, `75` → 32.
+    let qi = (127.0 * (1.0 - q / 100.0)) + 0.5;
+    qi.clamp(0.0, 127.0) as u8
+}
+
+/// Map an `oxideav-vp8` encode failure onto the coarse [`WebpError`].
+///
+/// Every encoder-side failure (a malformed input dimension, an out-of-
+/// range quantiser, a token-emit refusal …) collapses to
+/// [`WebpError::InvalidData`] — the caller-facing shape only distinguishes
+/// "the input was rejected" from "this build does not support the feature".
+impl From<EncodeError> for WebpError {
+    fn from(_: EncodeError) -> Self {
+        WebpError::InvalidData
+    }
+}
+
+/// Encode a complete `.webp` file from a packed I420 source.
+///
+/// `y` is `width * height` luma bytes, scan-line order. `u` and `v` are
+/// each `((width + 1) / 2) * ((height + 1) / 2)` chroma bytes (4:2:0).
+/// `quality` is the published-shape `0..=100` knob; values outside the
+/// range are clamped, `NaN` falls back to [`DEFAULT_QUALITY`].
+///
+/// The output layout depends on whether `meta` is empty:
+///
+/// * Empty `meta` → simple `RIFF` + `VP8 ` (no `VP8X` chunk).
+/// * Non-empty `meta` → extended `RIFF` + `VP8X` + `ICCP?` + `VP8 ` +
+///   `EXIF?` + `XMP ?`. The `VP8X` canvas dimensions match `width`/
+///   `height`; the bitstream's own §9.1 dimensions are also `width`/
+///   `height`.
+pub fn encode_vp8_lossy_yuv420p(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+    quality: f32,
+    meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let bitstream = encode_vp8_keyframe_packed(width, height, y, u, v, quality)?;
+    frame_lossy(width, height, &bitstream, None, meta)
+}
+
+/// Encode a complete `.webp` file from a packed I420 source plus a
+/// separate per-pixel alpha plane.
+///
+/// `alpha` is `width * height` bytes in scan-line order — the same shape
+/// the §2.7.1.2 `ALPH` decode path produces. The output is always the
+/// extended `VP8X` layout with the `L` (alpha) flag set; the alpha plane
+/// is emitted as a raw (method-0, no-filter) §2.7.1.2 `ALPH` chunk
+/// preceding the `VP8 ` chunk.
+///
+/// VP8 itself carries no alpha; the alpha plane lives in a separate chunk
+/// per RFC 9649 §2.7.1.2 — see [`crate::alph::decode_alpha`] for the
+/// inverse path.
+///
+/// The argument count matches the published 0.1.5 shape (eight: width,
+/// height, three planes, alpha, quality, metadata); the
+/// `too_many_arguments` lint is allowed at the published surface boundary.
+#[allow(clippy::too_many_arguments)]
+pub fn encode_vp8_lossy_yuva420p(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+    alpha: &[u8],
+    quality: f32,
+    meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let n = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or(WebpError::InvalidData)?;
+    if alpha.len() != n {
+        return Err(WebpError::InvalidData);
+    }
+    let bitstream = encode_vp8_keyframe_packed(width, height, y, u, v, quality)?;
+    frame_lossy(width, height, &bitstream, Some(alpha), meta)
+}
+
+/// Encode a complete `.webp` file from interleaved RGBA bytes.
+///
+/// `rgba` is `width * height * 4` bytes in scan-line order — the
+/// `oxideav_core::PixelFormat::Rgba` layout the workspace's image crates
+/// share, and the exact buffer
+/// `image::ImageBuffer<Rgba<u8>, Vec<u8>>` exposes via
+/// [`image::ImageBuffer::into_raw`]. The conversion is
+/// full-range BT.601 (R/G/B → Y/Cb/Cr) with 2×2 box-averaged chroma.
+///
+/// If any pixel's alpha differs from `0xff`, the alpha plane is emitted
+/// alongside the VP8 bitstream in a §2.7.1.2 `ALPH` chunk (method 0, no
+/// filter) — see [`encode_vp8_lossy_yuva420p`]. An all-opaque image
+/// emits the same simple / extended layout
+/// [`encode_vp8_lossy_yuv420p`] would.
+///
+/// [`image::ImageBuffer<Rgba<u8>, Vec<u8>>`]: https://docs.rs/image/
+/// [`image::ImageBuffer::into_raw`]: https://docs.rs/image/
+pub fn encode_vp8_lossy_rgba(
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+    quality: f32,
+    meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let (n, _stride4) = check_rgba_dimensions(width, height, rgba.len(), 4)?;
+    let (y, u, v) = rgba_planes_to_i420(width, height, rgba, 4);
+    // Scan the alpha channel for non-opaque pixels; if any exist, attach
+    // an ALPH chunk. Most RGB-sourced photographic content is fully
+    // opaque so the common case stays on the simple / extended-no-alpha
+    // shape.
+    let alpha = (0..n).map(|i| rgba[i * 4 + 3]).collect::<Vec<u8>>();
+    let has_alpha = alpha.iter().any(|&a| a != 0xff);
+
+    let bitstream = encode_vp8_keyframe_packed(width, height, &y, &u, &v, quality)?;
+    let alpha_slice = if has_alpha {
+        Some(alpha.as_slice())
+    } else {
+        None
+    };
+    frame_lossy(width, height, &bitstream, alpha_slice, meta)
+}
+
+/// Encode a complete `.webp` file from interleaved RGB24 bytes
+/// (3 bytes per pixel — no alpha channel).
+///
+/// `rgb` is `width * height * 3` bytes in scan-line order — the
+/// `image::ImageBuffer<Rgb<u8>, Vec<u8>>` backing buffer. The output is
+/// always treated as opaque (no `ALPH` chunk, no `VP8X` alpha flag), per
+/// the published 0.1.5 contract that `Rgb24` inputs map to the simple
+/// layout. The simple / extended choice still keys on `meta` so a caller
+/// that wants ICC / Exif / XMP metadata still pays a `VP8X` chunk.
+pub fn encode_vp8_lossy_rgb24(
+    width: u32,
+    height: u32,
+    rgb: &[u8],
+    quality: f32,
+    meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let (_n, _stride3) = check_rgba_dimensions(width, height, rgb.len(), 3)?;
+    let (y, u, v) = rgba_planes_to_i420(width, height, rgb, 3);
+    let bitstream = encode_vp8_keyframe_packed(width, height, &y, &u, &v, quality)?;
+    frame_lossy(width, height, &bitstream, None, meta)
+}
+
+// ─────────────────────── internals ───────────────────────
+
+/// Validate the buffer length matches `width * height * channels` and
+/// return `(pixel_count, row_stride_bytes)`.
+fn check_rgba_dimensions(
+    width: u32,
+    height: u32,
+    buf_len: usize,
+    channels: usize,
+) -> Result<(usize, usize), WebpError> {
+    if width == 0 || height == 0 {
+        return Err(WebpError::InvalidData);
+    }
+    let n = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or(WebpError::InvalidData)?;
+    let expected = n.checked_mul(channels).ok_or(WebpError::InvalidData)?;
+    if buf_len != expected {
+        return Err(WebpError::InvalidData);
+    }
+    let stride = (width as usize)
+        .checked_mul(channels)
+        .ok_or(WebpError::InvalidData)?;
+    Ok((n, stride))
+}
+
+/// Convert an interleaved RGB(A) buffer to a tightly-packed I420 set of
+/// planes via the full-range ITU-R BT.601 forward matrix.
+///
+/// `channels` is 3 (RGB24) or 4 (RGBA). Alpha bytes (if any) are dropped
+/// by the caller via a separate scan.
+fn rgba_planes_to_i420(
+    width: u32,
+    height: u32,
+    pixels: &[u8],
+    channels: usize,
+) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let w = width as usize;
+    let h = height as usize;
+    let cw = w.div_ceil(2);
+    let ch = h.div_ceil(2);
+
+    let mut y_plane = vec![0u8; w * h];
+    // Accumulate 2×2-block Cb / Cr sums in i32 then average; the count
+    // covers partial-row boundaries (1 / 2 / 4 samples per block).
+    let mut u_sum = vec![0i32; cw * ch];
+    let mut v_sum = vec![0i32; cw * ch];
+    let mut count = vec![0u32; cw * ch];
+
+    for py in 0..h {
+        for px in 0..w {
+            let idx = py * w + px;
+            let off = idx * channels;
+            let r = pixels[off] as i32;
+            let g = pixels[off + 1] as i32;
+            let b = pixels[off + 2] as i32;
+
+            // BT.601 full-range forward (Q16):
+            //   Y  =  0.299    R + 0.587    G + 0.114    B
+            //   Cb = -0.168736 R - 0.331264 G + 0.5      B + 128
+            //   Cr =  0.5      R - 0.418688 G - 0.081312 B + 128
+            //
+            // Q16 coefficients:
+            //   0.299    -> 19595
+            //   0.587    -> 38470
+            //   0.114    -> 7471      (sum = 65536 = 1.0)
+            //   0.168736 -> 11059
+            //   0.331264 -> 21709
+            //   0.5      -> 32768     (sum = 65536 = 1.0)
+            //   0.418688 -> 27439
+            //   0.081312 -> 5329      (sum = 65536 = 1.0)
+            const HALF: i32 = 1 << 15;
+            let yi = (19_595 * r + 38_470 * g + 7_471 * b + HALF) >> 16;
+            let cb = (-11_059 * r - 21_709 * g + 32_768 * b + HALF) >> 16;
+            let cr = (32_768 * r - 27_439 * g - 5_329 * b + HALF) >> 16;
+
+            y_plane[idx] = yi.clamp(0, 255) as u8;
+            let cbi = (cb + 128).clamp(0, 255);
+            let cri = (cr + 128).clamp(0, 255);
+
+            let cx = px / 2;
+            let cy = py / 2;
+            let cidx = cy * cw + cx;
+            u_sum[cidx] += cbi;
+            v_sum[cidx] += cri;
+            count[cidx] += 1;
+        }
+    }
+
+    let mut u_plane = vec![0u8; cw * ch];
+    let mut v_plane = vec![0u8; cw * ch];
+    for i in 0..u_plane.len() {
+        let n = count[i].max(1);
+        u_plane[i] = ((u_sum[i] + (n as i32) / 2) / (n as i32)).clamp(0, 255) as u8;
+        v_plane[i] = ((v_sum[i] + (n as i32) / 2) / (n as i32)).clamp(0, 255) as u8;
+    }
+
+    (y_plane, u_plane, v_plane)
+}
+
+/// Drive `oxideav_vp8::encode_keyframe` with a packed I420 source and the
+/// quality-derived [`KeyframeParams`].
+fn encode_vp8_keyframe_packed(
+    width: u32,
+    height: u32,
+    y: &[u8],
+    u: &[u8],
+    v: &[u8],
+    quality: f32,
+) -> Result<Vec<u8>, WebpError> {
+    if width == 0 || height == 0 {
+        return Err(WebpError::InvalidData);
+    }
+    let exp_y = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or(WebpError::InvalidData)?;
+    let cw = width.div_ceil(2) as usize;
+    let ch = height.div_ceil(2) as usize;
+    let exp_uv = cw.checked_mul(ch).ok_or(WebpError::InvalidData)?;
+    if y.len() != exp_y || u.len() != exp_uv || v.len() != exp_uv {
+        return Err(WebpError::InvalidData);
+    }
+
+    let frame = I420Frame::packed(width, height, y, u, v);
+    let params = KeyframeParams {
+        y_ac_qi: quality_to_qindex(quality),
+        ..KeyframeParams::default()
+    };
+    encode_keyframe(&frame, &params).map_err(WebpError::from)
+}
+
+/// Build a `.webp` around a VP8 bitstream, with optional alpha plane and
+/// optional file-level metadata.
+fn frame_lossy(
+    width: u32,
+    height: u32,
+    vp8_bitstream: &[u8],
+    alpha: Option<&[u8]>,
+    meta: &WebpMetadata<'_>,
+) -> Result<Vec<u8>, WebpError> {
+    let has_alpha = alpha.is_some();
+
+    // Simple layout: no alpha, no metadata. RIFF + VP8 only.
+    if !has_alpha && meta.is_empty() {
+        return build::build_webp_file(vp8_bitstream, build::ImageKind::Lossy, width, height)
+            .map_err(Error::from)
+            .map_err(WebpError::from);
+    }
+
+    // Extended layout: VP8X declares which features are present. §2.7
+    // chunk order: VP8X, ICCP?, ALPH?, VP8/VP8L, EXIF?, XMP?.
+    let flags = build::Vp8xFlags {
+        has_iccp: meta.icc.is_some(),
+        has_alpha,
+        has_exif: meta.exif.is_some(),
+        has_xmp: meta.xmp.is_some(),
+        has_animation: false,
+    };
+    let vp8x_payload = build::build_vp8x_chunk(width, height, flags)
+        .map_err(Error::from)
+        .map_err(WebpError::from)?;
+
+    let mut body = Vec::new();
+    let mut push_chunk = |fourcc, payload: &[u8]| -> Result<(), WebpError> {
+        let chunk = build::build_chunk(fourcc, payload)
+            .map_err(Error::from)
+            .map_err(WebpError::from)?;
+        body.extend_from_slice(&chunk);
+        Ok(())
+    };
+
+    push_chunk(container::fourcc::VP8X, &vp8x_payload)?;
+    if let Some(icc) = meta.icc {
+        push_chunk(container::fourcc::ICCP, icc)?;
+    }
+    if let Some(alpha_plane) = alpha {
+        // §2.7.1.2 method 0 (raw uncompressed), no filter, no
+        // preprocessing: a single `0x00` info byte followed by
+        // `width * height` raw alpha bytes.
+        let mut alph_payload = Vec::with_capacity(1 + alpha_plane.len());
+        alph_payload.push(0x00);
+        alph_payload.extend_from_slice(alpha_plane);
+        push_chunk(container::fourcc::ALPH, &alph_payload)?;
+    }
+    push_chunk(container::fourcc::VP8, vp8_bitstream)?;
+    if let Some(exif) = meta.exif {
+        push_chunk(container::fourcc::EXIF, exif)?;
+    }
+    if let Some(xmp) = meta.xmp {
+        push_chunk(container::fourcc::XMP, xmp)?;
+    }
+
+    // §2.4 file framing.
+    let file_size = (body.len() as u64) + 4;
+    if file_size > u64::from(u32::MAX) {
+        return Err(WebpError::InvalidData);
+    }
+    let mut out = Vec::with_capacity(12 + body.len());
+    out.extend_from_slice(&container::fourcc::RIFF);
+    out.extend_from_slice(&(file_size as u32).to_le_bytes());
+    out.extend_from_slice(&container::fourcc::WEBP);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_maps_to_qindex_bounds_and_default() {
+        assert_eq!(quality_to_qindex(100.0), 0);
+        assert_eq!(quality_to_qindex(0.0), 127);
+        // 75 → ~32 (the KeyframeParams default).
+        assert_eq!(quality_to_qindex(75.0), 32);
+        // Out-of-range inputs clamp into the table.
+        assert_eq!(quality_to_qindex(200.0), 0);
+        assert_eq!(quality_to_qindex(-50.0), 127);
+        // NaN falls back to default 75 → 32.
+        assert_eq!(quality_to_qindex(f32::NAN), 32);
+    }
+
+    #[test]
+    fn rgb_to_i420_neutral_grey_is_neutral_chroma() {
+        // A flat grey 4x4 image: every chroma sample should land near 128
+        // (neutral) and every luma sample near the grey value.
+        const W: u32 = 4;
+        const H: u32 = 4;
+        let mut rgb = Vec::with_capacity((W * H * 3) as usize);
+        for _ in 0..W * H {
+            rgb.extend_from_slice(&[100, 100, 100]);
+        }
+        let (y, u, v) = rgba_planes_to_i420(W, H, &rgb, 3);
+        for &yi in &y {
+            assert_eq!(yi, 100, "grey luma should equal source grey");
+        }
+        for (&ui, &vi) in u.iter().zip(v.iter()) {
+            assert!((127..=129).contains(&ui), "neutral Cb ≈ 128, got {ui}");
+            assert!((127..=129).contains(&vi), "neutral Cr ≈ 128, got {vi}");
+        }
+    }
+
+    #[test]
+    fn rgba_alpha_scan_promotes_to_extended() {
+        // A 2x2 RGBA with one non-opaque pixel must produce a file whose
+        // §2.7.1.1 VP8X chunk has the `L` (alpha) flag set, and an ALPH
+        // chunk following the VP8X.
+        const W: u32 = 2;
+        const H: u32 = 2;
+        let rgba = vec![
+            255, 0, 0, 255, // opaque red
+            0, 255, 0, 128, // half-transparent green
+            0, 0, 255, 255, // opaque blue
+            255, 255, 0, 255, // opaque yellow
+        ];
+        let file =
+            encode_vp8_lossy_rgba(W, H, &rgba, 75.0, &WebpMetadata::default()).expect("encode");
+
+        // Walk the container and confirm VP8X exists with alpha bit set.
+        let c = container::parse(&file).expect("parse RIFF");
+        let vp8x_chunk = c
+            .first_chunk_with_fourcc(container::fourcc::VP8X)
+            .expect("VP8X present");
+        let hdr = crate::vp8x::Vp8xHeader::parse(vp8x_chunk.payload(&file)).expect("VP8X parse");
+        assert!(hdr.has_alpha, "alpha bit set in VP8X");
+        // ALPH chunk present with method-0 info byte.
+        let alph = c
+            .first_chunk_with_fourcc(container::fourcc::ALPH)
+            .expect("ALPH present");
+        assert_eq!(
+            alph.payload(&file)[0],
+            0x00,
+            "ALPH info byte is method-0, no-filter"
+        );
+        // VP8 chunk present.
+        assert!(c.first_chunk_with_fourcc(container::fourcc::VP8).is_some());
+    }
+
+    #[test]
+    fn rgba_all_opaque_is_simple_layout() {
+        // Fully-opaque RGBA → simple (no VP8X) layout per the published
+        // contract: empty metadata, no alpha-flagged extended layout.
+        const W: u32 = 2;
+        const H: u32 = 2;
+        let rgba = vec![
+            10, 20, 30, 255, //
+            40, 50, 60, 255, //
+            70, 80, 90, 255, //
+            100, 110, 120, 255, //
+        ];
+        let file =
+            encode_vp8_lossy_rgba(W, H, &rgba, 75.0, &WebpMetadata::default()).expect("encode");
+        let c = container::parse(&file).expect("parse RIFF");
+        assert!(c.first_chunk_with_fourcc(container::fourcc::VP8X).is_none());
+        assert!(c.first_chunk_with_fourcc(container::fourcc::ALPH).is_none());
+        assert!(c.first_chunk_with_fourcc(container::fourcc::VP8).is_some());
+    }
+
+    #[test]
+    fn rgb24_metadata_promotes_to_extended_but_no_alpha() {
+        // Rgb24 input + metadata → VP8X declares I/E/X but NOT L.
+        const W: u32 = 2;
+        const H: u32 = 2;
+        let rgb = vec![
+            255, 0, 0, //
+            0, 255, 0, //
+            0, 0, 255, //
+            128, 128, 128, //
+        ];
+        let icc = b"fake-icc".to_vec();
+        let meta = WebpMetadata {
+            icc: Some(&icc),
+            exif: None,
+            xmp: None,
+        };
+        let file = encode_vp8_lossy_rgb24(W, H, &rgb, 75.0, &meta).expect("encode");
+        let c = container::parse(&file).expect("parse");
+        let vp8x_chunk = c
+            .first_chunk_with_fourcc(container::fourcc::VP8X)
+            .expect("VP8X");
+        let hdr = crate::vp8x::Vp8xHeader::parse(vp8x_chunk.payload(&file)).expect("VP8X parse");
+        assert!(hdr.has_iccp);
+        assert!(!hdr.has_alpha, "rgb24 input must not flag alpha");
+        // No ALPH chunk for opaque rgb24 inputs.
+        assert!(c.first_chunk_with_fourcc(container::fourcc::ALPH).is_none());
+    }
+
+    #[test]
+    fn yuv420p_simple_layout_round_trips_dimensions() {
+        // A neutral grey I420 source (128 luma, 128 chroma) must encode
+        // cleanly; the encoded file's parsed VP8 keyframe header reports
+        // the source dimensions.
+        const W: u32 = 16;
+        const H: u32 = 16;
+        let y = vec![128u8; (W * H) as usize];
+        let u = vec![128u8; ((W / 2) * (H / 2)) as usize];
+        let v = vec![128u8; ((W / 2) * (H / 2)) as usize];
+        let file = encode_vp8_lossy_yuv420p(W, H, &y, &u, &v, 75.0, &WebpMetadata::default())
+            .expect("encode");
+        // Round-trip the container.
+        let c = container::parse(&file).expect("parse");
+        let vp8 = c
+            .first_chunk_with_fourcc(container::fourcc::VP8)
+            .expect("VP8 present");
+        let lossy =
+            crate::vp8_chunk::WebpLossyChunk::from_chunk(&file, vp8).expect("VP8 keyframe header");
+        assert_eq!(u32::from(lossy.width()), W);
+        assert_eq!(u32::from(lossy.height()), H);
+    }
+
+    #[test]
+    fn yuva420p_emits_alph_chunk_with_alpha_plane() {
+        const W: u32 = 4;
+        const H: u32 = 4;
+        let y = vec![100u8; (W * H) as usize];
+        let u = vec![128u8; ((W / 2) * (H / 2)) as usize];
+        let v = vec![128u8; ((W / 2) * (H / 2)) as usize];
+        // Mix of opaque + transparent alpha; the ALPH chunk carries them
+        // verbatim under method 0 + no filter.
+        let alpha: Vec<u8> = (0..(W * H)).map(|i| (i * 17) as u8).collect();
+
+        let file =
+            encode_vp8_lossy_yuva420p(W, H, &y, &u, &v, &alpha, 75.0, &WebpMetadata::default())
+                .expect("encode");
+        let c = container::parse(&file).expect("parse");
+        let alph = c
+            .first_chunk_with_fourcc(container::fourcc::ALPH)
+            .expect("ALPH present");
+        let payload = alph.payload(&file);
+        assert_eq!(payload[0], 0x00, "method-0 info byte");
+        assert_eq!(&payload[1..], &alpha[..], "alpha plane raw round-trips");
+        // ALPH decode helper also reproduces the alpha plane.
+        let decoded = crate::decode_alpha_plane(&file)
+            .expect("decode alpha")
+            .expect("alpha present");
+        assert_eq!(decoded, alpha);
+    }
+
+    #[test]
+    fn yuv420p_rejects_short_plane() {
+        const W: u32 = 4;
+        const H: u32 = 4;
+        let y = vec![128u8; (W * H) as usize];
+        // Chroma plane one byte short of the (2×2) expectation.
+        let u = vec![128u8; ((W / 2) * (H / 2)) as usize - 1];
+        let v = vec![128u8; ((W / 2) * (H / 2)) as usize];
+        let err = encode_vp8_lossy_yuv420p(W, H, &y, &u, &v, 75.0, &WebpMetadata::default())
+            .expect_err("short plane rejected");
+        assert_eq!(err, WebpError::InvalidData);
+    }
+
+    #[test]
+    fn rgba_rejects_short_buffer() {
+        // 2x2 RGBA needs 16 bytes; pass 12.
+        let rgba = vec![0u8; 12];
+        let err = encode_vp8_lossy_rgba(2, 2, &rgba, 75.0, &WebpMetadata::default())
+            .expect_err("short buffer rejected");
+        assert_eq!(err, WebpError::InvalidData);
+    }
+
+    #[test]
+    fn rgb24_rejects_short_buffer() {
+        // 2x2 RGB24 needs 12 bytes; pass 9.
+        let rgb = vec![0u8; 9];
+        let err = encode_vp8_lossy_rgb24(2, 2, &rgb, 75.0, &WebpMetadata::default())
+            .expect_err("short rgb24 rejected");
+        assert_eq!(err, WebpError::InvalidData);
+    }
+}

--- a/tests/published_vp8_lossy_encode_api.rs
+++ b/tests/published_vp8_lossy_encode_api.rs
@@ -1,0 +1,164 @@
+//! Round-154 published-API smoke tests for the **VP8 lossy encode**
+//! surface — the published-0.1.5 `encode_vp8_lossy_*` entry points
+//! re-exposed over the `oxideav-vp8` sibling crate's
+//! `encode_keyframe` driver.
+//!
+//! Every test here uses only standalone APIs (no `registry` feature), so
+//! the file builds and runs under `--no-default-features`. It exercises:
+//!
+//! * `encode_vp8_lossy_yuv420p` — packed I420 planes → `.webp`.
+//! * `encode_vp8_lossy_yuva420p` — packed I420 + separate alpha plane →
+//!   `.webp` with §2.7.1.2 `ALPH` chunk.
+//! * `encode_vp8_lossy_rgba` — interleaved RGBA → `.webp` (auto-detects
+//!   non-opaque alpha and emits an `ALPH` chunk).
+//! * `encode_vp8_lossy_rgb24` — interleaved RGB24 → `.webp` (always
+//!   treated as opaque per the published contract).
+//! * `WebpMetadata` (borrowed) — the encode-side metadata input.
+//! * `CODEC_ID_VP8` / `CODEC_ID_VP8L` — the published registry codec IDs.
+
+use oxideav_webp::{
+    container, encode_vp8_lossy_rgb24, encode_vp8_lossy_rgba, encode_vp8_lossy_yuv420p,
+    encode_vp8_lossy_yuva420p, vp8_chunk, WebpMetadata, CODEC_ID_VP8, CODEC_ID_VP8L,
+};
+
+#[test]
+fn codec_ids_are_stable_strings() {
+    // The published 0.1.5 codec IDs the registry surface uses.
+    assert_eq!(CODEC_ID_VP8L, "webp_vp8l");
+    assert_eq!(CODEC_ID_VP8, "webp_vp8");
+}
+
+/// Build a 16×16 grey I420 source frame.
+fn grey_i420(width: u32, height: u32, luma: u8) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let n = (width * height) as usize;
+    let cw = width.div_ceil(2);
+    let ch = height.div_ceil(2);
+    let cn = (cw * ch) as usize;
+    (vec![luma; n], vec![128; cn], vec![128; cn])
+}
+
+#[test]
+fn encode_vp8_lossy_yuv420p_emits_riff_vp8_file() {
+    const W: u32 = 16;
+    const H: u32 = 16;
+    let (y, u, v) = grey_i420(W, H, 120);
+    let file =
+        encode_vp8_lossy_yuv420p(W, H, &y, &u, &v, 75.0, &WebpMetadata::default()).expect("encode");
+    // RIFF/WEBP magic at the file head.
+    assert_eq!(&file[0..4], b"RIFF");
+    assert_eq!(&file[8..12], b"WEBP");
+    // Simple layout (empty metadata + no alpha) → no VP8X chunk.
+    let c = container::parse(&file).expect("parse");
+    assert!(c.first_chunk_with_fourcc(container::fourcc::VP8X).is_none());
+    // VP8 chunk reports the source dimensions back through its keyframe
+    // header.
+    let vp8 = c
+        .first_chunk_with_fourcc(container::fourcc::VP8)
+        .expect("VP8");
+    let lossy = vp8_chunk::WebpLossyChunk::from_chunk(&file, vp8).expect("keyframe");
+    assert_eq!(u32::from(lossy.width()), W);
+    assert_eq!(u32::from(lossy.height()), H);
+}
+
+#[test]
+fn encode_vp8_lossy_yuva420p_writes_alph_chunk() {
+    const W: u32 = 4;
+    const H: u32 = 4;
+    let (y, u, v) = grey_i420(W, H, 100);
+    // Distinct alpha pattern so the round-trip is detectable.
+    let alpha: Vec<u8> = (0..(W * H) as u8).collect();
+    let file = encode_vp8_lossy_yuva420p(W, H, &y, &u, &v, &alpha, 75.0, &WebpMetadata::default())
+        .expect("encode");
+    let c = container::parse(&file).expect("parse");
+    let alph = c
+        .first_chunk_with_fourcc(container::fourcc::ALPH)
+        .expect("ALPH present");
+    let payload = alph.payload(&file);
+    // §2.7.1.2 info byte is method-0 / no filter / no preprocessing.
+    assert_eq!(payload[0], 0x00);
+    assert_eq!(&payload[1..], &alpha[..]);
+    // The standalone `decode_alpha_plane` helper round-trips the plane.
+    let plane = oxideav_webp::decode_alpha_plane(&file)
+        .expect("decode_alpha_plane")
+        .expect("alpha plane present");
+    assert_eq!(plane, alpha);
+}
+
+#[test]
+fn encode_vp8_lossy_rgba_keeps_simple_layout_when_opaque() {
+    const W: u32 = 4;
+    const H: u32 = 4;
+    let mut rgba = Vec::with_capacity((W * H * 4) as usize);
+    for i in 0..W * H {
+        rgba.extend_from_slice(&[(i & 0xff) as u8, 0x80, 0x40, 0xff]);
+    }
+    let file = encode_vp8_lossy_rgba(W, H, &rgba, 75.0, &WebpMetadata::default()).expect("encode");
+    let c = container::parse(&file).expect("parse");
+    // Opaque RGBA + empty metadata → simple layout, no VP8X.
+    assert!(c.first_chunk_with_fourcc(container::fourcc::VP8X).is_none());
+    assert!(c.first_chunk_with_fourcc(container::fourcc::ALPH).is_none());
+}
+
+#[test]
+fn encode_vp8_lossy_rgba_extended_when_alpha_is_present() {
+    const W: u32 = 2;
+    const H: u32 = 2;
+    let rgba = vec![
+        10, 20, 30, 0xff, //
+        40, 50, 60, 0x80, // non-opaque pixel forces extended layout
+        70, 80, 90, 0xff, //
+        100, 110, 120, 0xff,
+    ];
+    let file = encode_vp8_lossy_rgba(W, H, &rgba, 75.0, &WebpMetadata::default()).expect("encode");
+    let c = container::parse(&file).expect("parse");
+    assert!(c.first_chunk_with_fourcc(container::fourcc::VP8X).is_some());
+    assert!(c.first_chunk_with_fourcc(container::fourcc::ALPH).is_some());
+}
+
+#[test]
+fn encode_vp8_lossy_rgb24_always_simple_alpha_off() {
+    const W: u32 = 4;
+    const H: u32 = 4;
+    let rgb: Vec<u8> = (0..(W * H * 3) as u8).collect();
+    let file = encode_vp8_lossy_rgb24(W, H, &rgb, 75.0, &WebpMetadata::default()).expect("encode");
+    let c = container::parse(&file).expect("parse");
+    // Rgb24 input → opaque, never carries an ALPH chunk.
+    assert!(c.first_chunk_with_fourcc(container::fourcc::ALPH).is_none());
+}
+
+#[test]
+fn encode_vp8_lossy_quality_default_handles_nan() {
+    // NaN must be tolerated (clamped to default 75 → qi=32). The file
+    // must still encode cleanly.
+    const W: u32 = 16;
+    const H: u32 = 16;
+    let (y, u, v) = grey_i420(W, H, 128);
+    let _ = encode_vp8_lossy_yuv420p(W, H, &y, &u, &v, f32::NAN, &WebpMetadata::default())
+        .expect("NaN quality tolerated");
+}
+
+#[test]
+fn encode_vp8_lossy_rejects_zero_dimension() {
+    let rgba = vec![0u8; 0];
+    assert!(encode_vp8_lossy_rgba(0, 1, &rgba, 75.0, &WebpMetadata::default()).is_err());
+    assert!(encode_vp8_lossy_rgba(1, 0, &rgba, 75.0, &WebpMetadata::default()).is_err());
+}
+
+#[test]
+fn encode_vp8_lossy_rgba_with_metadata_promotes_layout() {
+    const W: u32 = 4;
+    const H: u32 = 4;
+    let rgba = vec![0xffu8; (W * H * 4) as usize]; // opaque white
+    let xmp = b"<?xpacket begin?>".to_vec();
+    let meta = WebpMetadata {
+        icc: None,
+        exif: None,
+        xmp: Some(&xmp),
+    };
+    let file = encode_vp8_lossy_rgba(W, H, &rgba, 75.0, &meta).expect("encode");
+    let c = container::parse(&file).expect("parse");
+    // Metadata pulls the file onto the extended layout, even with no alpha.
+    assert!(c.first_chunk_with_fourcc(container::fourcc::VP8X).is_some());
+    // XMP chunk landed at the metadata-after-image position.
+    assert!(c.first_chunk_with_fourcc(container::fourcc::XMP).is_some());
+}


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-26

### Other

- drop decorative attribution from round-154 module banner
- round 154 — published §2.5 VP8 lossy encode entry points
- round 152 — histogram-distance per-region clusterer
- round 151 — §6.2.2 multi-meta-prefix encoder
- round 150 — §4.4 color-indexing forward pass
- round 149 — §3.7.2.1.1 simple code length code chooser
- round 148 — §5.2.3 color_cache_code_bits sweep
- round 147 — §3.5.2 / §4.2 color-transform forward pass
- round 146 — §4.1 spatial-predictor forward transform
- round 145 — §2.7 metadata-aware container writer
- round 130 — §5.2.2 width-aware distance-code chooser
- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
- wire lossy decode against published DecodeError (not unpublished Vp8Error)
- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
- §5.2.1 / §5.2.3 color-cache writer (round 121)
- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
- §5.2.2 LZ77 backward-reference matching (round 119)
- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
- round 117 — restore published VP8L lossless-encode public names
- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
- add API-COMPAT.md — public API shape the rebuild must reproduce
- round 115 — first VP8L lossless encoder (literal-only round trip)
- register oxideav_core::Decoder into RuntimeContext (round 112)
- wire top-level decode_webp to RGBA for VP8L (round 111)
- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
- round 7: typed §2.6 `VP8L` chunk routing handle
- round 6: typed §2.5 `VP8 ` chunk routing handle
- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
- round 4: ANMF §2.7.1.1 typed per-frame header parse
- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
- in-crate copies of fixture inputs for standalone CI checkout
- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
- orphan rebuild: clean-room scaffold post 2026-05-20 audit

### Added

* **Clean-room round 154 (2026-05-26).** Published-shape §2.5 `VP8 ` lossy
  encode entry points landed, completing the `API-COMPAT.md` four-pixel-
  layout surface (`encode_vp8_lossy_yuv420p` / `_yuva420p` / `_rgba` /
  `_rgb24`) plus the `CODEC_ID_VP8` registry-ID constant. All four route
  through the `oxideav-vp8` sibling crate's `encode_keyframe` driver and
  wrap the emitted VP8 bitstream into a complete `.webp` file: simple
  layout (`RIFF` + `VP8 `) when no alpha plane is present and the
  `WebpMetadata` is empty; extended layout (`RIFF` + `VP8X` + `ICCP?` +
  `ALPH?` + `VP8 ` + `EXIF?` + `XMP ?`) otherwise. The `ALPH` chunk is
  emitted in §2.7.1.2 method-0 (raw, no filter) form (one `0x00` info
  byte followed by `width * height` raw alpha bytes), interoperable with
  the existing `decode_alpha_plane` round-trip. RGB/RGBA inputs are
  converted to a tightly-packed I420 source via the full-range
  ITU-R BT.601 forward matrix — the inverse of the §2.5 decode path's
  YCbCr→RGB conversion — with 2×2 box-averaged chroma. The
  published-shape `quality: f32` knob in `0..=100.0` (default 75.0)
  maps to RFC 6386 §9.6's `y_ac_qi: u8` in `0..=127` via the linear
  inversion `qi = round(127 * (1 - q / 100))`, so `quality = 75` lands
  on the `KeyframeParams::default()` `y_ac_qi = 32`. The RGBA path
  auto-promotes to the extended `ALPH`-bearing layout iff any pixel's
  alpha is non-opaque; the Rgb24 path is always treated as opaque per
  the published 0.1.5 contract. Nine standalone integration tests
  (`tests/published_vp8_lossy_encode_api.rs`) plus ten in-module unit
  tests cover the layout-promotion rules, the alpha plane round-trip,
  the simple/extended decision, the I420 chroma down-sample arithmetic,
  the NaN/clamp behaviour on `quality`, and the dimension-mismatch
  refusals. Spec sources consulted: RFC 9649 (WebP container) §2.5,
  §2.7, §2.7.1.2 mirrored under `docs/image/webp/`; RFC 6386 (VP8)
  §9.1, §9.2, §9.6; ITU-R BT.601 (full-range forward matrix). No
  external implementation source was consulted.

* **Clean-room round 152 (2026-05-26).** Histogram-distance per-region
  clusterer for the §6.2.2 multi-meta-prefix encoder, replacing the
  round-151 mean-green bucketiser. The new
  `cluster_blocks_by_histogram_distance` featurises every
  `(1 << prefix_bits)`-square block as a coarse 48-element RGB
  histogram (16 bins per channel after a `CLUSTER_BIN_SHIFT = 4`
  collapse), seeds `num_groups` cluster centroids by a deterministic
  farthest-from-already-chosen rule (a k-means++-style maximum-
  minimum-L1 variant with no randomness), iterates Lloyd's assignment
  / centroid-update step for up to 8 passes (early-exit on
  no-assignment-change), and compacts the final assignment so the
  returned meta-codes always run `0..actual_groups - 1` with no gaps
  (per RFC 9649 §3.7.2.2.2, `num_prefix_groups = max(entropy image) +
  1`, so a gap would force the encoder to emit an unused prefix-code
  group). `encode_with_meta_prefix` now drives the histogram path; the
  round-151 mean-green helper is removed from production code.
  Uniform images and images whose seeding cannot find `num_groups`
  distinguishable centroids collapse to a single-group degenerate
  cleanly so the chooser falls back to the round-150 baseline. Five
  new clusterer tests:
  `histogram_clusterer_separates_blocks_sharing_a_mean` (a bimodal-
  vs-flat green fixture that mean-green cannot split — both regions
  share mean ≈ 128 but the histogram clusterer separates them),
  `histogram_clusterer_is_deterministic` (same input → same codes),
  `histogram_clusterer_collapses_on_uniform_image` (degenerate signal
  for the encoder to fall through to the single-group path),
  `histogram_clusterer_num_groups_one_returns_all_zeros`
  (short-circuit for the trivial `num_groups = 1` case), and
  `histogram_clusterer_returns_compact_group_ids` (compaction
  invariant — no gaps in the returned meta-code range). The existing
  `meta_prefix_clusterer_splits_two_region_bimodal_fixture` test was
  retargeted at the new clusterer and still asserts the top-vs-bottom
  split on the headline bimodal image. Two new regression-bench tests
  (`histogram_clusterer_reduces_mp_bytes_on_two_region_sweep` and
  `histogram_clusterer_reduces_mp_bytes_on_mean_collision_sweep`)
  compare the multi-prefix candidate byte cost between the two
  clusterers across the chooser's full `(prefix_bits, num_groups)`
  sweep and assert the histogram path never regresses; on the
  diagnostic noisy two-region fixtures the histogram path shrinks the
  best-of-sweep multi-prefix candidate by 2.39–5.68 % (64×64
  8944→8730 B, 128×128 35049→33264 B, 64×128 17640→16903 B, 256×256
  139497→131580 B). The multi-prefix candidate still does not beat
  the round-150 super-chooser on these synthetic fixtures (LZ77 +
  predictor + color-cache dominate on uniform-noise inputs) but the
  gap is now 4–6 % narrower across every shape; on the mean-collision
  fixture (designed so per-block means match across regions that
  differ in distribution) the mean-green path collapses to a single
  group while the histogram path successfully partitions the image.
  Spec source: WebP Lossless Bitstream specification §6.2.2 / §3.7.2
  mirrored under `docs/image/webp/` and RFC 9649 §3.7.2 / §3.7.2.2.
  No external implementation was consulted.

* **Clean-room round 151 (2026-05-26).** §6.2.2 multi-meta-prefix
  (entropy-image) encoder for the VP8L lossless path. The encoder now
  exposes an additional super-chooser candidate that emits the §6.2.2
  *multi-prefix-code-group* shape: meta-prefix bit `%b1`, 3-bit
  `prefix_bits - 2`, an entropy-coded sub-resolution image carrying one
  meta-prefix code per `(1 << prefix_bits)`-square block, `N` prefix-code
  groups (5 prefix codes each), and the LZ77 token stream emitted with
  each token's symbols under the prefix-code group selected by its
  start pixel's block. `encode_with_meta_prefix` takes `prefix_bits`,
  `num_groups`, and `cache_code_bits`; `sweep_meta_prefix_candidate`
  sweeps `prefix_bits ∈ {4, 5, 6, 7}` (16/32/64/128-pixel blocks) ×
  `num_groups ∈ [2..4]` × the round-148 `cache_code_bits ∈ [1..11]`
  plus disabled-cache baseline and keeps the smallest non-degenerate
  stream. The clusterer (`cluster_blocks_by_mean_green`) bucketises
  blocks by mean-green value into equal-width groups; uniform images
  (where the clustering collapses) and images too small for the
  requested block count return `None` cleanly so the chooser stays at
  the single-group baseline. Empty-bucket prefix codes fall back to
  the §3.7.2.1.1 single-symbol-0 form (the same shape the existing
  empty-distance code uses) so the decoder accepts the resulting
  one-leaf code without ever consuming a symbol from it. Ten new
  tests: `meta_prefix_clusterer_splits_two_region_bimodal_fixture`
  (mean-green clusterer maps top/bottom halves to disjoint groups),
  `meta_prefix_two_group_round_trips_through_decoder` (end-to-end
  round-trip on a 64×64 two-region image),
  `meta_prefix_two_group_with_cache_round_trips_through_decoder`
  (composition with the §5.2.3 color cache at `code_bits = 8`),
  `meta_prefix_three_and_four_groups_round_trip_through_decoder`
  (3-group and 4-group round-trips on a noisy multi-region image),
  `meta_prefix_all_sweep_prefix_bits_round_trip_through_decoder`
  (round-trip across every `prefix_bits` value the chooser sweeps),
  `meta_prefix_returns_none_when_too_small_for_a_split` and
  `meta_prefix_returns_none_on_uniform_image` (degenerate-case
  rejection), `round_151_chooser_round_trips_on_two_region_image`
  (full-chooser end-to-end through `decode_webp`),
  `round_151_diagnostic_sweep_records_per_shape_costs` (observational
  per-shape baseline-vs-multi-prefix size table), and
  `round_151_multi_meta_prefix_beats_single_group_on_noisy_image`
  (chooser-never-regresses invariant on a 128×128 noisy two-region
  image). On the synthetic fixtures the multi-meta-prefix candidate
  consistently stays larger than the single-group baseline (the cost
  of N additional 280-symbol prefix-code tables — typically thousands
  of bytes each — dominates the per-region savings on small to
  mid-size images), so the chooser correctly keeps the round-150
  pick; the candidate's value is structural — the round-151 encoder
  is now spec-conformant for any future per-region clustering
  improvement to plug into without changing the on-wire serialiser.
  No external implementation was consulted; spec source is the WebP
  Lossless Bitstream specification §6.2.2 / §3.7.2.2 mirrored under
  `docs/image/webp/` and RFC 9649 §3.7.2.2 / §3.7.2.2.1 / §3.7.2.2.2,
  cross-checked against the existing decoder-side
  `vp8l_decode::decode_entropy_image` and `decode_argb_multi_group`.

* **Clean-room round 150 (2026-05-26).** §4.4 color-indexing transform
  forward pass for the VP8L lossless encoder. The encoder now evaluates
  a new candidate alongside the round-149 super-chooser set: when an
  O(N) palette probe (`collect_palette`) confirms the image has ≤ 256
  unique ARGB values, `encode_with_color_indexing` builds a sorted
  palette (sorted ARGB-numerically so the §4.4 subtraction-coded
  color-table deltas concentrate near zero), replaces every pixel with
  its palette index, bundles indices into one byte per the §4.4 table
  (`width_bits = 3 / 2 / 1 / 0` for palettes of 1..=2 / 3..=4 / 5..=16
  / 17..=256 entries — packing 8 / 4 / 2 / 1 indices into each green
  byte respectively per the §4.4 LSB-first packing rule), and hands the
  bundled image to the standard `spatially-coded-image` writer at the
  subsampled `packed_width = DIV_ROUND_UP(width, 1 << width_bits)`. The
  candidate uses the round-148 `cache_code_bits ∈ [1..11]` sweep plus
  the disabled-cache baseline and is cross-compared against every other
  candidate; the smallest stream wins. The §4.4 path doesn't dominate
  every palette image (the §5.2.3 color cache + LZ77 already crunch
  random binary content to ~1 bit/pixel), but it wins cleanly on
  palette-ish content with horizontal coherence — the bundling drops
  the entropy stage's symbol count by 2..8× and amortises the small
  palette-table overhead. On a 64×32 binary row-rotation fixture the
  round-150 chooser shrinks the encoded stream from 73 B (round-149
  baseline) to 62 B (-15.1%). Five new tests:
  `encoder_color_indexing_width_bits_matches_spec_table` (the §4.4
  threshold table), `forward_color_table_round_trips_with_decoder_inverse`
  (forward subtraction-encode + decoder inverse round-trip),
  `collect_palette_early_exits_above_256_unique_colors` (the on-wire
  256-entry limit), `color_indexing_round_trip_across_all_width_bits_regimes`
  (end-to-end decode round-trips covering all four `width_bits` values
  on 2/4/16/64-color palettes), and
  `round_150_color_indexing_beats_other_candidates_on_palette_image`
  (chooser-actually-picks-CI verification on the headline fixture),
  plus `color_indexing_chooser_skips_photo_like_content` (non-regression
  on photo-like content where the palette probe returns `None`). No
  external implementation was consulted; spec source is the WebP
  Lossless Bitstream specification §4.4 mirrored under
  `docs/image/webp/` and RFC 9649 (the IETF WebP Image Format),
  cross-checked against the existing decoder-side
  `vp8l_transform::inverse_color_indexing` and `inverse_color_table`
  (round 109).

* **Clean-room round 149 (2026-05-26).** §3.7.2.1.1 *simple code length
  code* chooser for the VP8L lossless encoder. Previously every prefix
  code went through `write_normal_code_lengths` (§3.7.2.1.2 *normal code
  length code*), which always pays the 1-flag + 4-`num_code_lengths` +
  3-bit-per-CLC + 1-`max_symbol`-gate header tax (≥ 18 bits, ≥ 58 bits
  when more than one length value is present). The new chooser in
  `WriteCode::write_code_lengths` recognises the simple form's two
  qualifying shapes (1 or 2 used symbols, each at length 1, in `[0..255]`),
  computes the exact bit-cost of both forms (`simple_form_bits` and
  `normal_form_bits`), and emits whichever is cheaper. The simple form
  costs as little as 4 bits (1 symbol with value in `[0..1]`), making it a
  dramatic win on the bulk of single-leaf prefix codes that arise
  naturally in WebP streams: the empty distance code on images with no
  LZ77 matches, the per-channel literal codes on solid blocks, and the
  alpha code on opaque images. Measured deltas on synthetic fixtures:
  1×1 opaque drops from 174 B (round 148) to 32 B (-81.6%); 32×32 solid
  gray drops from 174 B to 68 B (-60.9%); 16×16 four-band gradient
  drops from 328 B to 80 B (-75.6%); 8×8 two-alpha-value drops from
  178 B to 76 B (-57.3%). The chooser also propagates through the
  super-chooser's 12 candidate streams (no-tx, subtract-green,
  predictor, color-transform × cache sweep), so the candidate-cheapest
  pick now reflects the smaller-tax simple-form costs as well. Eight
  new tests: `simple_form_rejects_tables_outside_3_7_2_1_1_constraints`,
  `simple_form_accepts_one_or_two_length_one_symbols`,
  `simple_form_bits_matches_written_layout`,
  `chooser_prefers_simple_form_for_empty_distance_code`,
  `chooser_round_trips_through_decoder_on_both_branches`,
  `round_149_simple_form_shrinks_1x1_lossless_baseline`,
  `round_149_simple_form_shrinks_synthetic_fixtures`, and
  `round_149_two_symbol_simple_form_round_trips`. No external
  implementation was consulted; spec source is the WebP Lossless
  Bitstream specification §3.7.2.1.1 mirrored under `docs/image/webp/`,
  cross-checked against the existing decoder-side reader in
  `vp8l_prefix::read_simple_code_lengths` (round 104).

* **Clean-room round 148 (2026-05-26).** §5.2.3 `color_cache_code_bits`
  sweep for the VP8L lossless encoder. Previously the chooser locked
  every cache-enabled candidate at `DEFAULT_COLOR_CACHE_BITS = 8`
  (256-entry cache), giving the §5.2.3 trade-off only two effective
  positions: disabled or 256 entries. The new `select_best_cache_bits`
  helper sweeps the disabled-cache baseline plus every value in the
  §5.2.3-allowed `[1..11]` range (2..=2048-entry caches) for each
  base candidate — the no-tx and subtract-green literals candidates
  in `encode_argb_literals_with_width`, the §4.1 predictor candidate
  in `encode_argb_with_predictor_chooser`, and each color-transform
  `size_bits` candidate (per-region + single-block) in the same
  super-chooser. The sweep is non-monotonic: narrow caches win on
  small-palette payloads (fewer wasted alphabet slots), wide caches
  win on photo-like payloads (fewer hash collisions), and the
  disabled-cache baseline wins on noise (no `%b1 4BIT` header tax,
  no GREEN-alphabet growth from `280` to `280 + (1 << code_bits)`).
  On a 32×32 16-color pseudo-random palette fixture, the round-148
  sweep shrinks the encoded stream by a measurable fraction relative
  to the hardcoded-8 chooser (see
  `round_148_sweep_beats_hardcoded_8_on_small_palette` for the
  reported byte counts). Five new tests: `select_best_cache_bits`
  call-pattern coverage (12 candidates: `None` + `[1..=11]`),
  minimum-stream selection, monotonic-non-regression versus the
  hardcoded-8 chooser across three contrasting payloads, strict-beat
  on a small-palette payload, and live decoder verification that the
  chosen stream's `color_cache_code_bits` lands at a non-default
  `[1..11]` value.

* **Clean-room round 147 (2026-05-26).** §3.5.2 / §4.2 color-transform
  forward pass for the VP8L lossless encoder. The encoder now
  evaluates four new candidates alongside the existing six chooser
  candidates: the §3.5.2 color transform with two `size_bits` values
  (`4` → 16×16 per-region blocks; the maximal single-block size that
  collapses the entire image into one CTE), each with and without a
  §5.2.3 color cache. For each block, `pick_block_cte` runs an exact
  per-axis greedy sweep over a 25-entry candidate grid (`±0..±96`
  with fine resolution near zero) picking the
  `(green_to_red, green_to_blue, red_to_blue)` triple that minimises
  a residual-magnitude proxy. The per-axis greedy is exact because
  the §3.5.2 cost decomposes additively across channels (green is
  untouched, red depends only on `green_to_red`, blue depends
  additively on `(green_to_blue, red_to_blue)`). The sub-resolution
  color image is written as a §7.2 `color-image = 3BIT
  entropy-coded-image` (re-using `write_entropy_coded_image_literals`
  from round 146), the main image is forward-transformed into the
  red/blue residuals, and the residuals feed the standard
  `spatially-coded-image` writer. On a 128×128 fixture with per-
  block-varying linear channel correlation (four-slope palette), the
  chooser shrinks the stream from 47636 B (round-146 baseline) to
  41399 B — a 13.1% reduction. On the published 128×128 natural
  fixture the round-146 predictor candidate already wins at 1011 B
  and the new color candidate doesn't beat it (the chooser correctly
  keeps the predictor pick — no regression). The chooser falls back
  to the existing six candidates when either dimension is below one
  block. Nine new tests: `color_xfrm_delta` matching the §3.5.2
  signed-fixed-point formula on spec examples, per-pixel forward+
  inverse round-trip through the decoder's `inverse_color`, a solid-
  block CTE-cost-minimum assertion, a known-slope CTE recovery on a
  synthetic `red ≈ green / 2` block, forward + inverse multi-block
  bit-exact round trip, end-to-end public-API round trip on a chroma-
  correlated image, a chooser non-regression on a low-correlation
  synthetic and on uncorrelated noise, a strict-beat assertion on
  the varying-slope fixture (with `eprintln!` byte counts for
  visibility), and the natural-fixture round trip + non-regression.

* **Clean-room round 146 (2026-05-26).** §4.1 spatial-predictor forward
  transform for the VP8L lossless encoder. The encoder now evaluates two
  new candidates alongside the existing
  `(no-tx | subtract-green) × (no-cache | cache)` set: the §4.1 predictor
  transform with and without a §5.2.3 color cache. For each
  `(1 << size_bits)`-pixel square block (default
  `size_bits = 4` → 16×16 blocks), `pick_block_mode` walks the 14 §4.1
  prediction modes `0..=13` and selects the mode minimising a residual-
  magnitude proxy (sum of per-channel `|residual|` folded onto
  `[-128, 127]`). The sub-resolution predictor image is written as a §7.2
  `predictor-image = 3BIT entropy-coded-image` (a new
  `write_entropy_coded_image_literals` helper, also reusable by §4.2 in a
  future round), the main image is forward-transformed into per-pixel
  residuals, and the residuals feed the standard
  `spatially-coded-image` writer. On a 64×64 smooth gradient the chooser
  shrinks the stream from 9793 B (no-tx baseline) to 303 B — a 96.9%
  reduction; on the published 128×128 natural fixture, from 46797 B to
  1011 B — 97.8%. The chooser falls back to the existing four
  candidates when either dimension is below one block. Internally,
  `encode_tokens` was split: `write_spatially_coded_image` writes the
  body after the §3.8.2 optional-transform terminator, and
  `write_prefix_codes_and_tokens` is the shared `data = prefix-codes
  lz77-coded-image` emitter, so the predictor candidate composes the
  same low-level building blocks as the round-145 path. Eight new
  tests: residual-subtract-add round-trip, `pick_block_mode` solid-
  block cost, forward+inverse predictor bit-exact round trip,
  end-to-end round trip on a smooth gradient, a chooser size-reduction
  assertion (with `eprintln!` byte counts for visibility), a chooser
  noise-non-regression assertion, and a 128×128 natural fixture
  round-trip + size-reduction log. The
  `lossless-128x128-natural.webp` fixture was copied from
  `docs/image/webp/fixtures/lossless-128x128-natural/input.webp` into
  `tests/data/` to make the natural-image regression test
  self-contained.

* **Clean-room round 145 (2026-05-26).** §2.7 metadata-aware container
  writer: `build::build_webp_file_with_metadata(payload, image_kind,
  canvas_width, canvas_height, has_alpha, FileMetadata)` assembles a
  RIFF/WEBP file in the §2.7 *extended* layout with a §2.7.1 `VP8X`
  chunk + optional `ICCP` / `EXIF` / `XMP ` payloads, derives the
  §2.7.1 `I` / `L` / `E` / `X` flag bits from which `FileMetadata`
  fields are `Some` (plus the explicit `has_alpha` argument), and
  emits the chunks in §2.7 canonical order (`VP8X | ICCP | <VP8 |
  VP8L> | EXIF | XMP`). Twelve new tests cover round-trip through
  `extract_metadata` for the eight `{none, iccp, exif, xmp, iccp+exif,
  iccp+xmp, exif+xmp, iccp+exif+xmp}` presence combinations, the
  §2.3 `0x00` pad-byte generation on odd-length metadata payloads
  (verifies the §2.4 `File Size` field still matches the parsed
  value), the exhaustive 16-way §2.7.1 flag-bit derivation against
  the parser's `Vp8xHeader::parse`, and canvas-validation propagation
  (`CanvasDimZero` / `CanvasTooLarge`). The new `FileMetadata<'a>`
  borrowed struct mirrors the published `WebpMetadata` shape but
  lives inside `build` so the writer compiles under
  `--no-default-features` (no `oxideav-core` in the standalone
  build's dependency tree).

* **Clean-room round 130 (2026-05-25).** §5.2.2 **width-aware distance-code
  chooser** for the VP8L lossless encoder. Each backward reference now
  picks the smaller of the scan-line code (`D + 120`, the round-119
  default) and any §5.2.2 distance-map code `c ∈ 1..=120` whose
  `(xi, yi)` entry reconstructs to `D` for the image width — so a row-
  distance match (D = W) on a 256-wide image collapses from scan-line
  code 376 (prefix 16, 7 extra bits per emission) to map code 1
  (prefix 0, 0 extra bits). The reconstruction in
  `vp8l_decode::distance_code_to_pixel_distance` is identical for both
  forms, so the round trip stays bit-exact. New public helper
  `pixel_distance_to_distance_code(distance, image_width)`; new internal
  `encode_argb_literals_with_width(pixels, image_width)` that threads
  the actual image width into the chooser (wired by `encode_vp8l_payload`
  → `encode_webp_lossless` / `encode_vp8l_argb` / animation encoders).
  The legacy width-less `encode_argb_literals` is retained for test
  callers that exercise the entropy stage without spatial structure;
  it defaults to width = 1, which disables the chooser (no distance-map
  entry reconstructs typical distances at a single-pixel-wide row).
  Headline: a 256×256 row-repeating fixture shrinks from 972 B to 958 B
  (~1.4 % reduction); a 128×128 row-correlated fixture from 522 B to
  519 B (~0.6 %). Eight new tests cover chooser correctness
  (`distance_chooser_reconstructs_each_distance_map_entry`,
  `distance_chooser_picks_map_code_for_row_distance`,
  `distance_chooser_falls_back_to_scan_line_when_no_map_match`,
  `distance_chooser_width_one_uses_scan_line_for_large_distances`),
  per-prefix non-regression (`chooser_never_picks_larger_prefix_than_scan_line`),
  measured size-reduction
  (`width_aware_distance_beats_scan_line_only_on_row_correlated_image`,
  `width_aware_distance_compounds_on_many_short_row_offset_matches`,
  `width_aware_distance_headline_256x256_row_repeating`,
  `width_aware_distance_beats_scan_line_only_on_photo_like_image`,
  `width_aware_re_encode_of_real_fixture_is_smaller`), and round-trip
  bit-exactness across widths
  (`width_aware_round_trip_across_assorted_widths`). 356 tests total.

* **Clean-room round 127 (2026-05-25).** `AnimFrameMode::Auto` and
  `AnimFrameMode::Delta` are no longer `WebpError::Unsupported` — both
  now encode the caller's frames against the previous canvas using a
  **lossless dirty-rectangle delta** path on top of the existing VP8L
  encoder. `Delta` always emits the dirty-rect sub-frame (or, for the
  first frame / a frame whose dirty rect spans the whole canvas, a full
  keyframe); `Auto` evaluates both candidates and emits the smaller
  bitstream. Both honour the §2.7.1.1 `B = 1` / `D = 0`
  (overwrite, no dispose) ANMF semantics so the encoded file round-trips
  byte-for-byte through `decode_webp`'s canvas compositor. The
  even-offset constraint of §2.7.1.1 is preserved by aligning the dirty
  rect's top-left down to the nearest even coordinate. Identical
  consecutive frames emit a degenerate 2×2 sub-frame so duration timing
  is preserved without re-encoding. Headline: a 128×128 frame pair with
  an 8×8 changed block compresses from 87 476 B (all-Lossless) to
  43 986 B (Delta or Auto) — ~50 % size reduction with a byte-exact
  round trip. The original lossy-keyframe-vs-inter-frame-delta `Auto`
  semantics will return once `oxideav-vp8` ships a real lossy encoder;
  the dirty-rect path remains useful on lossless input regardless. New
  tests: `auto_and_delta_modes_emit_valid_files_round_127`,
  `dirty_rect_shrinks_anmf_payload_for_localised_change`,
  `auto_mode_picks_dirty_rect_on_localised_change`,
  `dirty_rect_canvas_coords_covers_only_the_changed_pixels`,
  `dirty_rect_is_none_on_identical_frames` (lib unit), and
  `auto_and_delta_modes_round_trip_byte_exact`,
  `delta_mode_three_frames_round_trip_byte_exact`,
  `auto_mode_picks_dirty_rect_on_small_localised_change`
  (`published_anim_api.rs`). 345 tests total.

* **Clean-room round 127 (2026-05-25).** Decoder-side §2.7.1.1
  **canvas compositing**. `decode_webp` / `decode_animation` now sizes
  a canvas from the §2.7.1 `VP8X` chunk, initialises it to the
  §2.7.1.1 `ANIM` `Background Color`, applies the previous frame's
  disposal method (`None` or `Background`) to its sub-rectangle, then
  draws the current frame at its `(x, y)` offset using its blending
  method: `Overwrite` copies the sub-rect pixels verbatim onto the
  canvas; `AlphaBlend` runs the §2.7.1.1 8-bit integer approximation
  of `blend.A = src.A + dst.A * (1 - src.A / 255)` /
  `blend.RGB = (src.RGB * src.A + dst.RGB * dst.A *
  (1 - src.A / 255)) / blend.A` (sRGB space, no gamma
  linearisation — matching the spec's stated 8-bit formula). Each
  returned `WebpFrame.rgba` is the full canvas snapshot after that
  frame is rendered, sized `canvas_w × canvas_h` (replacing the prior
  per-sub-rect-only convention). Frames whose declared rect overflows
  the canvas are rejected as `InvalidData`. The libwebp-encoded
  `animated-with-alpha.webp` fixture (all three ANMFs at offset (0,0)
  spanning the full 64×64 canvas) keeps decoding to the same per-frame
  RGBA buffers as before. New helpers: `lib::fill_canvas_rect`,
  `lib::blit_rect_overwrite`, `lib::blit_rect_alpha_blend`.

* **Clean-room round 127 (2026-05-25).** `AnimFrame::new` default
  `blend` switched from `BlendingMethod::AlphaBlend` to
  `BlendingMethod::Overwrite` so a full-canvas frame round-trips
  byte-for-byte through the new canvas compositor. Callers that need
  alpha-blending of a translucent sub-frame onto the existing canvas
  must build the struct literally and set `blend:
  BlendingMethod::AlphaBlend`. This is a behavioural change vs prior
  rounds (the existing `published_anim_api.rs` tests against varying-
  alpha frames updated to use the new semantics).

* **Clean-room round 124 (2026-05-25).** §2.5 `VP8 ` (lossy) **decode**
  path, routed through the `oxideav-vp8` sibling crate. Re-added the
  `oxideav-vp8 = "0.2"` dependency (vp8 0.2 now exposes a public
  `Vp8Error` at its crate root) with `default-features = false`, so it
  does not pull `oxideav-core` into the standalone build. New
  `vp8_decode` module routes a `WebpLossyChunk` payload to
  `oxideav_vp8::decode_vp8` (reconstructed, loop-filtered I420 key-frame)
  and converts it to interleaved RGBA via nearest-neighbour chroma
  up-sampling and the RFC 6386 §9.2 ITU-R BT.601 full-range YCbCr→RGB
  matrix. `decode_webp` / `decode_webp_image` now decode simple-lossy and
  `VP8X`-extended-lossy still images (with optional `ALPH`-over-`VP8 `
  alpha) instead of the previous `Unsupported(LossyVp8)` refusal. Added
  the `impl From<oxideav_vp8::DecodeError> for WebpError` adapter (a VP8
  inter-frame maps to `Unsupported`; every other decode failure to
  `InvalidData`) and the internal `Error::Vp8(DecodeError)` variant.
  Verified against the cwebp-encoded `lossy-1x1.webp` (simple) and
  `lossy-with-alpha-128x128.webp` (`VP8X` + `ALPH` + `VP8 `) fixtures;
  +13 tests (5 `vp8_decode` unit + rewired lossy-fixture/registry tests),
  339 total.

  *Deferred:* API-COMPAT.md specifies a
  `From<oxideav_vp8::Vp8Error> for WebpError` adapter against vp8's
  `Vp8Error` umbrella type. That type is on vp8 **master** (commit
  `d85d244`) but **not yet on crates.io** — it landed after the v0.2.0
  tag. The live decode path is wired against the published 0.2.0
  `DecodeError`; the `Vp8Error` adapter is a follow-up for once vp8
  publishes a release carrying it.

* **Clean-room round 121 (2026-05-25).** §5.2.1 / §5.2.3 **color-cache
  writer** in the VP8L encoder. `encode_argb_literals` now evaluates a
  256-entry color cache (`color_cache_code_bits = 8`) alongside the
  no-cache path and emits whichever is smaller; combined with the
  round-120 subtract-green chooser the encoder now picks the smallest of
  all four `(no-tx | subtract-green) × (no-cache | cache)` candidates.
  When the cache is enabled, the §3.8.3 `color-cache-info` header
  becomes `%b1 8` (1-bit flag + 4-bit `code_bits`), the GREEN alphabet
  grows to `256 + 24 + 256 = 536` symbols per §6.2.3, and a literal
  repeat is written as a single §5.2.3 cache code (`256 + 24 + index`)
  instead of four channel literals. New `EncoderColorCache` helper
  mirrors the decoder's `vp8l_decode::ColorCache` semantics bit-for-bit
  (hash formula `(0x1e35a7bd * argb) >> (32 - code_bits)`,
  zero-initialised entries, every emitted pixel re-inserted in stream
  order — both literals and every pixel covered by a §5.2.2
  backward-reference copy). A new `cacheify_tokens` 2nd-pass walks the
  LZ77 token stream and rewrites any `Literal(argb)` whose hashed slot
  already holds `argb` to a `Token::CacheRef { index }`. Cache state
  stays in sync with the decoder by inserting every covered pixel of a
  `Copy` token. New test-only `encode_argb_literals_color_cache`
  forces the cache path for the round-121 size-reduction comparison;
  production callers stay on the chooser. Headline: a 32×32
  pseudo-random small-palette (8 distinct ARGB colors) image compresses
  from 1131 B (no-cache LZ77) to 622 B (color-cache on), a ~45 % size
  reduction. Uncorrelated-noise images stay on the no-cache no-tx path
  (the chooser never regresses). Round-trip is bit-exact through
  `decode_lossless_image` on every existing fixture + the new
  color-cache round-trip + meta-prefix-header read-back tests. New
  tests: `encoder_color_cache_hash_matches_decoder_hash`,
  `encoder_color_cache_starts_zero_initialized`,
  `encoder_color_cache_insert_then_contains_round_trips`,
  `cacheify_tokens_collapses_repeat_literal_into_cache_ref`,
  `cacheify_tokens_copy_updates_cache_for_subsequent_literal`,
  `color_cache_path_round_trips_via_public_entry_points`,
  `color_cache_beats_no_cache_on_small_palette_image`,
  `color_cache_chooser_does_not_regress_on_uncorrelated_noise`,
  `color_cache_header_round_trips_through_meta_prefix_reader`. The
  crate still builds + tests under `--no-default-features` (the cache
  uses only the existing `oxideav-core`-free decode helpers).

* **Clean-room round 120 (2026-05-24).** §3.5.3 / §3.8.2 **subtract-green
  transform** forward path in the VP8L encoder. New `apply_subtract_green`
  helper subtracts the green channel from red and blue per pixel
  (`r := (r - g) & 0xff`, `b := (b - g) & 0xff`), the exact inverse of
  the decoder's existing `vp8l_transform::inverse_subtract_green`.
  `encode_argb_literals` now evaluates both the no-transform and the
  subtract-green paths and emits whichever is smaller — the §3.8.2
  transform header costs only three bits (`%b1 %b10`, transform type 2
  with no body), so on green-correlated natural-image-like content the
  per-channel red/blue entropy drops sharply for a near-free win;
  uncorrelated noise falls back to no-transform (the chooser never
  regresses). The literal-only and subtract-green-forced paths stay
  available as `encode_argb_literals_only` and
  `encode_argb_literals_subtract_green` for the round-119/120 size
  comparison tests. Headline: a 32×32 synthetic green-correlated image
  (red and blue track green plus small noise) compresses from 3243 B
  (no-transform) to 2211 B (subtract-green) — a ~32 % size reduction.
  Round-trip is bit-exact through `decode_lossless_image` because the
  decoder's §4 inverse pass undoes the encoded transform. New tests:
  `apply_subtract_green_is_inverse_of_inverse_subtract_green`,
  `apply_subtract_green_only_touches_red_and_blue`,
  `subtract_green_beats_no_transform_on_green_correlated_image`,
  `encode_argb_literals_chooses_smaller_path`,
  `subtract_green_path_round_trips_via_public_entry_points`,
  `encode_argb_literals_does_not_regress_on_uncorrelated_noise`.
  The crate still builds + tests under `--no-default-features` (the
  forward transform uses no `oxideav-core` surface).

* **Clean-room round 119 (2026-05-24).** §5.2.2 **LZ77 backward-reference
  matching** in the VP8L encoder. `encode_argb_literals` now runs a
  hash-chain matcher (`Lz77Matcher`) over the ARGB pixel buffer before
  the entropy stage: every repeated run of `>= MIN_MATCH` (3) pixels at
  scan-line distance `D` becomes a §5.2.2 length + distance backward
  reference instead of `length` separate ARGB literals. Length values
  flow through the GREEN alphabet's `256 + length_prefix` symbols;
  distances use prefix code #5 with the §3.6.2.2.1 scan-line form
  `distance_code = D + 120` (always valid per the spec's `> 120` branch
  — the §3.6.2.2.1 distance map is an optional decoder convenience the
  encoder declines to use). The new `value_to_prefix` helper is the
  exact inverse of the decoder's `read_lz77_value` prefix-value
  transform, round-tripped through the live decoder at a spread of
  values and at every length `1..=MAX_MATCH` (4096). The previous
  literal-only emit path stays available as `encode_argb_literals_only`
  for the size-reduction comparison test. Headline: a 64×64 image whose
  rows repeat an 8-color palette compresses from 4758 B (literal-only)
  to 163 B (LZ77), a ~97 % reduction; pixels with no exploitable
  repetition (xorshift noise) come out the same size. New tests:
  `value_to_prefix_small_values_have_no_extra_bits`,
  `value_to_prefix_round_trips_length_range`,
  `value_to_prefix_round_trips_through_decoder`,
  `round_trip_solid_color_uses_lz77_copy`,
  `round_trip_periodic_pattern_uses_overlapping_copy`,
  `lz77_beats_literal_only_on_repetitive_image`,
  `lz77_round_trips_incompressible_pixels`,
  `round_trip_splits_match_at_max_length`. The crate still builds under
  `--no-default-features` (the matcher uses only the existing
  `oxideav-core`-free decode helpers).

* **Clean-room round 118 (2026-05-24).** Re-exposed the
  **published-0.1.5 animation-encode API** for the VP8L-lossless path, on
  top of the round-115 VP8L encoder + the §2.7.1.1 `ANIM` / `ANMF` framing
  (see `API-COMPAT.md`). Standalone (no `oxideav-core` dep):
  * `build_animated_webp(frames) -> Result<Vec<u8>, WebpError>` and
    `build_animated_webp_with_options(frames, opts)` — assemble a
    multi-frame `.webp` (`RIFF`/`WEBP` + `VP8X(A[,L][,I][,E][,X])` +
    [`ICCP`] + `ANIM` + `ANMF…ANMF` + [`EXIF`] + [`XMP `]). The `VP8X`
    canvas is sized to cover every frame; each frame's pixels become a
    §2.6 `VP8L` chunk inside the `ANMF` Frame Data.
  * `AnimFrame { pixels, width, height, x, y, duration, blend, dispose,
    mode }` (flat RGBA `pixels`; even `x`/`y`; `AnimFrame::new` helper),
    `AnimFrameMode { Auto, Delta, Lossless }` (`Lossless` wired;
    `Auto`/`Delta` → `WebpError::Unsupported`, blocked on `oxideav-vp8`
    #1041), `AnimEncoderOptions { loop_count, background_rgba, metadata,
    delta }`, `DeltaConfig` (`max_components_override` /
    `auto_inner_threshold_bytes` / `msssim_downsample_kernel` builders),
    `DownsampleKernel { Box, Gaussian }`.
  * `decode_webp` now assembles an animated file into N `WebpFrame`s
    (per-frame `VP8L` decode + optional `ALPH` alpha override), populating
    `WebpImage::anim_background_rgba` / `anim_loop_count`.
  * Standalone test `tests/published_anim_api.rs` (runs under
    `--no-default-features`): 3-frame round trip, options + metadata,
    blend/dispose/offset carry, `Auto`/`Delta` `Unsupported`, and the
    `DeltaConfig` builder chain.

* **Clean-room round 117 (2026-05-24).** Re-exposed the
  **published-0.1.5 lossless-encode public names** on top of the round-115
  in-crate VP8L encoder (see `API-COMPAT.md`). All available standalone
  (no `oxideav-core` dep):
  * `encode_vp8l_argb(argb, width, height) -> Result<Vec<u8>, WebpError>`
    — a **bare** §2.6 / §3.4 `VP8L` bitstream (image-header + image
    stream), **no** RIFF wrapper. `argb` is `width * height` packed ARGB
    (`(a<<24)|(r<<16)|(g<<8)|b`); the §3.4 `alpha_is_used` header bit is
    auto-detected.
  * `encode_vp8l_argb_with(argb, width, height, has_alpha)` — the fixed
    (non-RDO) form: `has_alpha` sets the header bit explicitly.
  * `encode_vp8l_argb_with_metadata(w, h, &argb, has_alpha, &meta) ->
    Result<Vec<u8>, WebpError>` — a complete `.webp`. Emits the simple
    `VP8L` layout when opaque and metadata-free, else auto-promotes to the
    §2.7 extended `VP8X` layout (`VP8X` + [`ICCP`] + `VP8L` + [`EXIF`] +
    [`XMP `], chunks in §2.7 order, flag octet declaring exactly the
    present features). Round-trips through `decode_webp`; embedded metadata
    reads back via `extract_metadata`.
  * `WebpMetadata<'a> { icc/exif/xmp: Option<&'a [u8]> }` (borrowed encode
    input, `::default()` = embed nothing) and
    `WebpMetadataOwned { icc/exif/xmp: Option<Vec<u8>> }` (owned,
    registry-side; `as_borrowed()` + `From<WebpMetadataOwned> for
    WebpFileMetadata`).
  * `pub const CODEC_ID_VP8L = "webp_vp8l"`.
* **Registry `webp_vp8l` encoder (dual-API).** `register` now also
  installs a VP8L encoder codec under `CODEC_ID_VP8L` (alongside a decoder
  for symmetry). It accepts `Rgba` / `Rgb24` input (the `Rgb24` path
  streams as fully opaque, no 3→4 expansion) and emits a `.webp` per
  frame. Direct factories `registry::make_encoder(&params)`,
  `registry::make_encoder_with_metadata(&params, WebpMetadataOwned)`, and
  the `VideoFrame`-flavoured `registry::encode_vp8l_frame(...)` keep the
  registry path + direct factory dual-API convention.
* **New tests.** `tests/published_encode_api.rs` (standalone, runs under
  `--no-default-features`): bare-bitstream shape, simple/extended layout
  selection, metadata embed + read-back, forced-alpha round trip,
  dimension-mismatch rejection. Plus in-crate unit tests for the bare
  encode helpers (`vp8l_encode`) and the registry encoder
  (round-trip RGBA, Rgb24-as-opaque, VP8X-on-metadata, NeedMore/Eof).

* **Clean-room round 116 (2026-05-24).** First step of restoring the
  **published-0.1.5 public decode API shape** so downstream consumers
  compile again (see `API-COMPAT.md`). New published-shape decode types
  (all available standalone, no `oxideav-core` dep):
  * `WebpImage { frames: Vec<WebpFrame>, metadata: WebpFileMetadata,
    anim_background_rgba: Option<[u8; 4]>, anim_loop_count: Option<u16> }`.
  * `WebpFrame { rgba: Vec<u8>, width: u32, height: u32, duration_ms: u32 }`
    — `rgba.len() == width * height * 4`, tightly packed `[R, G, B, A]`,
    no stride padding (drops straight into `image::ImageBuffer::from_raw`).
  * `WebpFileMetadata { icc: Option<Vec<u8>>, exif: Option<Vec<u8>>,
    xmp: Option<Vec<u8>> }`.
  * `WebpError { InvalidData, Unsupported, Eof, NeedMore }`, with
    `From<Error>` mapping the rich internal error onto the coarse
    published shape.

### Changed

* **`decode_webp` restored to the published shape.** It now returns
  `Result<WebpImage, WebpError>` (was the rebuild's own unpublished
  `Result<Vec<u8>, Error>`). Built on the already-rebuilt §4–§6 VP8L
  decoder: a simple/extended-lossless file yields a single-frame
  `WebpImage`. VP8 lossy and animation paths are reported
  `WebpError::Unsupported` (never faked) until those decoders are
  rebuilt. The flat-`Vec<u8>` behaviour is preserved via
  `decode_webp(..).frames[0].rgba`; the low-level
  `decode_webp_image -> DecodedWebp` and `decode_lossless_image` helpers
  are unchanged and remain as additional API.
* New `extract_metadata(bytes) -> Result<WebpFileMetadata, WebpError>` —
  metadata-only walk (ICC / Exif / XMP), decodes no pixels.
* New standalone integration test `tests/published_decode_api.rs`
  (runs under `--no-default-features`): builds an in-memory RGBA buffer,
  encodes via the VP8L lossless encoder, decodes via `decode_webp`, and
  asserts the round-tripped `WebpFrame.rgba` is byte-exact with
  `len == w * h * 4` — proving the flat `image`-crate buffer shape.

* **Clean-room round 115 (2026-05-24).** First **VP8L lossless encoder**.
  New `vp8l_encode` module (compiles standalone, no `oxideav-core` dep):
  * `encode_webp_lossless(rgba, width, height)` — encodes an interleaved
    8-bit RGBA image (`[R, G, B, A]` scan order, the `DecodedWebp::rgba`
    layout) to a complete RIFF/WEBP file carrying a §2.6 simple-lossless
    `VP8L` chunk. Re-exported at the crate root as
    `oxideav_webp::encode_webp_lossless`. The encoded file decodes back to
    the exact input bytes through `decode_webp` — a pixel-exact round trip.
  * Simplest spec-conformant path: §3.8.2 `optional-transform` = `%b0`
    (no transform / pass-through), §3.8.3 `color-cache-info` = `%b0`
    (no color cache), §3.7.2.2 `meta-prefix` = `%b0` (single prefix-code
    group), and a literal-only §3.8.3 image (every pixel a §3.7.3 ARGB
    literal, no LZ77 backward references). The distance prefix code (#5)
    is the §3.7.2.1.1 single-symbol-0 form ("empty prefix codes can be
    coded as those containing a single symbol 0").
  * §3.7.2 canonical prefix-code construction: per-channel symbol
    frequencies → length-limited (≤ 15-bit) Huffman code lengths
    (`build_code_lengths`, min-heap build + length-limiting rebalance) →
    `(length, value)`-ordered canonical codes (`canonical_codes`) — the
    identical assignment the round-104 `vp8l_prefix::PrefixCode` reader
    consumes. Code lengths are written with the §3.7.2.1.2 *normal code
    length code* (or the trivial single-leaf form for constant channels).
  * `BitWriter` — the LSB-first inverse of `vp8l_stream::BitReader`.
  * `EncodeError` (`PixelBufferMismatch` / `InvalidDimensions` / `Build`)
    with a `From<EncodeError>` into the crate-wide `Error`.
  * 15 unit tests + 4 integration round trips: encode→decode is pixel-exact
    on synthetic 1×1 / gradient / solid / 16×16-pseudo-random images and on
    the real `lossless-1x1`, `lossless-32x32-rgba`, and
    `lossless-color-indexing-paletted` fixtures (decoded by the independent
    decode path, re-encoded, re-decoded, compared byte-for-byte).
  * Encoder scope is decode-only-validated for now: no §3.8.2 transform
    encoding, no LZ77 / color-cache compression. Files are larger than a
    libwebp-encoded equivalent but spec-valid and round-trip-exact.

* **Clean-room round 112 (2026-05-24).** The codec is now registered into
  `oxideav_core::RuntimeContext` — `register()` is no longer a no-op. New
  `registry` module (gated behind the default-on `registry` feature):
  * `registry::WebpDecoder` — an `oxideav_core::Decoder` impl over
    `decode_webp_image`. Each `send_packet` carries one whole
    `RIFF/WEBP` file; `receive_frame` returns a single-planar
    `Frame::Video` of interleaved 8-bit RGBA (`PixelFormat::Rgba`,
    stride `width * 4`). Covers §2.6 / §3.4 `VP8L` lossless (simple or
    `VP8X`-extended) with optional §2.7.1.2 `ALPH`-over-`VP8L` alpha
    override. A §2.5 `VP8 ` lossy file, and any animation / header-only
    file with no `VP8L`/`VP8 ` image-data chunk, surface as
    `oxideav_core::Error::Unsupported` (lossy callers route the chunk
    via `extract_lossy_chunk`).
  * `register()` / `registry::register_codecs` install one `CodecInfo`
    under the `webp` codec id with the decoder factory and a `WEBP`
    FourCC tag claim; `registry::register_containers` installs the
    `.webp` file-extension hint. No encoder factory is registered.
  * The decoder's `CodecParameters` carry the decoded `width` /
    `height` / `PixelFormat::Rgba` after the first `receive_frame`
    (read via `WebpDecoder::params`).
  * `registry::decode_webp_to_frame(bytes, pts)` — a direct
    `VideoFrame`-flavoured wrapper around `decode_webp_image`.
  * `From<Error> for oxideav_core::Error` — `Unsupported` maps to the
    core `Unsupported`; every other variant flows through `InvalidData`
    carrying the sub-module's `Display` text.
  * 10 unit tests in `registry::tests` cover the RuntimeContext install,
    FourCC resolution, an end-to-end lossless decode through the
    registered factory, the `VP8 ` lossy `Unsupported` refusal, the
    params dim/format surfacing, the one-packet/one-frame contract, the
    post-flush `Eof`, and the error conversion.

* **Clean-room round 111 (2026-05-24).** Top-level still-image decode is
  wired up — `decode_webp` no longer returns `NotImplemented` for the
  cases the crate can decode. New surface:
  * `decode_webp_image(bytes) -> DecodedWebp` — walks the `RIFF/WEBP`
    container, decodes a §2.6 / §3.4 `VP8L` lossless image (simple **or**
    `VP8X`-extended) through the full §4–§6 chain, and returns the
    `DecodedWebp { width, height, rgba }` struct. `rgba` is
    `width*height*4` interleaved `[R, G, B, A]` bytes in scan order — the
    `oxideav_core::PixelFormat::Rgba` layout the workspace's image crates
    share. When a (spec-discouraged, per §2.7.1.2 "SHOULD NOT") `ALPH`
    chunk accompanies the `VP8L` image, its decoded alpha plane overrides
    the per-pixel alpha.
  * `decode_webp(bytes) -> Vec<u8>` — the flat-buffer shorthand: same
    decode, returns just the packed RGBA bytes.
  * `Error::Unsupported(UnsupportedKind)` — a §2.5 `VP8 ` lossy file is a
    clean `Unsupported(LossyVp8)` (route it onward with
    `extract_lossy_chunk`); a file with no `VP8L`/`VP8 ` image-data chunk
    (animation / header-only) is `Unsupported(NoImageData)`. Lossy is
    **not** stub-decoded.
  * End-to-end tests decode the `lossless-1x1`,
    `lossless-color-indexing-paletted`, and `lossless-32x32-rgba`
    fixtures all the way to RGBA (dims + pixel spot-checks against the
    round-109 ARGB ground truth, including the RGBA alpha-channel
    repack), a synthesized `VP8X`+`VP8L` extended file, and a
    hand-assembled `VP8X`+`VP8L`+`ALPH` file proving the `ALPH` alpha
    override.

* **Clean-room round 110 (2026-05-24).** §2.7.1.2 `ALPH` alpha-channel
  bitstream decode — the alpha plane is now produced end-to-end. New
  surface in `alph`:
  * `alph::decode_alpha(payload, width, height)` — decodes a whole
    `ALPH` chunk payload to a `width * height` plane of 8-bit alpha
    values. Covers both compression methods: method 0 (raw 8-bit
    values, length `width*height`) and method 1 (a *headerless* §3 VP8L
    image-stream of implicit dimensions, decoded via the new
    `vp8l_transform::decode_lossless_headerless`, with the alpha lifted
    from the **green** channel per §2.7.1.2). Then applies the
    §2.7.1.2 inverse filter — none / horizontal (A) / vertical (B) /
    gradient (`clip(A+B-C)`) — as `alpha = (predictor + X) % 256`, with
    the documented top-left (predictor 0), left-most (use pixel above),
    and top-most (use pixel left) edge cases.
  * `decode_alpha_plane(bytes)` — container-level entry point: walks the
    `RIFF/WEBP` file, takes the alpha-plane dimensions from the `VP8X`
    canvas (or the `VP8 ` keyframe header when no `VP8X` is present),
    locates the `ALPH` chunk, and decodes. Returns `Ok(None)` when the
    file carries no `ALPH` chunk.
  * `AlphError` gained `DimensionsOverflow`, `RawLengthMismatch`,
    `UnsupportedCompression`, and `Vp8l` variants.
  * `vp8l_transform::decode_lossless_headerless(payload, width, height)`
    — the headerless §3 image-stream decode (no 5-byte image header)
    that the compressed alpha path reuses; the existing
    `decode_lossless` now delegates to a shared driver.
  * Verified bit-exact against the black-box `dwebp -alpha` validator on
    the `lossy-with-alpha-128x128` fixture (all 16384 alpha bytes
    identical); filter inverses are unit-tested against hand-computed
    §2.7.1.2 vectors for all four methods.

* **Clean-room round 109 (2026-05-24).** VP8L §4 inverse-transform
  passes — the layer that consumes round-108's `decode_argb` ARGB buffer
  and produces final pixels, closing the lossless decode path
  end-to-end. New module `vp8l_transform` exposes:
  * `vp8l_transform::decode_lossless(payload, width, height)` — the
    top-level driver. Reads the §4 / §7.2 `optional-transform` list
    (each transform's fixed fields **and** its §5-encoded
    `entropy-coded-image` body), tracks §4.4 width subsampling, decodes
    the main §5.1 ARGB image at the (subsampled) width via `decode_argb`,
    then applies the inverse transforms in reverse read order (§4: "last
    one first").
  * `vp8l_transform::inverse_predictor` — §4.1: 14 prediction modes
    (`Average2` / `Select` / `ClampAddSubtractFull` /
    `ClampAddSubtractHalf`) over the TL/T/TR/L block grid, with the
    border rules (top-left → `0xff000000`, top row → L, left column → T,
    rightmost column uses the row's leftmost pixel as TR) and the
    per-channel residual add.
  * `vp8l_transform::inverse_color` — §4.2: per-block
    `ColorTransformElement` add-back (`ColorTransformDelta(t,c) =
    (t*c) >> 5` with signed-8-bit `t`/`c`), green→red / green→blue /
    red→blue, on the red and blue channels only.
  * `vp8l_transform::inverse_subtract_green` — §4.3: add green into red
    and blue (`& 0xff`).
  * `vp8l_transform::inverse_color_table` (§4.4 subtraction-decode of the
    palette) + `vp8l_transform::inverse_color_indexing` (palette lookup;
    ≤16-color pixel un-bundling of 2/4/8 indices per green byte; the
    width un-subsample back to the canvas width; out-of-range indices →
    transparent black `0x00000000`).
  * `vp8l_decode::decode_entropy_coded_image(reader, width, height)` —
    a generalized §7.3 `entropy-coded-image` decoder (color-cache-info +
    one prefix-code group + §5.2 data, no meta-prefix layer) used to
    decode each transform's sub-resolution body. `decode_entropy_image`
    now delegates to it.
  * `vp8l_decode::DecodedImage::pixels_mut` / `from_parts` (used by the
    in-place inverse passes and the color-indexing re-size) and a new
    `DecodeError::DuplicateTransform` variant.
  * `decode_lossless_image(bytes)` — container-level entry point: walks
    the file, extracts the `VP8L` chunk, and decodes it to a
    `DecodedImage`. Returns `Ok(None)` for `VP8 `-only files.
* 18 new unit tests in `vp8l_transform::tests` (each predictor
  primitive; predictor border rules for the top-left / top-row / left-
  column cases; the §4.2 signed delta + forward↔inverse round-trip + in-
  place block use; §4.3 green add-back with wrap; §4.4 subtraction
  decode + no-bundling lookup + out-of-range → transparent black +
  width_bits-1/3 bundling + the threshold table) + 4 integration tests
  in `fixture_walks` that decode three real fixtures *bit-exactly*
  against their `expected.png` ARGB ground truth:
  * `round109_lossless_1x1_color_indexing_decodes_end_to_end` →
    `0xFFB43C5A`.
  * `round109_lossless_color_indexing_paletted_decodes_end_to_end`
    (32×32, 8-color palette, width_bits=1 bundling).
  * `round109_lossless_32x32_rgba_full_transform_chain_decodes_end_to_end`
    (SUBTRACT_GREEN + PREDICTOR + CROSS_COLOR + level-1 color cache,
    real alpha).
  * `round109_decode_lossless_image_returns_none_for_lossy_file`.
  New in-crate fixture `tests/data/lossless-color-indexing-paletted.webp`
  (byte-for-byte copy of the docs corpus). Test count: **229** (was
  207).
* The decoder is **standalone-friendly** — `vp8l_transform` compiles
  under `--no-default-features` with no `oxideav-core` dependency.

### Notes (round 109)

The VP8L lossless decode path is now **complete end-to-end**: container
walk → §4 transform list (with bodies) → §5/§6 entropy decode → §4
inverse-transform chain → final ARGB pixels, validated bit-exact on the
`lossless-1x1`, `lossless-color-indexing-paletted`, and
`lossless-32x32-rgba` fixtures. `decode_webp` itself still returns
`Error::NotImplemented` (it would need ARGB→output-format packing +
the VP8 lossy + ALPH alpha paths); callers wanting lossless pixels use
`decode_lossless_image`.

* **Clean-room round 108 (2026-05-24).** VP8L §6.2.2 entropy-image
  multi-group ARGB decode — the piece that turns the round-106
  meta-prefix dispatch and the round-107 single-group §5.2 loop into a
  full multi-group ARGB decode. New `vp8l_decode` surface:
  * `vp8l_decode::decode_argb(reader, width, height)` — the full
    ARGB-role decode. Reads the round-106 `MetaPrefixHeader` for the
    `Argb` role and dispatches: `meta-prefix = %b0` runs the
    single-group `decode_image` path; `meta-prefix = %b1` decodes the
    §6.2.2 entropy image, derives `num_prefix_groups = max(entropy
    image) + 1`, reads that many `PrefixCodeGroup`s, and runs the
    §6.2.3 loop selecting a group per pixel block.
  * `vp8l_decode::decode_entropy_image(reader, prefix_bits,
    prefix_image_width, prefix_image_height)` — decodes the §6.2.2
    entropy image (itself a §5 `entropy-coded-image`) into a
    `MetaPrefixIndex`. Each block's meta-prefix code is the red+green
    channels of its entropy-image pixel: `(argb >> 8) & 0xffff`.
  * `vp8l_decode::MetaPrefixIndex` — the per-block meta-prefix codes
    plus `prefix_bits` / `block_width` / `block_height`. Exposes
    `num_prefix_groups()` (max-based, not block count) and
    `meta_code_for(x, y)` (`meta[(y >> prefix_bits) * block_width +
    (x >> prefix_bits)]`).
  * New `DecodeError` variants `MetaPrefix` / `EmptyEntropyImage` /
    `MetaPrefixIndexOutOfRange`, plus a `From<MetaPrefixError>` impl.
* 9 new unit tests in `vp8l_decode::tests` (meta-index helpers and
  max-based `num_prefix_groups`; entropy-image red+green meta-code
  extraction incl. the high-code red-channel path; two-group per-block
  selection; single-group `decode_argb`; single-group parity with
  `decode_image`; multi-group with a shared color cache; zero-dim
  entropy-image refusal) and 3 integration tests in `fixture_walks`
  (public `decode_argb` multi-group + single-group, public
  `decode_entropy_image` with max-based group count).
* **Clean-room round 107 (2026-05-24).** VP8L §5.2 LZ77
  backward-reference + §5.2.3 color-cache per-pixel ARGB decode loop —
  the §6.2.3 decoder that consumes symbols from a round-106
  `PrefixCodeGroup` and produces a decoded ARGB pixel buffer. New
  module `vp8l_decode` exposes:
  * `vp8l_decode::decode_image(reader, group, color_cache, width,
    height)` — the §6.2.3 per-pixel decode loop. Reads GREEN symbol
    `S` from prefix code #1 and dispatches by range (§5.2.1 literal /
    §5.2.2 LZ77 backward reference / §5.2.3 color-cache code) until
    `width * height` ARGB pixels are emitted. Returns a
    `vp8l_decode::DecodedImage` (scan-line ARGB, pre-inverse-transform).
  * `vp8l_decode::read_lz77_value(reader, prefix_code)` — the §5.2.2
    prefix-code → value transform shared by length and distance
    (`prefix < 4 → prefix + 1`, else `offset + ReadBits(extra) + 1`).
  * `vp8l_decode::DISTANCE_MAP` (the 120-element §5.2.2 neighbor-offset
    table) + `distance_code_to_pixel_distance(code, width)` (the
    `dist = xi + yi*width`, clamp-to-1, `> 120 → code - 120` mapping).
  * `vp8l_decode::ColorCache` — the §5.2.3 cache: zero-initialized,
    hashed by `(0x1e35a7bd * argb) >> (32 - code_bits)`; `new` /
    `hash` / `insert` / `lookup` / `size`. Every emitted pixel is
    re-inserted in stream order.
  * `vp8l_decode::GreenSymbol::classify(symbol, alphabet_size)` — the
    §6.2.3 GREEN range dispatch (`Literal` / `LengthPrefix` /
    `ColorCache`), unit-testable in isolation.
  * `vp8l_decode::DecodeError` plus public constants
    `NUM_DISTANCE_MAP_CODES` / `NUM_LENGTH_PREFIX_CODES` /
    `COLOR_CACHE_HASH_MULTIPLIER`.
* 24 new unit tests in `vp8l_decode::tests` (§5.2.2 LZ77 value
  transform across prefix codes 0–6 + the length-4096 boundary at
  prefix 23; distance-map length / spec-example first entries /
  above-120 offset / negative-offset clamp; §6.2.3 GREEN literal /
  length / color-cache classification + out-of-range refusal; §5.2.3
  color-cache hash formula / insert-lookup round-trip /
  zero-initialization; full decode loop for a literal-only 2×1 image,
  a single literal pixel, a length/distance back-reference with LZ77
  self-overlap, a color-cache hit, plus backward-reference-underflow
  and no-cache refusals) plus 2 integration tests:
  * `round107_lossless_1x1_color_table_decodes_end_to_end_to_palette_pixel`
    drives container walk → §4 transform list → resume at the
    COLOR_INDEXING §5 body → §5.2.3 + §6.2 meta-prefix header →
    `decode_image` over `lossless-1x1.webp`'s 1×1 color-table image,
    producing the single palette pixel ARGB `0xFFB43C5A`
    (255,180,60,90) straight from the fixture's own VP8L payload bytes.
  * `round107_decode_error_surfaces_through_crate_error` locks the
    `DecodeError → oxideav_webp::Error::Vp8lDecode` `From` wiring.
  Test count: **195** (was 169).
* The decoder is **standalone-friendly** — `vp8l_decode` compiles
  under `--no-default-features` with no `oxideav-core` dependency.

### Changed

* `Error` gained a `Vp8lDecode(vp8l_decode::DecodeError)` variant.

### Notes

`decode_webp` still returns `Error::NotImplemented`. Round 107 closes
the §5.2 single-group ARGB decode path: a single `PrefixCodeGroup`
plus the §5.2 data now decodes to a full ARGB pixel buffer. The
remaining lossless work is the §6.2.2 entropy-image *multi-group*
path (one group per pixel block, selected by an entropy image) and
the §4 inverse-transform passes (predictor / color / subtract-green /
color-indexing) that operate on the buffer this loop produces.

* **Clean-room round 106 (2026-05-24).** VP8L §5.2.3 color-cache info
  + §6.2.2 meta-prefix dispatch + §6.2 5-prefix-code-group reader —
  the preamble every §5 image-data block opens with, sitting on top of
  the round-104 single-prefix-code reader. New module `meta_prefix`
  exposes:
  * `meta_prefix::ColorCacheInfo` — the §5.2.3 `color-cache-info`
    field. `ColorCacheInfo::read(reader)` dispatches on the leading
    1-bit flag, reads the 4-bit `color_cache_code_bits` when set,
    validates the §5.2.3 `[1..11]` range MUST, and surfaces
    `is_enabled()` / `size()` (`1 << code_bits`).
  * `meta_prefix::PrefixCodeGroup` — the five-prefix-code group the
    §6.2 / §6.2.3 / §5.2 decode paths consume (GREEN+length+cache /
    RED / BLUE / ALPHA / DIST). `PrefixCodeGroup::read(reader,
    color_cache_size)` reads them in §6.2 bitstream order, sizing the
    GREEN alphabet at `256 + 24 + color_cache_size` per §6.2.3.
  * `meta_prefix::ImageRole` — the §5.1 image-data role tag (`Argb`
    vs. `EntropyCoded`). Per §6.2.2 + §7.3 ABNF, the §6.2.2
    meta-prefix dispatch bit is present ONLY for the ARGB role.
  * `meta_prefix::MetaPrefixHeader::read(reader, role, image_w,
    image_h)` — the combined §5.2.3 + §6.2.2 + §6.2 preamble reader.
    Returns either `MetaPrefixCodes::Single { group }` (single
    prefix-code group, single Huffman group case + every non-ARGB
    role) or `MetaPrefixCodes::EntropyImagePending { prefix_bits,
    image_width, image_height, entropy_image_bit_position }` (ARGB
    role + multi-group case; the entropy image is itself a
    §5.2-encoded `entropy-coded-image` that requires the next layer's
    LZ77 + color-cache decoder, so the reader records the boundary
    and stops — mirroring how round 99 stopped at the first §5
    transform body and round 104 resumed there).
  * `meta_prefix::MetaPrefixError` plus public constants
    `COLOR_CACHE_BITS_MIN` / `COLOR_CACHE_BITS_MAX` /
    `PREFIX_BITS_MIN` / `PREFIX_BITS_MAX`.
* 15 new unit tests in `meta_prefix::tests` (color-cache info
  disabled / enabled at `code_bits` 1 / 11 / 0-refused / 12-refused,
  GREEN alphabet size formula, group read order matches §6.2,
  EntropyCoded role skips meta-prefix bit, ARGB single-group read,
  ARGB multi-group entropy-image boundary + bit position, ARGB
  `DIV_ROUND_UP` rounding, ARGB max `prefix_bits=9`, ARGB
  color-cache propagation into GREEN alphabet, truncated
  `ColorCacheInfo` EOF, truncated `MetaPrefixHeader` EOF) plus 3
  integration tests:
  * `round106_lossless_1x1_color_table_meta_prefix_header_reads_single_group`
    reads the COLOR_INDEXING transform's color-table image with the
    `EntropyCoded` role and asserts the surfaced group matches r104's
    by-hand decode (GREEN=60 / RED=180 / BLUE=90 / ALPHA=255 /
    DIST=0).
  * `round106_meta_prefix_argb_single_group_synthetic_matches_trace_shape`
    exercises the ARGB-role single-group shape (`color_cache_bits=0`,
    `meta_huffman=0`, `num_htree_groups=1`) every fixture trace
    reports when no entropy image is in play.
  * `round106_meta_prefix_argb_multi_group_records_entropy_image_boundary`
    exercises the ARGB-role multi-group shape (`prefix_bits=4` over a
    128×128 image), asserts 8×8 entropy-image dimensions and the
    recorded entropy-image bit position.
  Test count: **169** (was 151).
* The reader is **standalone-friendly** — `meta_prefix` compiles
  under `--no-default-features` with no `oxideav-core` dependency.

### Changed

* `Error` gained a `Vp8lMetaPrefix(meta_prefix::MetaPrefixError)`
  variant.

### Notes

`decode_webp` still returns `Error::NotImplemented`. Round 106 lands
the §5.2.3 + §6.2.2 + §6.2 preamble every §5 image-data block opens
with. The remaining lossless-pixel-path work is §5.2 LZ77
backward-reference decode + §5.2.3 color-cache *symbol-lookup*
decode (the per-pixel decoder that pulls symbols from a
`PrefixCodeGroup`) — that pair will close out the ARGB-role single-
and entropy-coded-image-role paths in one round, with the
entropy-image §5.2 decode (which feeds the ARGB multi-group path)
following thereafter.

* **Clean-room round 104 (2026-05-24).** VP8L §6.2.1 prefix-code
  reader + canonical decoder — the first piece of the §5 / §6 entropy
  machinery that sits on top of the round-99 §4 transform list. New
  module `vp8l_prefix` exposes:
  * `vp8l_prefix::PrefixCode` — a built canonical prefix code over an
    alphabet. `PrefixCode::read(reader, alphabet_size)` reads one
    code's lengths off the wire (dispatching on the §6.2.1 lead