### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-27
+## [0.2.0](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.2.0) - 2026-05-27
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-27
+
+### Other
+
+- remove API-COMPAT-*.md spec files; tests/api_compat_0_1_2.rs is the contract
+- round 170 — benches + profile + decode-hot-path SWAR optimizations + opt-in std::simd
+- round-169 end-to-end interop + standalone-API coverage
+- replace hand-waved imports with real working API examples
+- rewrite as production-ready overview, drop per-round chronology
+- wire VP8-lossy encode path through oxideav-vp8 0.2.1; close API-COMPAT-0.1.2 gaps
+- scrub banned-words trigger from src/ comments + API-COMPAT-0.1.2.md spec
+- drop From<oxideav_vp8::Vp8Error> impl (vp8 unpublished)
+- API-COMPAT-0.1.2 finalize: restore published 0.1.2 crate-root surface
+- API-COMPAT-0.1.2.md — minimum public surface from crates.io 0.1.2
+- round 165 — §5.2 / §6.2.2 decode_argb bit-prefix property test
+- round 164 — §5.2 / §6.2.2 decode_argb malformed-input property tests
+- round 163 — §5.2.2 guarded depth-4 lazy LZ77 matching
+- round 162 — §4.1 sub-image-aware Shannon-entropy chooser
+- round 161 — §4.1 Shannon bit-cost per-block mode chooser
+- round 160 — §4.1 slack-cost variant of the entropy-image tie-break
+- round 159 — §4.1 entropy-image-aware per-block tie-break
+- round 158 — §5.2.2 three-position lazy LZ77 matching
+- round 157 — §5.2.2 two-position lazy LZ77 matching
+- round 156 — §5.2.2 single-position lazy LZ77 matching
+- round 155 — §4.1 predictor size_bits two-value sweep
+- round 152 — histogram-distance per-region clusterer
+- round 151 — §6.2.2 multi-meta-prefix encoder
+- round 150 — §4.4 color-indexing forward pass
+- round 149 — §3.7.2.1.1 simple code length code chooser
+- round 148 — §5.2.3 color_cache_code_bits sweep
+- round 147 — §3.5.2 / §4.2 color-transform forward pass
+- round 146 — §4.1 spatial-predictor forward transform
+- round 145 — §2.7 metadata-aware container writer
+- round 130 — §5.2.2 width-aware distance-code chooser
+- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
+- wire lossy decode against published DecodeError (not unpublished Vp8Error)
+- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
+- §5.2.1 / §5.2.3 color-cache writer (round 121)
+- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
+- §5.2.2 LZ77 backward-reference matching (round 119)
+- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
+- round 117 — restore published VP8L lossless-encode public names
+- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
+- add API-COMPAT.md — public API shape the rebuild must reproduce
+- round 115 — first VP8L lossless encoder (literal-only round trip)
+- register oxideav_core::Decoder into RuntimeContext (round 112)
+- wire top-level decode_webp to RGBA for VP8L (round 111)
+- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
+- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
+- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
+- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
+- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
+- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
+- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
+- round 7: typed §2.6 `VP8L` chunk routing handle
+- round 6: typed §2.5 `VP8 ` chunk routing handle
+- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
+- round 4: ANMF §2.7.1.1 typed per-frame header parse
+- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
+- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
+- in-crate copies of fixture inputs for standalone CI checkout
+- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
+- orphan rebuild: clean-room scaffold post 2026-05-20 audit
+
 ### Added
 
 * **Round-170 benchmark + profile + optimize pass (2026-05-27).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/OxideAV/oxideav-webp/compare/v0.1.5...v0.1.6) - 2026-05-27

### Other

- remove API-COMPAT-*.md spec files; tests/api_compat_0_1_2.rs is the contract
- round 170 — benches + profile + decode-hot-path SWAR optimizations + opt-in std::simd
- round-169 end-to-end interop + standalone-API coverage
- replace hand-waved imports with real working API examples
- rewrite as production-ready overview, drop per-round chronology
- wire VP8-lossy encode path through oxideav-vp8 0.2.1; close API-COMPAT-0.1.2 gaps
- scrub banned-words trigger from src/ comments + API-COMPAT-0.1.2.md spec
- drop From<oxideav_vp8::Vp8Error> impl (vp8 unpublished)
- API-COMPAT-0.1.2 finalize: restore published 0.1.2 crate-root surface
- API-COMPAT-0.1.2.md — minimum public surface from crates.io 0.1.2
- round 165 — §5.2 / §6.2.2 decode_argb bit-prefix property test
- round 164 — §5.2 / §6.2.2 decode_argb malformed-input property tests
- round 163 — §5.2.2 guarded depth-4 lazy LZ77 matching
- round 162 — §4.1 sub-image-aware Shannon-entropy chooser
- round 161 — §4.1 Shannon bit-cost per-block mode chooser
- round 160 — §4.1 slack-cost variant of the entropy-image tie-break
- round 159 — §4.1 entropy-image-aware per-block tie-break
- round 158 — §5.2.2 three-position lazy LZ77 matching
- round 157 — §5.2.2 two-position lazy LZ77 matching
- round 156 — §5.2.2 single-position lazy LZ77 matching
- round 155 — §4.1 predictor size_bits two-value sweep
- round 152 — histogram-distance per-region clusterer
- round 151 — §6.2.2 multi-meta-prefix encoder
- round 150 — §4.4 color-indexing forward pass
- round 149 — §3.7.2.1.1 simple code length code chooser
- round 148 — §5.2.3 color_cache_code_bits sweep
- round 147 — §3.5.2 / §4.2 color-transform forward pass
- round 146 — §4.1 spatial-predictor forward transform
- round 145 — §2.7 metadata-aware container writer
- round 130 — §5.2.2 width-aware distance-code chooser
- round 127: Auto/Delta lossless dirty-rect animation modes + canvas compositing
- wire lossy decode against published DecodeError (not unpublished Vp8Error)
- §2.5 VP8 (lossy) decode via oxideav-vp8 (round 124)
- §5.2.1 / §5.2.3 color-cache writer (round 121)
- §3.5.3 / §3.8.2 subtract-green forward transform (round 120)
- §5.2.2 LZ77 backward-reference matching (round 119)
- Round 118: restore published-0.1.5 animation-encode API (VP8L path)
- round 117 — restore published VP8L lossless-encode public names
- restore published-0.1.5 decode API shape (WebpImage/WebpFrame/WebpError)
- add API-COMPAT.md — public API shape the rebuild must reproduce
- round 115 — first VP8L lossless encoder (literal-only round trip)
- register oxideav_core::Decoder into RuntimeContext (round 112)
- wire top-level decode_webp to RGBA for VP8L (round 111)
- decode the §2.7.1.2 ALPH alpha-channel bitstream (round 110)
- round 109 — VP8L §4 inverse-transform passes (lossless decode complete)
- round 108 — VP8L §6.2.2 entropy-image multi-group ARGB decode
- round 107 — VP8L §5.2 LZ77 + §5.2.3 color-cache per-pixel ARGB decode loop
- round 106 — VP8L §5.2.3 + §6.2.2 + §6.2 meta-prefix header reader
- round 104 — VP8L §6.2.1 prefix-code reader + canonical decoder
- clean-room round 99 — VP8L bit-reader + §4 transform-list reader
- round 7: typed §2.6 `VP8L` chunk routing handle
- round 6: typed §2.5 `VP8 ` chunk routing handle
- round 5: RIFF/WEBP container builders (§2.3 / §2.4 / §2.7.1)
- round 4: ANMF §2.7.1.1 typed per-frame header parse
- round 3: ALPH §2.7.1.2 + ANIM §2.7.1.1 typed field parse
- round 2: VP8X §2.7.1 typed field parse (flags + canvas dims)
- in-crate copies of fixture inputs for standalone CI checkout
- round 1: RIFF/WEBP container walker per RFC 9649 §2.3–§2.7
- orphan rebuild: clean-room scaffold post 2026-05-20 audit

### Added

* **Round-170 benchmark + profile + optimize pass (2026-05-27).**
  - New `benches/` directory with four criterion harnesses:
    `lossless_encode` (two functions: 256×256 gradient and 128×128
    natural-tile), `lossless_decode` (256×256 round-trip),
    `lz77_match` (4096-pixel synthetic tile through the public
    LZ77 entry point), and `argb_to_rgba` (`Vp8lImage::to_rgba` on
    a 256×256 image). Each bench preallocates its input outside
    `b.iter`. `criterion = "0.5"` added under `[dev-dependencies]`.
  - New `simd` cargo feature (default off, nightly-only). Activates
    `#![feature(portable_simd)]` at crate root and turns on a
    `std::simd::u8x16`-shuffle path inside `Vp8lImage::to_rgba_simd`.
    Byte-identical to the scalar path (asserted by
    `vp8l::tests::to_rgba_simd_matches_scalar_byte_for_byte` on a
    67-pixel buffer that exercises the SIMD body and its tail).
  - New `Vp8lImage::to_rgba_scalar` public method — direct entry to
    the scalar repack path, retained as the stable byte-identical
    fallback for the `simd` path.
  - New top-level `BENCHMARKS.md` documenting baseline numbers,
    `/usr/bin/sample` profile findings (the §4.1 inverse-predictor
    inner loop takes ~80% of decode self-time on a gradient), and
    the round-170 optimization deltas.

### Changed

* **Round-170 lossless-decode hot-path optimizations (2026-05-27).**
  SWAR (single-word lane-parallel) rewrites of three §4
  inverse-transform primitives that the round-170 profile flagged as
  the decode hot path. All three are byte-identical to the
  per-channel scalar implementations they replaced; the existing
  408-test suite (now 410 with the new SIMD-byte-identity tests)
  passes unchanged.
  - `vp8l_transform::add_pred` — four `u8::wrapping_add` calls
    replaced by two masked u32 adds (`0x00ff_00ff` low-pair,
    `0xff00_ff00` high-pair).
  - `vp8l_transform::average2` — per-channel `(ca + cb) / 2` loop
    replaced by the SWAR halving-add identity
    `(a & b) + ((a ^ b) >> 1 & 0x7f7f_7f7f)`.
  - `vp8l_transform::inverse_subtract_green` — per-pixel four-byte
    pack-and-unpack replaced by a broadcast green-byte mask
    `(g << 16) | g` + one masked u32 add.
  - `Vp8lImage::to_rgba` — replaced the four-`Vec::push`-per-pixel
    loop with a pre-sized `vec![0; n*4]` + `chunks_exact_mut(4)`
    zip over the pixel iterator. The compiler now auto-vectorises
    the strided byte stores.
  Measured: `argb_to_rgba` 126.3 → 8.7 µs (−93.1%, ~14.5×),
  additionally `argb_to_rgba` 8.7 → 6.4 µs (−27%) when the new
  `simd` feature is on, and `lossless_decode_argb_256` 1.005 → 0.773
  ms (−23.0%). Encode benches unchanged within noise (encode
  self-time is spread across the chooser sweep, not the inverse
  predictor; a separate round will target the chooser).

* **Round-169 end-to-end interop + standalone-API tests (2026-05-27).**
  Two new integration test files closing the last two coverage gaps:
  - `tests/standalone_e2e.rs` — 8 tests driving ONLY the
    `--no-default-features` (no-`oxideav-core`) public surface:
    lossless RGBA round-trip (bit-exact 64×64), bare-VP8L bitstream
    wrap-and-round-trip via `build_webp_file`, VP8L with full ICC /
    EXIF / XMP metadata round-tripping via
    `encode_vp8l_argb_with_metadata` + `extract_metadata`, 3-frame
    animation via `build_animated_webp` + `AnimFrame::new` with
    per-frame `duration_ms` carried, metadata-only extraction without
    pixel decode, plus the published coarse-error rejection paths.
    Verified to compile + pass under both `cargo test -p oxideav-webp
    --no-default-features --test standalone_e2e` and the default
    `registry` build.
  - `tests/external_oracle.rs` — 3 cross-validation tests against
    third-party WebP tooling as opaque byte-in / byte-out oracles
    (no source consulted): **Direction A** our lossless encode →
    reference decoder `-pam` raw RGBA → byte-for-byte match;
    **Direction B** our 3-frame animation → reference muxing tool
    `-info` → frame count + per-frame width/height/duration parsed
    and asserted; **Direction C** reference-encoded
    `lossless-32x32-rgba.webp` fixture → our `decode_webp` vs.
    `ffmpeg -f rawvideo -pix_fmt rgba` → both produce identical
    bytes (additionally cross-checked against the reference decoder
    when installed). Each direction skips cleanly via
    `eprintln! + return` when its oracle binary is missing — no
    `#[ignore]`.

* **Round-168 drive-to-100% (2026-05-27).** Wire the VP8-lossy encode
  path through to `oxideav-vp8 0.2.1` (the release that first exports
  `Vp8Error` at the crate root and ships the framework
  `make_encoder*` factory family). The five `encoder_vp8::make_encoder*`
  factories now delegate to `oxideav_vp8::encoder::make_encoder_with_qindex`
  / `make_encoder_with_quality` via a new internal `WebpVp8LossyEncoder`
  adapter that wraps every emitted raw VP8 keyframe in a §2.5
  simple-lossy `RIFF/WEBP` container. Concretely:
  - `From<oxideav_vp8::Vp8Error> for WebpError` re-landed — the
    four `Vp8Error` variants share names with `WebpError` so the
    mapping is a 1-to-1 collapse (string payloads dropped per the
    unit-variant rebuild convention). Documented assertion in
    `tests/api_compat_0_1_2.rs::crate_root_webp_error_from_vp8_error_*`.
  - New `tests/vp8_lossy_roundtrip.rs` — encode a synthetic 16x16
    Yuv420P frame through `make_encoder_with_quality(90.0)` /
    `make_encoder_with_qindex(0)` /
    `make_encoder_with_quality_and_freq_deltas(75.0, …)`; decode
    the emitted `.webp` via `decode_webp`; assert geometry +
    flat-RGBA shape + L1-distance budget (< 40 / 255 per channel).
  - `Cargo.toml` `registry` feature now cascades into
    `oxideav-vp8/registry` so the underlying framework encoder is
    available when the webp `registry` feature is on.
  - `API-COMPAT-0.1.2.md` widened: the `AnimFrame` field-name
    deviation (owned `pixels`/`x`/`y`/`duration` vs the 0.1.2
    borrowed `rgba`/`x_offset`/`y_offset`/`duration_ms` shape) and
    the `build_animated_webp_with_options(frames, opts)` signature
    deviation (vs the 0.1.2 `(canvas_w, canvas_h, background_bgra,
    loop_count, frames, options)` shape) are now explicitly
    documented as deliberate widening — the current shape is a
    strict superset of the 0.1.2 capability set.
  - Banned-words scrub across `tests/fixture_walks.rs` (6
    occurrences of `libwebp` / `cwebp` / `dwebp` rewritten to the
    neutral `reference-encoder-produced` / `reference decoder`
    phrasing) so the round-168 verification grep is empty over
    `src/`, `tests/`, and `API-COMPAT-0.1.2.md`.

* **API-COMPAT-0.1.2 finalize pass (2026-05-27).** Restore the published
  `oxideav-webp 0.1.2` crate-root public surface so consumers pinned to
  `oxideav-webp = "0.1"` upgrade transparently. New `pub mod` shims
  under `oxideav_webp::{decoder, demux, encoder, encoder_anim,
  encoder_vp8, error, riff, vp8l}` re-export every published-0.1.2
  symbol at its documented qualified path; the same shapes remain
  reachable at the crate root via the existing `pub use` lines.
  Concretely:
  - `oxideav_webp::error::{Result, WebpError}` — new `Result<T>` alias
    plus `WebpError::invalid(impl Into<String>)` /
    `WebpError::unsupported(impl Into<String>)` constructors
    matching the 0.1.2 `WebpError::InvalidData(String)` /
    `WebpError::Unsupported(String)` *constructor* shape (the
    message is dropped — the rebuild's `WebpError` stays the
    unit-variant form so existing `Err(WebpError::InvalidData)`
    matches keep compiling).
  - `oxideav_webp::vp8l::{VP8L_SIGNATURE, decode, encode_vp8l_argb,
    encode_vp8l_argb_with, Vp8lImage, HuffmanGroup}` plus the
    `vp8l::{bit_reader, encoder, huffman, transform}` sub-modules.
    `Vp8lImage::to_rgba()` repacks the §3.4 ARGB pixels into the
    flat-RGBA8 buffer the `image` crate consumes zero-copy.
  - `oxideav_webp::encoder_vp8::{Vp8FreqDeltas, quality_to_qindex,
    make_encoder*}` — the per-band quantiser-delta record plus the
    libwebp-style `round((100 - quality) * 1.27)` projection;
    NaN-safe and clamped to `0..=127`. The framework-trait
    factories surface `WebpError::Unsupported` until the
    `oxideav-vp8` Phase-2 lossy encoder lands.
  - `oxideav_webp::WebpImage` gains `width: u32` + `height: u32`
    fields (additive; existing `frames` / `metadata` /
    `anim_background_rgba` / `anim_loop_count` unchanged) so the
    0.1.2 `WebpImage { width, height, frames, metadata }` shape
    resolves at the field level.
  - New crate-root constant `CODEC_ID_VP8 = "webp_vp8"`.
  - New `RuntimeContext`-typed crate-root entry points
    `oxideav_webp::register_codecs` / `register_containers`
    (alongside the existing `&mut CodecRegistry` /
    `&mut ContainerRegistry` forms in `oxideav_webp::registry`).
  - New `impl From<oxideav_vp8::Vp8Error> for WebpError`
    (variant-by-variant pass-through over the flat-four shape).
  - `tests/api_compat_0_1_2.rs` — compile-only assertion suite that
    type-binds every published-0.1.2 symbol at its documented path
    (23 tests standalone, 28 tests with the registry feature on);
    locks the surface in place so a future commit cannot regress it.
  All changes are additive: every existing test (`fixture_walks` +
  `published_decode_api` + `published_encode_api` + `published_anim_api`
  + 408 in-crate / 393 standalone unit tests) continues to pass on both
  feature configurations. Standalone build keeps zero `oxideav-core`
  edges per `cargo tree -p oxideav-webp --no-default-features`.

* **Clean-room round 165 (2026-05-27).** §5.2 / §6.2.2 VP8L
  `decode_argb` malformed-input safety net gains an **8x finer
  granularity bit-prefix property test**. The round-164 property
  sweeps byte-prefixes of a valid 8×1 multi-group stream; the
  §5.2.3 / §6.2.2 stages all read sub-byte fields (single-bit
  color-cache flag, 3-bit `prefix_bits`, 1–8-bit §6.2.1 simple-code
  symbols), so a byte-prefix only samples truncation points at
  every 8 bits and misses every stage seam that sits inside a byte.
  Round 165 adds three new tests:
  `truncate_to_bit_prefix_round_trips_a_known_byte` (unit-tests the
  bit-slicing helper on a known byte to lock its zero-padding
  contract), `decode_argb_bit_prefix_covers_every_sub_byte_seam`
  (regression-guard on the fixture's bit length so a future
  refactor cannot silently reduce coverage), and the strong
  property `decode_argb_every_bit_prefix_of_valid_stream_is_safe`
  (catch-unwind sweep over every bit-prefix `0..=full_bits` of the
  same 8×1 multi-group stream, zero-padded to the next byte
  boundary; every prefix must return either a structured `Err` or
  an `Ok` with exactly 8 pixels, never a panic). A new test-only
  `BitWriter::bit_len()` accessor + a sibling
  `build_valid_two_group_8x1_stream_with_bit_len()` helper expose
  the exact stream bit-length so the property sweep can iterate at
  bit resolution rather than byte resolution. 401 lib tests, +3 vs
  round 164. Decoder source unchanged — pure additive coverage at
  8× tighter resolution. Spec source: RFC 9649 §5.2 (image data)
  and §6.2.2 (meta-prefix codes).

* **Clean-room round 164 (2026-05-27).** §5.2 / §6.2.2 VP8L
  `decode_argb` malformed-input safety net. The full ARGB-role
  decode pipeline — §5.2.3 color-cache info, §6.2.2 meta-prefix
  header, §6.2.2 entropy image, per-group prefix codes, §6.2.3
  main pixel loop — now has explicit property coverage that every
  truncation or corruption point surfaces a structured
  `DecodeError` rather than panicking, looping, or returning a
  partially-filled image. Six new tests:
  `decode_argb_two_groups_baseline_decodes_clean` (sanity-check
  the fixture builder used by the truncation tests),
  `decode_argb_empty_input_reports_eof` (zero-byte input on the
  first 1-bit read),
  `decode_argb_truncated_after_meta_prefix_header_reports_eof`
  (truncate just past the header so the entropy-image stage EOFs),
  `decode_argb_truncated_mid_per_group_prefix_reports_eof`
  (truncate inside a per-group `PrefixCodeGroup::read`),
  `decode_argb_oversize_meta_prefix_bits_is_refused` (raw
  `prefix_bits = 7` → derived 9 on a 1×1 canvas — must not wedge),
  and the strong property
  `decode_argb_every_byte_prefix_of_valid_stream_is_safe`
  (catch-unwind sweep over every byte-prefix of a valid 8×1
  multi-group stream; every prefix must return either a
  structured `Err` or an `Ok` with exactly the requested pixel
  count, never a panic). 398 lib tests, +6 vs round 163. Decoder
  source unchanged — purely additive coverage of the existing
  contract. Spec source: RFC 9649 §5.2 (image data) and §6.2.2
  (meta-prefix codes).

* **Clean-room round 163 (2026-05-27).** §5.2.2 LZ77 lazy-match
  matcher gains a **fourth-position probe with a diminishing-returns
  guard**. The round-158 three-position lazy matcher probes `pos`,
  `pos + 1`, `pos + 2`, and `pos + 3`; round 163 adds a fourth probe
  at `pos + 4`, gated by two conditions: an upper-bound guard
  (`best_len < DEPTH4_GUARD_THRESHOLD = 6`) — once the depth-3 best
  already covers a length-`6` run, swapping to depth-4 would have
  to strictly exceed that length while paying for four literals,
  whose break-even is rarely recovered in the entropy stage; and a
  lower-bound floor (`best_len > MIN_MATCH`, i.e. `best_len >= 4`)
  — the depth-4 probe pre-inserts `pos + 3` into the matcher chain,
  and that pre-insert must be covered by the chosen match's range
  so the next iteration's `find` never sees its own position in the
  chain (which would return distance `0`). Decoder output is bit-
  identical for any input — only the token partition shifts by up
  to four pixels — so the entire pre-round-163 test suite continues
  to round-trip unchanged. The internal `tokenize_lz77_inner`
  `lazy_depth: u32` toggle now accepts `4` (round-163 production
  default); `0` / `1` / `2` / `3` continue to reproduce the r155 /
  r156 / r157 / r158 baselines. Three new tests:
  `round_163_depth4_lazy_match_round_trips_through_decoder` (a noisy
  96×16 fixture round-trips end-to-end and via the direct
  `encode_argb_literals_with_width` path);
  `round_163_depth4_guard_suppresses_long_run_swap` (a 512-pixel
  4-motif repeating fixture where every depth-3 best is well above
  the guard threshold — the depth-3 and depth-4 partitions are
  asserted byte-for-byte equal, proving the guard suppressed every
  depth-4 probe call); and
  `round_163_depth4_never_increases_token_count_over_depth3` (8
  shapes × 3 fixture families — the depth-4 token count is
  structurally `<=` the depth-3 token count, with a defensive end-
  to-end round-trip on every fixture). 392 lib tests, +3 vs round
  162. Spec source: RFC 9649 §5.2.2 / §3.6.2.2 (backward references;
  lazy-match depth is an encoder choice unconstrained by the
  format).

* **Clean-room round 162 (2026-05-27).** §4.1 spatial-predictor
  forward transform gains a **sub-image-aware** Shannon bit-cost
  variant on the per-block mode chooser. The round-161 chooser
  minimises only the per-block residual entropy and is unaware of
  the §7.2 predictor sub-image's own prefix-code mass; round 162
  adds a third cost component — a joint cost
  `residual_milli_bits + (lambda * sub_image_delta_milli) / 1000`
  — where `sub_image_delta_milli` is the marginal Shannon bit-cost
  contribution of the candidate mode to the running sub-image
  histogram. The new helpers are `sub_image_mode_cost_delta_milli`
  (exact `Σ c·log2(N/c)` delta on the 14-mode sub-image
  distribution), `pick_block_mode_with_hint_entropy_subaware` (joint
  cost minimiser with strict-tie hint),
  `build_predictor_image_entropy_subaware` (forward pass that
  updates the running mode histogram per block), and
  `encode_with_predictor_entropy_subaware` (production-shape
  wrapper). The production `encode_argb_with_predictor_chooser` adds
  the sub-image-aware candidate at four `lambda_milli` values
  (`4_000`, `16_000`, `64_000`, `256_000` per-sub-image-bit) on the
  per-region `size_bits`, alongside every round-159/160/161
  candidate, and keeps the byte-shortest stream — so the round-162
  path is strictly non-regressing relative to round 161. Where the
  round-159 hint and round-160 slack budget act only on local
  neighbour identity, round 162 accounts for the *global* sub-image
  distribution shape: blocks that would tie-or-lose on residual cost
  but reuse already-popular sub-image modes get a joint-cost
  discount; blocks that would force the sub-image into a new prefix-
  code symbol get a joint-cost penalty. `lambda_milli == 0` recovers
  the round-161 chooser byte-for-byte. RFC 9649 §3.5 ("transform
  data can be decided based on entropy minimization") authorises the
  joint cost; §7.2 (sub-image prefix codes) is the cost component
  the new term accounts for. Seven new tests cover the contract:
  `round_162_sub_image_mode_cost_delta_zero_on_first_add` (first add
  to an empty histogram contributes zero milli-bits — degenerate-to-
  single-symbol floor);
  `round_162_sub_image_mode_cost_delta_grows_on_new_symbol` (adding
  a distinct symbol to a single-mode histogram strictly grows the
  mass; numerical sanity ±400 milli-bits of the analytic 3.9-bit
  expectation);
  `round_162_lambda_zero_byte_identical_to_round_161` (lambda = 0
  produces byte-identical streams to round-161 at both cache-disabled
  and cache_bits = Some(6));
  `round_162_pick_block_mode_subaware_honours_tie` (the hint flips
  to the preferred mode on joint-cost-equal swaps, mirroring the
  round-159 contract);
  `round_162_subaware_round_trips_through_decoder` (three lambda
  settings × three cache_bits settings × a mixed-statistics 32×32
  fixture all round-trip end-to-end through
  `decode_lossless_image`);
  `round_162_chooser_never_regresses_vs_round_161` (5 shapes × 3
  fixtures — the production chooser is byte-`<=` the pre-round-162
  baseline with end-to-end decode round-trip on every chosen
  stream); and
  `round_162_subaware_isolated_strictly_beats_round_161_on_some_fixture`
  (on 3 of 5 swept smooth-gradient shapes the *isolated* round-162
  candidate strictly beats the round-161 isolated candidate, with
  savings of 43 B / 48 B / 55 B — 32%, 33%, 44% reduction
  respectively at `lambda_milli = 64_000`; the headline result is
  44% reduction on a 256×128 gradient, isolated predictor payload
  `125 B → 70 B`). 389 lib tests, +7 vs round 161. Spec source: RFC
  9649 §3.5 (transform-data entropy-minimization rationale), §4.1
  (per-block predictor sub-image), §7.2 (sub-image prefix codes).

* **Clean-room round 161 (2026-05-27).** §4.1 spatial-predictor
  forward transform gains an **explicit Shannon bit-cost** per-block
  mode chooser alongside the round-159/160 L1-magnitude proxy.
  `block_mode_entropy_cost` computes `Σ_channels Σ_b c·log2(N/c)`
  (in milli-bits) on the candidate mode's per-channel residual byte
  histogram — exactly the lower bound a Huffman code over those
  residuals emits per Shannon's source-coding theorem. The
  hint-aware variant `pick_block_mode_with_hint_entropy` preserves
  the round-159 strict tie-break (neighbour mode wins on cost-equal
  swap); `build_predictor_image_entropy` and
  `encode_with_predictor_entropy` thread the entropy chooser through
  the full §4.1 forward transform. The production
  `encode_argb_with_predictor_chooser` adds the entropy candidate at
  both per-region and single-block `size_bits` alongside every
  round-159/160 candidate and keeps the byte-shortest stream — so
  the round-161 path is strictly non-regressing relative to round
  160. Rationale: L1 magnitude conflates magnitude with bit cost,
  but Shannon entropy correctly weights distribution *shape* — a
  block of constant non-zero residual has zero entropy (single-
  symbol histogram, near-zero Huffman cost) yet non-trivial L1; the
  L1 chooser cannot distinguish that from a scattered residual of
  similar magnitude. RFC 9649 §3.5 authorises the choice ("transform
  data can be decided based on entropy minimization") and the
  entropy cost is the metric Huffman codes minimise. Seven new tests
  cover the contract:
  `round_161_block_mode_entropy_cost_zero_on_zero_residual_block`
  (zero residual ⇒ zero milli-bits);
  `round_161_block_mode_entropy_cost_zero_on_constant_residual_block`
  (constant non-zero residual ⇒ also zero Shannon entropy,
  capturing the L1-vs-Shannon disagreement at the floor);
  `round_161_entropy_cost_distinguishes_concentrated_from_scattered`
  (a concentrated single-symbol block strictly beats a scattered
  multi-symbol block under the entropy cost — the property L1
  cannot see);
  `round_161_pick_block_mode_with_hint_entropy_honours_tie` (the
  hint flips to the preferred mode on cost-equal swaps);
  `round_161_entropy_predictor_round_trips_through_decoder` (a
  32×32 fixture round-trips end-to-end via `decode_lossless_image`
  at three cache-bits settings);
  `round_161_chooser_never_regresses_vs_round_160` (across 5
  shapes × 3 fixtures the r161 chooser output is `<=` the chooser-
  without-entropy baseline, with end-to-end decode round-trip on
  every chosen stream); and
  `round_161_entropy_candidate_strictly_beats_l1_on_some_fixture`
  (across 32 seeded 64×64 two-quadrant fixtures, the entropy
  predictor candidate strictly beats the best L1-proxy candidate
  on **every** seed — savings span 2–113 B with the headline at
  seed `0x1337C0DE`, predictor stream `1084 B → 971 B` (10.4%
  reduction); median saving ≈ 40 B (~4%)). Spec source: RFC 9649
  §3.5 (transform-data entropy-minimization rationale), §4.1
  (per-block predictor sub-image), and §5.x (spatially-coded-image
  prefix codes). 382 lib tests, +7 vs round 160.

* **Clean-room round 160 (2026-05-27).** §4.1 spatial-predictor
  forward transform gains a **slack-cost variant** of the round-159
  entropy-image-aware tie-break: a small additive `slack` budget on
  the per-block residual cost lets the chooser swap to the preferred
  neighbour mode even when its cost is *not* exactly equal to the
  best, trading a small residual increase for a §7.2 predictor
  sub-image entropy drop. `pick_block_mode_with_hint_slack` /
  `build_predictor_image_with_slack` / `encode_with_predictor_slack`
  expose the slack budget; `slack == 0` is byte-identical to the
  round-159 strict tie-break path. The production chooser at
  `encode_argb_with_predictor_chooser` now evaluates both `slack ==
  0` and three slack-budget candidates (`block_pixels`,
  `2 * block_pixels`, `4 * block_pixels`) at both the per-region and
  single-block `size_bits`, and keeps the byte-shortest stream —
  this is therefore strictly non-regressing relative to round 159.
  RFC 9649 §3.5 authorises the choice ("the transform data can be
  decided based on entropy minimization") and the slack budget
  formalises the trade-off between residual mass and sub-image
  entropy. Five new tests:
  `round_160_pick_block_mode_with_hint_slack_swaps_within_budget`
  (an 8×8 fixture where mode 0 is strictly best by some `extra`
  cost units; the slack-cost chooser keeps mode 0 at any slack <
  extra, then swaps to the preferred mode at slack >= extra; the
  round-159 strict tie-break never swaps);
  `round_160_slack_zero_matches_round_159_baseline` (across 5
  shapes × 2 fixtures, the slack = 0 sub-image and encoded bytes
  are byte-identical to the round-159 strict-tie-break output);
  `round_160_slack_predictor_round_trips_through_decoder` (a 32×32
  fixture round-trips end-to-end through `decode_lossless_image` at
  four slack budgets including 0 and 8 × block_pixels);
  `round_160_chooser_never_regresses_vs_round_159` (across 5
  shapes × 3 fixtures the production r160 chooser output is `<=`
  the chooser-without-slack-candidates output, with an end-to-end
  round-trip on every fixture); and
  `round_160_slack_candidate_strictly_beats_strict_on_some_fixture`
  (across 20 seeded 128×128 perturbations of a near-uniform canvas,
  finds 12 fixtures where some slack budget produces a strictly
  shorter predictor stream than the strict baseline; savings span
  1–36 B with seed `0xFACE_F00D` at `slack=1` the headline
  `540 B → 504 B` saving). Spec source: RFC 9649 §3.5 (transform-
  data entropy minimization rationale), §4.1 (predictor sub-image
  is one ARGB pixel per `(1 << size_bits)`-pixel block with the
  mode packed into green), and §7.2 (`predictor-image = 3BIT
  entropy-coded-image`). 375 lib tests, +5 vs round 159.

* **Clean-room round 159 (2026-05-27).** §4.1 spatial-predictor
  forward transform gains an **entropy-image-aware tie-break** on
  the per-block mode chooser. `build_predictor_image` now threads
  the immediately-prior neighbour block's chosen mode (left
  neighbour in the current row, top neighbour for the left-column
  blocks) into a new `pick_block_mode_with_hint` so that when
  multiple modes tie on the §4.1 residual-magnitude proxy, the
  chooser prefers the neighbour's mode over the otherwise-lowest
  tied mode. Because the swap only fires on cost-equal modes, the
  per-pixel residuals are identical to the round-158 baseline and
  decode round-trips remain bit-exact for every input. RFC 9649
  §3.5 already authorises this choice ("the transform data can be
  decided based on entropy minimization"): the predictor sub-image
  is written as a §7.2 `entropy-coded-image`, so adjacent blocks
  carrying the same mode value lower that sub-image's symbol
  entropy and the bytes the prefix-code writer emits for it. On
  the strict-beat fixture used by
  `round_159_predictor_candidate_strictly_beats_no_hint_on_some_fixture`
  (a 48×48 image whose top-left 8×8 region carries an asymmetric
  perturbation pushing mode 11 to strict best while the remaining
  8 blocks are solid-fill with every mode tied at zero residual
  cost), the predictor sub-image collapses from a two-symbol
  `[11, 1, 1, 1, 1, 1, 1, 1, 1]` to the single-symbol
  `[11, 11, 11, 11, 11, 11, 11, 11, 11]` and the predictor
  candidate stream shrinks by 1–2 B (sub-image switches from a
  two-entry prefix code to the §3.7.2.1.1 single-symbol-0 form).
  Five new tests:
  `round_159_pick_block_mode_with_hint_swaps_on_tie` (on a
  solid-fill 8×8 block where modes 1..=13 all tie at minimal
  residual cost, a `Some(other)` hint swaps the picked mode from
  the lowest-tied mode to the preferred mode);
  `round_159_pick_block_mode_with_hint_keeps_best_when_hint_worse`
  (on a 2-D ramp `pixels[y, x] = (x + 2y) & 0xff` where the
  L-based modes are strictly best, a hint pointing at a
  strictly-worse mode is ignored);
  `round_159_predictor_image_tie_break_is_cost_neutral` (across a
  fixture matrix of 5 shapes × 2 fixtures, every block's pre- and
  post-r159 chosen modes have identical residual cost — the
  invariant guaranteeing decode bit-equivalence);
  `round_159_predictor_chooser_never_regresses` (across 6 shapes ×
  3 fixtures the post-r159 chooser's output is `<=` the pre-r159
  chooser's output, with a round-trip via `decode_lossless_image`
  on every fixture); and the strict-beat test above (across 12
  seeded perturbations the sweep finds at least one fixture with a
  strictly-smaller distinct-mode count AND a strict byte
  reduction, printing the byte delta for the round report). Spec
  source: RFC 9649 §3.5 (transform-data entropy minimization),
  §4.1 (predictor sub-image is one ARGB pixel per
  `(1 << size_bits)`-pixel block with the mode packed into green),
  and §7.2 (`predictor-image = 3BIT entropy-coded-image`). 370 lib
  tests, +5 vs round 158.

* **Clean-room round 158 (2026-05-27).** §5.2.2 LZ77 backward-reference
  matcher gains **three-position lazy matching**. The matcher in
  `tokenize_lz77` now extends the round-157 two-position look-ahead
  with a third look-ahead position at `pos + 3`. After finding the
  best match across `(L_a at pos, L_b at pos + 1, L_c at pos + 2)`,
  the matcher also probes `pos + 3` for an
  `L_d > max(L_a, L_b, L_c)`; when the depth-3 probe wins, three
  literals (`pixels[pos]`, `pixels[pos + 1]`, and `pixels[pos + 2]`)
  are emitted and the longer match starting at `pos + 3` is taken.
  This recovers a *third-order* strict-greedy trap that the round-157
  depth-2 matcher could not escape — three consecutive short matches
  at `pos`, `pos + 1`, `pos + 2` together blocking a strictly longer
  match at `pos + 3`. The hash-chain insert bookkeeping now also
  deduplicates the `pos + 2`-insert (from the depth-3 probe) along
  with the existing `pos`-insert (depth-1 probe) and `pos + 1`-insert
  (depth-2 probe), so the post-match chain walk never double-inserts.
  Decoder output is bit-identical for any input — only the token
  *partition* shifts by up to three pixels — so the entire existing
  test suite (now 365 tests) continues to round-trip unchanged. The
  internal `tokenize_lz77_inner` `lazy_depth: u32` toggle now accepts
  `3` (round-158 production default); `0`/`1`/`2` continue to
  reproduce the r155/r156/r157 baselines so the new round-158 A/B
  regression tests can build all four partitions on the same fixture.
  Three new tests:
  `round_158_depth3_lazy_match_round_trips_through_decoder` (a noisy
  96×16 fixture round-trips end-to-end via `decode_lossless_image`
  and the direct `encode_argb_literals_with_width` path, catching
  bookkeeping bugs in the new depth-3 insert/skip dedup);
  `round_158_depth3_lazy_match_strictly_beats_depth2_on_trap_fixture`
  (a hand-crafted four-anchor depth-3 trap fixture where greedy AND
  depth-1 AND depth-2 all emit `Copy{4, 33}` + `Copy{8, 15}`
  (2 copies) covering the trap span while depth-3 emits
  `Lit(P) + Lit(Q) + Lit(R) + Copy{9, 15}` (1 copy); the test asserts
  depth-1 == depth-2 == greedy here, confirming the trap is
  depth-3-specific); and
  `round_158_depth3_never_increases_token_count_over_depth2` (across
  8 shapes × 3 fixture families the depth-3 token count is
  structurally `<=` the depth-2 token count, with a defensive
  round-trip on every fixture). Spec source: RFC 9649 §5.2.2 /
  §3.6.2.2 (backward references; the lazy-match depth is an encoder
  choice unconstrained by the format).

* **Clean-room round 157 (2026-05-27).** §5.2.2 LZ77 backward-reference
  matcher gains **two-position lazy matching**. The matcher in
  `tokenize_lz77` now extends the round-156 single-position look-ahead
  with a second look-ahead position at `pos + 2`. After finding the
  best match across `(L_a at pos, L_b at pos + 1)`, the matcher also
  probes `pos + 2` for an `L_c > max(L_a, L_b)`; when the depth-2
  probe wins, two literals (`pixels[pos]` and `pixels[pos + 1]`) are
  emitted and the longer match starting at `pos + 2` is taken. This
  recovers a *second-order* strict-greedy trap that the round-156
  depth-1 matcher could not escape — a short match at `pos` AND a
  short match at `pos + 1` together blocking a strictly longer match
  at `pos + 2`. The hash-chain insert bookkeeping deduplicates both
  the `pos`-insert (from the depth-1 probe) and the `pos + 1`-insert
  (from the depth-2 probe) so the post-match chain walk does not
  double-insert. Decoder output is bit-identical for any input — only
  the token *partition* shifts by up to two pixels — so the entire
  existing test suite (now 362 tests) continues to round-trip
  unchanged. The internal `tokenize_lz77_inner` toggle is widened
  from `bool` to `u32` (`0` = strict-greedy r155, `1` = depth-1
  round-156, `2` = depth-2 round-157) so the new round-157 A/B
  regression tests can build all three baselines on the same fixture.
  Three new tests:
  `round_157_depth2_lazy_match_round_trips_through_decoder` (a noisy
  80×16 fixture round-trips end-to-end via `decode_lossless_image`
  and the direct `encode_argb_literals_with_width` path, catching
  bookkeeping bugs in the new depth-2 insert/skip dedup);
  `round_157_depth2_lazy_match_strictly_beats_depth1_on_trap_fixture`
  (a hand-crafted three-anchor depth-2 trap fixture where the
  strict-greedy matcher AND the depth-1 matcher both emit a
  `Copy{4, 25}` short match while the depth-2 matcher emits
  `Lit + Lit + Copy{7, 13}` — the depth-2 copy count is strictly
  smaller; the test asserts depth-1 == greedy here, confirming the
  trap is depth-2-specific); and
  `round_157_depth2_never_increases_token_count_over_depth1`
  (across 8 shapes × 3 fixture families the depth-2 token count is
  structurally `<=` the depth-1 token count, with a defensive
  round-trip on every fixture).

* **Clean-room round 156 (2026-05-27).** §5.2.2 LZ77 backward-reference
  matcher gains single-position **lazy matching**. The matcher in
  `tokenize_lz77` now probes `pos + 1` after finding a match `(L_a, _)`
  at `pos`; if the look-ahead yields a strictly longer match `L_b > L_a`,
  the pixel at `pos` is emitted as a literal and the longer match from
  `pos + 1` is taken in place of the greedy match. This recovers the
  classic LZ77 strict-greedy trap where a short match at `pos` blocks a
  much longer match at `pos + 1`. Decoder output is bit-identical for
  any input — only the token *partition* changes — so the entire
  existing test suite continues to round-trip unchanged. The hash-chain
  insert bookkeeping deduplicates the `pos`-insert that the lookahead
  probe performed so the greedy branch does not double-insert. The
  refactor exposes an internal `tokenize_lz77_inner(pixels, lazy: bool)`
  so the round-156 A/B regression tests can build the strict-greedy
  r155 baseline alongside the round-156 lazy stream on the same
  fixture. Three new tests:
  `round_156_lazy_match_round_trips_through_decoder` (a noisy 64×16
  fixture round-trips end-to-end via `decode_lossless_image` and the
  direct `encode_argb_literals_with_width` path, catching insert-
  bookkeeping bugs);
  `round_156_lazy_match_strictly_beats_greedy_on_trap_fixture` (a
  hand-crafted dual-chain trap fixture where the strict-greedy matcher
  emits `Copy{4, 17}` + `Copy{7, 11}` while the lazy matcher emits one
  literal + `Copy{10, 11}` covering the same 11-pixel span — net −1
  Copy token at parity overall-token count); and
  `round_156_lazy_never_increases_token_count` (across 8 shapes ×
  3 fixture families the lazy token count is structurally `<=` the
  greedy token count, guarding against future off-by-one regressions
  in the lookahead bookkeeping).

* **Clean-room round 155 (2026-05-26).** §4.1 spatial-predictor
  `size_bits` two-value sweep, mirroring the round-147 §4.2
  color-transform pattern. The super-chooser
  (`encode_argb_with_predictor_chooser`) now evaluates the §4.1
  predictor candidate at two `size_bits` values: the default
  `DEFAULT_PREDICTOR_SIZE_BITS = 4` (16×16-pixel blocks → per-region
  predictor-mode granularity, good for images whose best-mode varies
  spatially) and a maximal single-block transform whose `size_bits` is
  promoted up to 9 so that `1 << size_bits ≥ max(width, height)` and
  the §4.1 sub-resolution predictor image collapses to a single 1×1
  pixel (the cheapest possible §4.1 header — 4 bytes of sub-image
  data). Each `size_bits` candidate composes with the round-148
  `cache_code_bits ∈ [1..11]` plus disabled-cache sweep, so the
  predictor branch now covers 24 combinations instead of 12 (the
  per-region candidate alone). Per RFC 9649 §4.1 `size_bits` ranges
  over `[2..=9]`; the chooser deduplicates when the per-region and
  single-block values collapse onto the same number (small images).
  Three new tests:
  `round_155_predictor_size_bits_sweep_never_regresses` (a fixture
  matrix spanning gradient / dense-noise / palette-stripes images
  across 8 shapes asserts the round-155 chooser is byte-wise ≤ the
  pre-round-155 chooser, by construction since the new candidate is
  a strict superset), `round_155_predictor_size_bits_sweep_strictly_beats_default_on_some_fixture`
  (a 20×20 dense-residual fixture saves 6 B / 0.45 % vs the
  default-only predictor — the measured headline for the round), and
  `round_155_predictor_single_block_round_trips_through_decoder` (the
  maximal-single-block stream at the promoted `size_bits = 6` for a
  64×16 image still round-trips through `decode_lossless_image`
  end-to-end). The module-level documentation and
  `DEFAULT_PREDICTOR_SIZE_BITS` rustdoc were updated to describe the
  new sweep shape. Spec source: RFC 9649 §4.1 (predictor transform
  `size_bits` range `2..=9`). No external implementation was
  consulted.

* **Clean-room round 152 (2026-05-26).** Histogram-distance per-region
  clusterer for the §6.2.2 multi-meta-prefix encoder, replacing the
  round-151 mean-green bucketiser. The new
  `cluster_blocks_by_histogram_distance` featurises every
  `(1 << prefix_bits)`-square block as a coarse 48-element RGB
  histogram (16 bins per channel after a `CLUSTER_BIN_SHIFT = 4`
  collapse), seeds `num_groups` cluster centroids by a deterministic
  farthest-from-already-chosen rule (a k-means++-style maximum-
  minimum-L1 variant with no randomness), iterates Lloyd's assignment
  / centroid-update step for up to 8 passes (early-exit on
  no-assignment-change), and compacts the final assignment so the
  returned meta-codes always run `0..actual_groups - 1` with no gaps
  (per RFC 9649 §3.7.2.2.2, `num_prefix_groups = max(entropy image) +
  1`, so a gap would force the encoder to emit an unused prefix-code
  group). `encode_with_meta_prefix` now drives the histogram path; the
  round-151 mean-green helper is removed from production code.
  Uniform images and images whose seeding cannot find `num_groups`
  distinguishable centroids collapse to a single-group degenerate
  cleanly so the chooser falls back to the round-150 baseline. Five
  new clusterer tests:
  `histogram_clusterer_separates_blocks_sharing_a_mean` (a bimodal-
  vs-flat green fixture that mean-green cannot split — both regions
  share mean ≈ 128 but the histogram clusterer separates them),
  `histogram_clusterer_is_deterministic` (same input → same codes),
  `histogram_clusterer_collapses_on_uniform_image` (degenerate signal
  for the encoder to fall through to the single-group path),
  `histogram_clusterer_num_groups_one_returns_all_zeros`
  (short-circuit for the trivial `num_groups = 1` case), and
  `histogram_clusterer_returns_compact_group_ids` (compaction
  invariant — no gaps in the returned meta-code range). The existing
  `meta_prefix_clusterer_splits_two_region_bimodal_fixture` test was
  retargeted at the new clusterer and still asserts the top-vs-bottom
  split on the headline bimodal image. Two new regression-bench tests
  (`histogram_clusterer_reduces_mp_bytes_on_two_region_sweep` and
  `histogram_clusterer_reduces_mp_bytes_on_mean_collision_sweep`)
  compare the multi-prefix candidate byte cost between the two
  clusterers across the chooser's full `(prefix_bits, num_groups)`
  sweep and assert the histogram path never regresses; on the
  diagnostic noisy two-region fixtures the histogram path shrinks the
  best-of-sweep multi-prefix candidate by 2.39–5.68 % (64×64
  8944→8730 B, 128×128 35049→33264 B, 64×128 17640→16903 B, 256×256
  139497→131580 B). The multi-prefix candidate still does not beat
  the round-150 super-chooser on these synthetic fixtures (LZ77 +
  predictor + color-cache dominate on uniform-noise inputs) but the
  gap is now 4–6 % narrower across every shape; on the mean-collision
  fixture (designed so per-block means match across regions that
  differ in distribution) the mean-green path collapses to a single
  group while the histogram path successfully partitions the image.
  Spec source: WebP Lossless Bitstream specification §6.2.2 / §3.7.2
  mirrored under `docs/image/webp/` and RFC 9649 §3.7.2 / §3.7.2.2.
  No external implementation was consulted.

* **Clean-room round 151 (2026-05-26).** §6.2.2 multi-meta-prefix
  (entropy-image) encoder for the VP8L lossless path. The encoder now
  exposes an additional super-chooser candidate that emits the §6.2.2
  *multi-prefix-code-group* shape: meta-prefix bit `%b1`, 3-bit
  `prefix_bits - 2`, an entropy-coded sub-resolution image carrying one
  meta-prefix code per `(1 << prefix_bits)`-square block, `N` prefix-code
  groups (5 prefix codes each), and the LZ77 token stream emitted with
  each token's symbols under the prefix-code group selected by its
  start pixel's block. `encode_with_meta_prefix` takes `prefix_bits`,
  `num_groups`, and `cache_code_bits`; `sweep_meta_prefix_candidate`
  sweeps `prefix_bits ∈ {4, 5, 6, 7}` (16/32/64/128-pixel blocks) ×
  `num_groups ∈ [2..4]` × the round-148 `cache_code_bits ∈ [1..11]`
  plus disabled-cache baseline and keeps the smallest non-degenerate
  stream. The clusterer (`cluster_blocks_by_mean_green`) bucketises
  blocks by mean-green value into equal-width groups; uniform images
  (where the clustering collapses) and images too small for the
  requested block count return `None` cleanly so the chooser stays at
  the single-group baseline. Empty-bucket prefix codes fall back to
  the §3.7.2.1.1 single-symbol-0 form (the same shape the existing
  empty-distance code uses) so the decoder accepts the resulting
  one-leaf code without ever consuming a symbol from it. Ten new
  tests: `meta_prefix_clusterer_splits_two_region_bimodal_fixture`
  (mean-green clusterer maps top/bottom halves to disjoint groups),
  `meta_prefix_two_group_round_trips_through_decoder` (end-to-end
  round-trip on a 64×64 two-region image),
  `meta_prefix_two_group_with_cache_round_trips_through_decoder`
  (composition with the §5.2.3 color cache at `code_bits = 8`),
  `meta_prefix_three_and_four_groups_round_trip_through_decoder`
  (3-group and 4-group round-trips on a noisy multi-region image),
  `meta_prefix_all_sweep_prefix_bits_round_trip_through_decoder`
  (round-trip across every `prefix_bits` value the chooser sweeps),
  `meta_prefix_returns_none_when_too_small_for_a_split` and
  `meta_prefix_returns_none_on_uniform_image` (degenerate-case
  rejection), `round_151_chooser_round_trips_on_two_region_image`
  (full-chooser end-to-end through `decode_webp`),
  `round_151_diagnostic_sweep_records_per_shape_costs` (observational
  per-shape baseline-vs-multi-prefix size table), and
  `round_151_multi_meta_prefix_beats_single_group_on_noisy_image`
  (chooser-never-regresses invariant on a 128×128 noisy two-region
  image). On the synthetic fixtures the multi-meta-prefix candidate
  consistently stays larger than the single-group baseline (the cost
  of N additional 280-symbol prefix-code tables — typically thousands
  of bytes each — dominates the per-region savings on small to
  mid-size images), so the chooser correctly keeps the round-150
  pick; the candidate's value is structural — the round-151 encoder
  is now spec-conformant for any future per-region clustering
  improvement to plug into without changing the on-wire serialiser.
  No external implementation was consulted; spec source is the WebP
  Lossless Bitstream specification §6.2.2 / §3.7.2.2 mirrored under
  `docs/image/webp/` and RFC 9649 §3.7.2.2 / §3.7.2.2.1 / §3.7.2.2.2,
  cross-checked against the existing decoder-side
  `vp8l_decode::decode_entropy_image` and `decode_argb_multi_group`.

* **Clean-room round 150 (2026-05-26).** §4.4 color-indexing transform
  forward pass for the VP8L lossless encoder. The encoder now evaluates
  a new candidate alongside the round-149 super-chooser set: when an
  O(N) palette probe (`collect_palette`) confirms the image has ≤ 256
  unique ARGB values, `encode_with_color_indexing` builds a sorted
  palette (sorted ARGB-numerically so the §4.4 subtraction-coded
  color-table deltas concentrate near zero), replaces every pixel with
  its palette index, bundles indices into one byte per the §4.4 table
  (`width_bits = 3 / 2 / 1 / 0` for palettes of 1..=2 / 3..=4 / 5..=16
  / 17..=256 entries — packing 8 / 4 / 2 / 1 indices into each green
  byte respectively per the §4.4 LSB-first packing rule), and hands the
  bundled image to the standard `spatially-coded-image` writer at the
  subsampled `packed_width = DIV_ROUND_UP(width, 1 << width_bits)`. The
  candidate uses the round-148 `cache_code_bits ∈ [1..11]` sweep plus
  the disabled-cache baseline and is cross-compared against every other
  candidate; the smallest stream wins. The §4.4 path doesn't dominate
  every palette image (the §5.2.3 color cache + LZ77 already crunch
  random binary content to ~1 bit/pixel), but it wins cleanly on
  palette-ish content with horizontal coherence — the bundling drops
  the entropy stage's symbol count by 2..8× and amortises the small
  palette-table overhead. On a 64×32 binary row-rotation fixture the
  round-150 chooser shrinks the encoded stream from 73 B (round-149
  baseline) to 62 B (-15.1%). Five new tests:
  `encoder_color_indexing_width_bits_matches_spec_table` (the §4.4
  threshold table), `forward_color_table_round_trips_with_decoder_inverse`
  (forward subtraction-encode + decoder inverse round-trip),
  `collect_palette_early_exits_above_256_unique_colors` (the on-wire
  256-entry limit), `color_indexing_round_trip_across_all_width_bits_regimes`
  (end-to-end decode round-trips covering all four `width_bits` values
  on 2/4/16/64-color palettes), and
  `round_150_color_indexing_beats_other_candidates_on_palette_image`
  (chooser-actually-picks-CI verification on the headline fixture),
  plus `color_indexing_chooser_skips_photo_like_content` (non-regression
  on photo-like content where the palette probe returns `None`). No
  external implementation was consulted; spec source is the WebP
  Lossless Bitstream specification §4.4 mirrored under
  `docs/image/webp/` and RFC 9649 (the IETF WebP Image Format),
  cross-checked against the existing decoder-side
  `vp8l_transform::inverse_color_indexing` and `inverse_color_table`
  (round 109).

* **Clean-room round 149 (2026-05-26).** §3.7.2.1.1 *simple code length
  code* chooser for the VP8L lossless encoder. Previously every prefix
  code went through `write_normal_code_lengths` (§3.7.2.1.2 *normal code
  length code*), which always pays the 1-flag + 4-`num_code_lengths` +
  3-bit-per-CLC + 1-`max_symbol`-gate header tax (≥ 18 bits, ≥ 58 bits
  when more than one length value is present). The new chooser in
  `WriteCode::write_code_lengths` recognises the simple form's two
  qualifying shapes (1 or 2 used symbols, each at length 1, in `[0..255]`),
  computes the exact bit-cost of both forms (`simple_form_bits` and
  `normal_form_bits`), and emits whichever is cheaper. The simple form
  costs as little as 4 bits (1 symbol with value in `[0..1]`), making it a
  dramatic win on the bulk of single-leaf prefix codes that arise
  naturally in WebP streams: the empty distance code on images with no
  LZ77 matches, the per-channel literal codes on solid blocks, and the
  alpha code on opaque images. Measured deltas on synthetic fixtures:
  1×1 opaque drops from 174 B (round 148) to 32 B (-81.6%); 32×32 solid
  gray drops from 174 B to 68 B (-60.9%); 16×16 four-band gradient
  drops from 328 B to 80 B (-75.6%); 8×8 two-alpha-value drops from
  178 B to 76 B (-57.3%). The chooser also propagates through the
  super-chooser's 12 candidate streams (no-tx, subtract-green,
  predictor, color-transform × cache sweep), so the candidate-cheapest
  pick now reflects the smaller-tax simple-form costs as well. Eight
  new tests: `simple_form_rejects_tables_outside_3_7_2_1_1_constraints`,
  `simple_form_accepts_one_or_two_length_one_symbols`,
  `simple_form_bits_matches_written_layout`,
  `chooser_prefers_simple_form_for_empty_distance_code`,
  `chooser_round_trips_through_decoder_on_both_branches`,
  `round_149_simple_form_shrinks_1x1_lossless_baseline`,
  `round_149_simple_form_shrinks_synthetic_fixtures`, and
  `round_149_two_symbol_simple_form_round_trips`. No external
  implementation was consulted; spec source is the WebP Lossless
  Bitstream specification §3.7.2.1.1 mirrored under `docs/image/webp/`,
  cross-checked against the existing decoder-side reader in
  `vp8l_prefix::read_simple_code_lengths` (round 104).

* **Clean-room round 148 (2026-05-26).** §5.2.3 `color_cache_code_bits`
  sweep for the VP8L lossless encoder. Previously the chooser locked
  every cache-enabled candidate at `DEFAULT_COLOR_CACHE_BITS = 8`
  (256-entry cache), giving the §5.2.3 trade-off only two effective
  positions: disabled or 256 entries. The new `select_best_cache_bits`
  helper sweeps the disabled-cache baseline plus every value in the
  §5.2.3-allowed `[1..11]` range (2..=2048-entry caches) for each
  base candidate — the no-tx and subtract-green literals candidates
  in `encode_argb_literals_with_width`, the §4.1 predictor candidate
  in `encode_argb_with_predictor_chooser`, and each color-transform
  `size_bits` candidate (per-region + single-block) in the same
  super-chooser. The sweep is non-monotonic: narrow caches win on
  small-palette payloads (fewer wasted alphabet slots), wide caches
  win on photo-like payloads (fewer hash collisions), and the
  disabled-cache baseline wins on noise (no `%b1 4BIT` header tax,
  no GREEN-alphabet growth from `280` to `280 + (1 << code_bits)`).
  On a 32×32 16-color pseudo-random palette fixture, the round-148
  sweep shrinks the encoded stream by a measurable fraction relative
  to the hardcoded-8 chooser (see
  `round_148_sweep_beats_hardcoded_8_on_small_palette` for the
  reported byte counts). Five new tests: `select_best_cache_bits`
  call-pattern coverage (12 candidates: `None` + `[1..=11]`),
  minimum-stream selection, monotonic-non-regression versus the
  hardcoded-8 chooser across three contrasting payloads, strict-beat
  on a small-palette payload, and live decoder verification that the
  chosen stream's `color_cache_code_bits` lands at a non-default
  `[1..11]` value.

* **Clean-room round 147 (2026-05-26).** §3.5.2 / §4.2 color-transform
  forward pass for the VP8L lossless encoder. The encoder now
  evaluates four new candidates alongside the existing six chooser
  candidates: the §3.5.2 color transform with two `size_bits` values
  (`4` → 16×16 per-region blocks; the maximal single-block size that
  collapses the entire image into one CTE), each with and without a
  §5.2.3 color cache. For each block, `pick_block_cte` runs an exact
  per-axis greedy sweep over a 25-entry candidate grid (`±0..±96`
  with fine resolution near zero) picking the
  `(green_to_red, green_to_blue, red_to_blue)` triple that minimises
  a residual-magnitude proxy. The per-axis greedy is exact because
  the §3.5.2 cost decomposes additively across channels (green is
  untouched, red depends only on `green_to_red`, blue depends
  additively on `(green_to_blue, red_to_blue)`). The sub-resolution
  color image is written as a §7.2 `color-image = 3BIT
  entropy-coded-image` (re-using `write_entropy_coded_image_literals`
  from round 146), the main image is forward-transformed into the
  red/blue residuals, and the residuals feed the standard
  `spatially-coded-image` writer. On a 128×128 fixture with per-
  block-varying linear channel correlation (four-slope palette), the
  chooser shrinks the stream from 47636 B (round-146 baseline) to
  41399 B — a 13.1% reduction. On the published 128×128 natural
  fixture the round-146 predictor candidate already wins at 1011 B
  and the new color candidate doesn't beat it (the chooser correctly
  keeps the predictor pick — no regression). The chooser falls back
  to the existing six candidates when either dimension is below one
  block. Nine new tests: `color_xfrm_delta` matching the §3.5.2
  signed-fixed-point formula on spec examples, per-pixel forward+
  inverse round-trip through the decoder's `inverse_color`, a solid-
  block CTE-cost-minimum assertion, a known-slope CTE recovery on a
  synthetic `red ≈ green / 2` block, forward + inverse multi-block
  bit-exact round trip, end-to-end public-API round trip on a chroma-
  correlated image, a chooser non-regression on a low-correlation
  synthetic and on uncorrelated noise, a strict-beat assertion on
  the varying-slope fixture (with `eprintln!` byte counts for
  visibility), and the natural-fixture round trip + non-regression.

* **Clean-room round 146 (2026-05-26).** §4.1 spatial-predictor forward
  transform for the VP8L lossless encoder. The encoder now evaluates two
  new candidates alongside the existing
  `(no-tx | subtract-green) × (no-cache | cache)` set: the §4.1 predictor
  transform with and without a §5.2.3 color cache. For each
  `(1 << size_bits)`-pixel square block (default
  `size_bits = 4` → 16×16 blocks), `pick_block_mode` walks the 14 §4.1
  prediction modes `0..=13` and selects the mode minimising a residual-
  magnitude proxy (sum of per-channel `|residual|` folded onto
  `[-128, 127]`). The sub-resolution predictor image is written as a §7.2
  `predictor-image = 3BIT entropy-coded-image` (a new
  `write_entropy_coded_image_literals` helper, also reusable by §4.2 in a
  future round), the main image is forward-transformed into per-pixel
  residuals, and the residuals feed the standard
  `spatially-coded-image` writer. On a 64×64 smooth gradient the chooser
  shrinks the stream from 9793 B (no-tx baseline) to 303 B — a 96.9%
  reduction; on the published 128×128 natural fixture, from 46797 B to
  1011 B — 97.8%. The chooser falls back to the existing four
  candidates when either dimension is below one block. Internally,
  `encode_tokens` was split: `write_spatially_coded_image` writes the
  body after the §3.8.2 optional-transform terminator, and
  `write_prefix_codes_and_tokens` is the shared `data = prefix-codes
  lz77-coded-image` emitter, so the predictor candidate composes the
  same low-level building blocks as the round-145 path. Eight new
  tests: residual-subtract-add round-trip, `pick_block_mode` solid-
  block cost, forward+inverse predictor bit-exact round trip,
  end-to-end round trip on a smooth gradient, a chooser size-reduction
  assertion (with `eprintln!` byte counts for visibility), a chooser
  noise-non-regression assertion, and a 128×128 natural fixture
  round-trip + size-reduction log. The
  `lossless-128x128-natural.webp` fixture was copied from
  `docs/image/webp/fixtures/lossless-128x128-natural/input.webp` into
  `tests/data/` to make the natural-image regression test
  self-contained.

* **Clean-room round 145 (2026-05-26).** §2.7 metadata-aware container
  writer: `build::build_webp_file_with_metadata(payload, image_kind,
  canvas_width, canvas_height, has_alpha, FileMetadata)` assembles a
  RIFF/WEBP file in the §2.7 *extended* layout with a §2.7.1 `VP8X`
  chunk + optional `ICCP` / `EXIF` / `XMP ` payloads, derives the
  §2.7.1 `I` / `L` / `E` / `X` flag bits from which `FileMetadata`
  fields are `Some` (plus the explicit `has_alpha` argument), and
  emits the chunks in §2.7 canonical order (`VP8X | ICCP | <VP8 |
  VP8L> | EXIF | XMP`). Twelve new tests cover round-trip through
  `extract_metadata` for the eight `{none, iccp, exif, xmp, iccp+exif,
  iccp+xmp, exif+xmp, iccp+exif+xmp}` presence combinations, the
  §2.3 `0x00` pad-byte generation on odd-length metadata payloads
  (verifies the §2.4 `File Size` field still matches the parsed
  value), the exhaustive 16-way §2.7.1 flag-bit derivation against
  the parser's `Vp8xHeader::parse`, and canvas-validation propagation
  (`CanvasDimZero` / `CanvasTooLarge`). The new `FileMetadata<'a>`
  borrowed struct mirrors the published `WebpMetadata` shape but
  lives inside `build` so the writer compiles under
  `--no-default-features` (no `oxideav-core` in the standalone
  build's dependency tree).

* **Clean-room round 130 (2026-05-25).** §5.2.2 **width-aware distance-code
  chooser** for the VP8L lossless encoder. Each backward reference now
  picks the smaller of the scan-line code (`D + 120`, the round-119
  default) and any §5.2.2 distance-map code `c ∈ 1..=120` whose
  `(xi, yi)` entry reconstructs to `D` for the image width — so a row-
  distance match (D = W) on a 256-wide image collapses from scan-line
  code 376 (prefix 16, 7 extra bits per emission) to map code 1
  (prefix 0, 0 extra bits). The reconstruction in
  `vp8l_decode::distance_code_to_pixel_distance` is identical for both
  forms, so the round trip stays bit-exact. New public helper
  `pixel_distance_to_distance_code(distance, image_width)`; new internal
  `encode_argb_literals_with_width(pixels, image_width)` that threads
  the actual image width into the chooser (wired by `encode_vp8l_payload`
  → `encode_webp_lossless` / `encode_vp8l_argb` / animation encoders).
  The legacy width-less `encode_argb_literals` is retained for test
  callers that exercise the entropy stage without spatial structure;
  it defaults to width = 1, which disables the chooser (no distance-map
  entry reconstructs typical distances at a single-pixel-wide row).
  Headline: a 256×256 row-repeating fixture shrinks from 972 B to 958 B
  (~1.4 % reduction); a 128×128 row-correlated fixture from 522 B to
  519 B (~0.6 %). Eight new tests cover chooser correctness
  (`distance_chooser_reconstructs_each_distance_map_entry`,
  `distance_chooser_picks_map_code_for_row_distance`,
  `distance_chooser_falls_back_to_scan_line_when_no_map_match`,
  `distance_chooser_width_one_uses_scan_line_for_large_distances`),
  per-prefix non-regression (`chooser_never_picks_larger_prefix_than_scan_line`),
  measured size-reduction
  (`width_aware_distance_beats_scan_line_only_on_row_correlated_image`,
  `width_aware_distance_compounds_on_many_short_row_offset_matches`,
  `width_aware_distance_headline_256x256_row_repeating`,
  `width_aware_distance_beats_scan_line_only_on_photo_like_image`,
  `width_aware_re_encode_of_real_fixture_is_smaller`), and round-trip
  bit-exactness across widths
  (`width_aware_round_trip_across_assorted_widths`). 356 tests total.

* **Clean-room round 127 (2026-05-25).** `AnimFrameMode::Auto` and
  `AnimFrameMode::Delta` are no longer `WebpError::Unsupported` — both
  now encode the caller's frames against the previous canvas using a
  **lossless dirty-rectangle delta** path on top of the existing VP8L
  encoder. `Delta` always emits the dirty-rect sub-frame (or, for the
  first frame / a frame whose dirty rect spans the whole canvas, a full
  keyframe); `Auto` evaluates both candidates and emits the smaller
  bitstream. Both honour the §2.7.1.1 `B = 1` / `D = 0`
  (overwrite, no dispose) ANMF semantics so the encoded file round-trips
  byte-for-byte through `decode_webp`'s canvas compositor. The
  even-offset constraint of §2.7.1.1 is preserved by aligning the dirty
  rect's top-left down to the nearest even coordinate. Identical
  consecutive frames emit a degenerate 2×2 sub-frame so duration timing
  is preserved without re-encoding. Headline: a 128×128 frame pair with
  an 8×8 changed block compresses from 87 476 B (all-Lossless) to
  43 986 B (Delta or Auto) — ~50 % size reduction with a byte-exact
  round trip. The original lossy-keyframe-vs-inter-frame-delta `Auto`
  semantics will return once `oxideav-vp8` ships a real lossy encoder;
  the dirty-rect path remains useful on lossless input regardless. New
  tests: `auto_and_delta_modes_emit_valid_files_round_127`,
  `dirty_rect_shrinks_anmf_payload_for_localised_change`,
  `auto_mode_picks_dirty_rect_on_localised_change`,
  `dirty_rect_canvas_coords_covers_only_the_changed_pixels`,
  `dirty_rect_is_none_on_identical_frames` (lib unit), and
  `auto_and_delta_modes_round_trip_byte_exact`,
  `delta_mode_three_frames_round_trip_byte_exact`,
  `auto_mode_picks_dirty_rect_on_small_localised_change`
  (`published_anim_api.rs`). 345 tests total.

* **Clean-room round 127 (2026-05-25).** Decoder-side §2.7.1.1
  **canvas compositing**. `decode_webp` / `decode_animation` now sizes
  a canvas from the §2.7.1 `VP8X` chunk, initialises it to the
  §2.7.1.1 `ANIM` `Background Color`, applies the previous frame's
  disposal method (`None` or `Background`) to its sub-rectangle, then
  draws the current frame at its `(x, y)` offset using its blending
  method: `Overwrite` copies the sub-rect pixels verbatim onto the
  canvas; `AlphaBlend` runs the §2.7.1.1 8-bit integer approximation
  of `blend.A = src.A + dst.A * (1 - src.A / 255)` /
  `blend.RGB = (src.RGB * src.A + dst.RGB * dst.A *
  (1 - src.A / 255)) / blend.A` (sRGB space, no gamma
  linearisation — matching the spec's stated 8-bit formula). Each
  returned `WebpFrame.rgba` is the full canvas snapshot after that
  frame is rendered, sized `canvas_w × canvas_h` (replacing the prior
  per-sub-rect-only convention). Frames whose declared rect overflows
  the canvas are rejected as `InvalidData`. The libwebp-encoded
  `animated-with-alpha.webp` fixture (all three ANMFs at offset (0,0)
  spanning the full 64×64 canvas) keeps decoding to the same per-frame
  RGBA buffers as before. New helpers: `lib::fill_canvas_rect`,
  `lib::blit_rect_overwrite`, `lib::blit_rect_alpha_blend`.

* **Clean-room round 127 (2026-05-25).** `AnimFrame::new` default
  `blend` switched from `BlendingMethod::AlphaBlend` to
  `BlendingMethod::Overwrite` so a full-canvas frame round-trips
  byte-for-byte through the new canvas compositor. Callers that need
  alpha-blending of a translucent sub-frame onto the existing canvas
  must build the struct literally and set `blend:
  BlendingMethod::AlphaBlend`. This is a behavioural change vs prior
  rounds (the existing `published_anim_api.rs` tests against varying-
  alpha frames updated to use the new semantics).

* **Clean-room round 124 (2026-05-25).** §2.5 `VP8 ` (lossy) **decode**
  path, routed through the `oxideav-vp8` sibling crate. Re-added the
  `oxideav-vp8 = "0.2"` dependency (vp8 0.2 now exposes a public