### PR TITLE
chore: release v0.2.2

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -221,6 +221,73 @@ exploratory work this round (LLVM already auto-vectorises the
 closure-of-four `i32` body well on AArch64), so the next attempt
 will need a true SWAR formulation rather than a byte-loop rewrite.
 
+## Round-204 (2026-06-01) — SWAR + per-block mode-hoist exploration (no commit)
+
+The round-194 BENCHMARKS note flagged
+`inverse_predictor_mode12_256x256` (605 µs) and
+`inverse_predictor_mode13_256x256` (835 µs) as the next mode-by-mode
+targets. Round 204 explored two structural rewrites that the round-194
+note explicitly anticipated; **both regressed** and were not committed.
+The notes here are recorded so the next attempt doesn't re-walk the
+same path.
+
+### Attempt 1 — true SWAR for `clamp_add_subtract_full`
+
+The round-194 note warned that a naïve `to_le_bytes()` + 4-iteration
+`i16` loop regressed mode 12, and suggested a "true SWAR formulation"
+instead. The natural SWAR for `clamp(a + b - c)` per 8-bit channel
+biases each lane by 0x100 to dodge underflow:
+
+* `sum = a + b + 0x0100_0100 - c` per even / odd 16-bit-lane pair,
+  with `a`, `b`, `c` masked to `0x00ff_00ff`. Each lane is in
+  `[0x001, 0x2fe]` (no inter-lane carry).
+* `q = sum >> 8 & 0x0003_0003` is `{0, 1, 2}` per lane:
+  `0` → clamp-to-0, `1` → take low byte of sum, `2` → clamp-to-255.
+* The per-lane "0xff if set" mask is built with the
+  shift-and-subtract trick `(x << 8) - x` (multiplication-free
+  because `0x0001_0001 * 0xff` carries across lanes).
+
+Verified bit-identical to the closure-of-four reference for 4 096
+randomised triples + a single-channel exhaustive sweep over
+`[0,255]^3` = 16.7 M triples. **Performance regressed mode 12 from
+586 µs to 663 µs (+13%) and mode 13 from 812 µs to 894 µs (+10%).**
+LLVM auto-vectorises the i32 reference closure to NEON
+add/sub/min/max instructions on aarch64; the SWAR sequence's
+sequential dependency chain through `sum → q → in_range_bit
+→ in_range_mask → result` is longer than the four-way ILP that the
+closure form enables.
+
+### Attempt 2 — per-block mode-hoist
+
+`DEFAULT_PREDICTOR_SIZE_BITS = 4` (the encoder default) makes each
+predictor-image block 16 pixels wide, so the per-pixel match-dispatch
+on `mode` in `inverse_predictor`'s inner loop runs 16 times for a
+constant `mode`. Hoisting the match out (read `mode` per block, then
+run a mode-specialised inner loop for `block_w` pixels) eliminates
+the redundant match work and the redundant TR-load for 8 of 14 modes.
+**Performance regressed at `size_bits = 0`** (where the bench runs)
+because each block is one pixel: the outer block-walk adds dispatch
+overhead with no amortisation, raising mode 12 to 653 µs (+11%) and
+mode 13 to 863 µs (+6%). The real-world `lossless_decode_argb_256`
+bench (256×256 gradient at `size_bits = 4`) also drifted +1.3% — the
+gradient's mode mix is dominated by light-arithmetic predictors so
+the saved match dispatch doesn't recover the added block-loop cost.
+
+Both rewrites need a separate amortising bench (e.g. a fixture that
+forces `size_bits >= 2` and exercises mode 12 / 13 with realistic
+density) before they can be evaluated honestly; the existing
+`inverse_predictor_mode{11,12,13}_256x256` benches over-amortise the
+per-pixel work at `size_bits = 0` and hide the per-block savings.
+
+The structural follow-up: add a parametric bench that takes
+`size_bits in {2, 4}` and runs the existing constant-mode pattern
+over a fixture sized to amortise the per-block cost (e.g. a
+512×512 buffer at `size_bits = 4` = 1 024 blocks of 16 pixels, the
+real-world operating point of the default encoder). With that bench
+in place, both rewrites can be re-measured against a representative
+operating point without confusing per-pixel-mode-bench regressions
+for global wins or losses.
+
 ## Reproducing
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/OxideAV/oxideav-webp/compare/v0.2.1...v0.2.2) - 2026-06-01
+
+### Other
+
+- round 204 — first cargo-fuzz harness (decode + extract_metadata)
+- round 194 — §4.1 Select algebraic simplification + per-mode bench
+
 ### Added
 
 - `fuzz/` — first cargo-fuzz harness for the crate. Two libfuzzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+### Added
+
+- `fuzz/` — first cargo-fuzz harness for the crate. Two libfuzzer
+  targets:
+  * `decode` — feeds arbitrary bytes through the public
+    `decode_webp` entry point and asserts the call always returns a
+    `Result` (no panic / abort / OOM). Drives the RIFF walk, VP8L
+    bitstream (§3 prefix codes + §4 transforms + §5 LZ77 + §6
+    meta-prefix), VP8 lossy framing (delegated to the
+    `oxideav-vp8` sibling), the `VP8X` extended layout, the `ALPH`
+    alpha plane, and the `ANIM` + `ANMF` animation chunks in one
+    pass.
+  * `extract_metadata` — feeds arbitrary bytes through
+    `extract_metadata` so the `ICCP` / `EXIF` / `XMP ` chunk
+    readers are exercised in isolation (no pixel decode budget
+    spent).
+  Build with `RUSTUP_TOOLCHAIN=nightly cargo fuzz build` (nightly
+  required by libfuzzer-sys's sanitizer flags). Both targets
+  compile cleanly under the standalone build
+  (`oxideav-webp = { default-features = false }`), so the fuzz
+  harness has no `oxideav-core` dep. Round-204 smoke runs:
+  50 000 iterations each, seeded from the 18 in-tree fixture
+  WEBPs. `extract_metadata` completes panic-free at 97 cov / 160
+  features (no findings); `decode` surfaces a multiply-overflow
+  panic in the `oxideav-vp8` sibling's
+  `inverse_transform::inverse_dct_4x4` on a fuzzer-mutated VP8
+  lossy `RIFF` envelope — a cross-crate finding scoped to
+  `oxideav-vp8`, not `oxideav-webp`, so flagged as a follow-up
+  rather than fixed inline.
+
 ### Optimized
 
 - §4.1 `Select` (predictor mode 11): algebraic simplification of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -36,16 +36,40 @@ oxideav-webp = "0.1"
 
 ### Benchmarks
 
-The crate ships four criterion benches under `benches/` (decode +
-encode + LZ77 matcher + `argb→rgba` repack). Numbers, profile
-findings, and the optimization log live in [`BENCHMARKS.md`](./BENCHMARKS.md).
-Run with:
+The crate ships five criterion benches under `benches/` (decode +
+encode + LZ77 matcher + `argb→rgba` repack + per-mode
+`inverse_predictor`). Numbers, profile findings, and the optimization
+log live in [`BENCHMARKS.md`](./BENCHMARKS.md). Run with:
 
 ```text
 CARGO_TARGET_DIR=/tmp/oxideav-webp-bench-target \
   cargo bench --manifest-path crates/oxideav-webp/Cargo.toml \
     --bench <name> -- --quick
 ```
+
+### Fuzzing
+
+The crate ships two cargo-fuzz harnesses under `fuzz/`:
+
+* `decode` — feeds arbitrary bytes through `decode_webp` and
+  asserts the call always returns a `Result` (no panic / abort /
+  OOM). Drives the RIFF walk, VP8L bitstream (§3 prefix codes +
+  §4 transforms + §5 LZ77 + §6 meta-prefix), VP8 lossy framing,
+  the `VP8X` extended layout, the `ALPH` alpha plane, and the
+  `ANIM` + `ANMF` animation chunks.
+* `extract_metadata` — feeds arbitrary bytes through
+  `extract_metadata` so the `ICCP` / `EXIF` / `XMP ` chunk readers
+  are driven in isolation.
+
+```text
+# Nightly is required by libfuzzer-sys's sanitizer flags.
+RUSTUP_TOOLCHAIN=nightly cargo fuzz run decode
+RUSTUP_TOOLCHAIN=nightly cargo fuzz run extract_metadata
+```
+
+Seed the corpus from the in-tree fixtures at
+`docs/image/webp/fixtures/*/input.webp` to bootstrap meaningful
+coverage from the first iteration.
 
 ## Standalone use (no `oxideav-core`)
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,6 @@
+/target
+/Cargo.lock
+artifacts
+coverage
+corpus
+fuzz-*.log

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,119 @@
+[package]
+name = "oxideav-webp-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+# WebP's RIFF + VP8 + VP8L + VP8X + ALPH + ANIM + ANMF stack is a
+# layered byte-stream parser with several classic memory-safety
+# trap-doors that a fuzz target should drive against arbitrary input:
+#
+#  * `decode_webp`            — feed arbitrary bytes to the full
+#                               public decoder and assert it always
+#                               returns a `Result` rather than
+#                               panicking / aborting / OOMing. This
+#                               drives the RIFF walk, VP8L bitstream
+#                               (LZ77 + prefix codes + §4 transforms +
+#                               color-cache + meta-prefix), VP8 lossy
+#                               framing (delegated to the
+#                               `oxideav-vp8` sibling), the `VP8X`
+#                               extended layout, the `ALPH` alpha
+#                               plane, and the `ANIM` + `ANMF`
+#                               animation chunks all in one pass.
+#                               Classic WebP danger spots:
+#
+#                                 - 12-byte RIFF preamble: a hostile
+#                                   chunk-size word must not allow
+#                                   reading past the slice when the
+#                                   declared size exceeds the actual
+#                                   payload (commonly seen in
+#                                   `RIFFxxxxWEBPVP8 …` truncated
+#                                   files).
+#                                 - VP8L 14-bit width/height: the
+#                                   spec admits up to 16384×16384;
+#                                   the decoder must cross-check the
+#                                   declared canvas against the
+#                                   remaining bitstream budget before
+#                                   allocating `width * height * 4`
+#                                   bytes.
+#                                 - LZ77 backref distances + length
+#                                   codes: a hostile sequence must
+#                                   either refuse on out-of-window
+#                                   distances or wrap them per §5.2.2
+#                                   without index-out-of-bounds.
+#                                 - Meta-prefix code-length code:
+#                                   §3.7 codes use the §3.5.6 simple
+#                                   / normal length distinction, and
+#                                   the normal path itself runs a
+#                                   second-level prefix decode — a
+#                                   hostile combination must not loop
+#                                   or panic during the inner walk.
+#                                 - §4 transform chain: up to four
+#                                   transforms can appear in any
+#                                   order. The decoder applies the
+#                                   inverses in reverse; a hostile
+#                                   `transform_present` chain that
+#                                   repeats the same transform must
+#                                   refuse rather than re-apply.
+#                                 - ANMF rectangle bounds: per-frame
+#                                   tile offset + width + height
+#                                   must stay inside the canvas; a
+#                                   hostile `(x_offset, frame_width)`
+#                                   that overflows `u32` arithmetic
+#                                   must surface as `Err(…)`.
+#                                 - `ALPH` filter / preproc bits:
+#                                   four filter methods + two
+#                                   preproc modes + an optional
+#                                   compressed alpha lossless
+#                                   sub-bitstream — every combination
+#                                   must classify without panicking.
+#
+#  * `extract_metadata`       — feed arbitrary bytes to the public
+#                               `extract_metadata` entry point. This
+#                               drives the RIFF walk and the `ICCP`
+#                               / `EXIF` / `XMP ` chunk readers
+#                               without paying for the pixel decode.
+#                               A hostile chunk-size field on any of
+#                               the three metadata chunks must not
+#                               allow the reader to allocate beyond
+#                               the declared input length.
+#
+# Black-box validators (`cwebp` / `dwebp` / `ffmpeg` binaries) are
+# allowed but the fuzz harness doesn't dlopen them — panic-freedom
+# is the contract under test, and that's a self-contained property.
+# The clean-room wall bars libwebp / `image` crate as a cross-decode
+# oracle.
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.oxideav-webp]
+path = ".."
+default-features = false
+
+# Prevent this fuzz package from being pulled into the umbrella
+# workspace at `crates/*` glob-resolve time.
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+# ------------------------------------------------------------------
+# Fuzz targets.
+# ------------------------------------------------------------------
+
+[[bin]]
+name = "decode"
+path = "fuzz_targets/decode.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "extract_metadata"
+path = "fuzz_targets/extract_metadata.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -1,0 +1,62 @@
+#![no_main]
+
+//! Decode arbitrary fuzz-supplied bytes through `decode_webp`.
+//!
+//! The decoder must always return a `Result` and never panic / abort
+//! / OOM, regardless of how malformed the input is. The return value
+//! is intentionally discarded — the contract under test is *the call
+//! returns*, not what it returns.
+//!
+//! Classic WebP danger spots this target drives:
+//!
+//! * **RIFF preamble walk** — a hostile chunk-size word (the 4-byte
+//!   `u32` at offset 4) must not allow reading past the slice when
+//!   the declared size exceeds the actual payload length. Commonly
+//!   seen in truncated downloads where the header survives but the
+//!   payload is cut short.
+//! * **VP8L canvas declaration** — §5.1 stores width-1 / height-1
+//!   each in 14 bits, so the legal canvas is 1..=16384 in each
+//!   dimension. A hostile combination must cross-check against the
+//!   bitstream budget before allocating `width * height * 4` bytes.
+//! * **VP8L §5.2.2 LZ77 backref length / distance** — the prefix
+//!   codes admit any length/distance pair on the wire; a hostile
+//!   distance > current decode position or length that walks past
+//!   the canvas must surface as `Err(…)` rather than indexing into
+//!   uninitialised memory.
+//! * **VP8L §3.5 meta-prefix code** — the §3.5.6 "simple length
+//!   code" vs "normal" distinction and the §3.5.7 normal-form
+//!   reader-of-readers (the code-length code is itself prefix-coded)
+//!   are a classic infinite-loop trap. Every combination of header
+//!   bits must terminate.
+//! * **VP8L §4 transform chain** — up to four transforms may appear
+//!   in the bitstream, applied in reverse on decode. A hostile chain
+//!   that repeats the same transform type, or declares a sub-image
+//!   `size_bits` that overflows the sub-image dimensions, must
+//!   refuse rather than re-apply.
+//! * **VP8X extended layout** — the 10-byte VP8X chunk carries a
+//!   bitmask telling the decoder which optional chunks to expect
+//!   (`ALPH` / `ANIM` / `ICCP` / `EXIF` / `XMP`). A hostile mask
+//!   pointing at chunks that don't exist (or omitting bits for
+//!   chunks that do) must classify without panic.
+//! * **ANMF rectangle bounds** — per-frame tile offset + width +
+//!   height must stay inside the canvas; a hostile `(x_offset,
+//!   frame_width)` that overflows `u32` arithmetic must surface as
+//!   `Err(…)`.
+//! * **`ALPH` filter / preproc bits** — four filter methods + two
+//!   preproc modes + an optional compressed alpha lossless
+//!   sub-bitstream — every combination must classify without
+//!   panicking.
+//!
+//! No external library is consulted as a cross-decode oracle: the
+//! clean-room wall bars libwebp / Pillow / the `image` crate, and
+//! the format is well-specified enough that panic-freedom is the
+//! contract worth driving. The harness uses the standalone API
+//! (`default-features = false`) so no `oxideav-core` runtime is
+//! built.
+
+use libfuzzer_sys::fuzz_target;
+use oxideav_webp::decode_webp;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = decode_webp(data);
+});

--- a/fuzz/fuzz_targets/extract_metadata.rs
+++ b/fuzz/fuzz_targets/extract_metadata.rs
@@ -1,0 +1,30 @@
+#![no_main]
+
+//! Extract metadata from arbitrary fuzz-supplied bytes through
+//! `extract_metadata`.
+//!
+//! The reader must always return a `Result` and never panic / abort
+//! / OOM, regardless of how malformed the input is. The return value
+//! is intentionally discarded — the contract under test is *the call
+//! returns*.
+//!
+//! Specifically targeted: the RIFF + VP8X + `ICCP` / `EXIF` / `XMP `
+//! chunk readers without paying for the pixel decode. A hostile
+//! chunk-size field on any of the three metadata chunks must not
+//! allow the reader to allocate beyond the declared input length.
+//!
+//! The metadata path is a strict subset of the full `decode_webp`
+//! path — it walks the same RIFF skeleton, picks the same VP8X
+//! chunk for the canvas declaration, and stops at the three
+//! metadata chunks instead of also decoding pixels. Splitting it
+//! into its own fuzz target keeps the corpus minimal (bytes that
+//! exercise only the metadata-walk path don't have to also satisfy
+//! the bitstream-decoder's wider validation surface) and makes any
+//! ICCP / EXIF / XMP-specific panic regression easy to localise.
+
+use libfuzzer_sys::fuzz_target;
+use oxideav_webp::extract_metadata;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = extract_metadata(data);
+});


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/OxideAV/oxideav-webp/compare/v0.2.1...v0.2.2) - 2026-06-01

### Other

- round 204 — first cargo-fuzz harness (decode + extract_metadata)
- round 194 — §4.1 Select algebraic simplification + per-mode bench

### Added

- `fuzz/` — first cargo-fuzz harness for the crate. Two libfuzzer
  targets:
  * `decode` — feeds arbitrary bytes through the public
    `decode_webp` entry point and asserts the call always returns a
    `Result` (no panic / abort / OOM). Drives the RIFF walk, VP8L
    bitstream (§3 prefix codes + §4 transforms + §5 LZ77 + §6
    meta-prefix), VP8 lossy framing (delegated to the
    `oxideav-vp8` sibling), the `VP8X` extended layout, the `ALPH`
    alpha plane, and the `ANIM` + `ANMF` animation chunks in one
    pass.
  * `extract_metadata` — feeds arbitrary bytes through
    `extract_metadata` so the `ICCP` / `EXIF` / `XMP ` chunk
    readers are exercised in isolation (no pixel decode budget
    spent).
  Build with `RUSTUP_TOOLCHAIN=nightly cargo fuzz build` (nightly
  required by libfuzzer-sys's sanitizer flags). Both targets
  compile cleanly under the standalone build
  (`oxideav-webp = { default-features = false }`), so the fuzz
  harness has no `oxideav-core` dep. Round-204 smoke runs:
  50 000 iterations each, seeded from the 18 in-tree fixture
  WEBPs. `extract_metadata` completes panic-free at 97 cov / 160
  features (no findings); `decode` surfaces a multiply-overflow
  panic in the `oxideav-vp8` sibling's
  `inverse_transform::inverse_dct_4x4` on a fuzzer-mutated VP8
  lossy `RIFF` envelope — a cross-crate finding scoped to
  `oxideav-vp8`, not `oxideav-webp`, so flagged as a follow-up
  rather than fixed inline.

### Optimized

- §4.1 `Select` (predictor mode 11): algebraic simplification of the
  reference-form `|estimate_c - L_c|` / `|estimate_c - T_c|`
  per-channel absolute differences. Substituting
  `estimate = L + T - TL` makes the two terms reduce to `|T_c - TL_c|`
  and `|L_c - TL_c|` respectively (the `estimate` term cancels), so
  the per-pixel body computes only `Manhattan(T, TL)` and
  `Manhattan(L, TL)` directly — half the per-pixel arithmetic with
  the same `p_L < p_T` tie-break.
  `inverse_predictor_mode11_256x256` (new bench) drops from 597 µs to
  484 µs (−18.9%); end-to-end `lossless_decode_argb_256` drops from
  765 µs to 743 µs (−2.9%) on the 256×256 gradient fixture where mode
  11 is one of several modes the encoder picks. Bit-identical to the
  reference form per the new `select_matches_estimate_reference_random`
  test which sweeps 1 024 deterministic LCG triples + four hand-picked
  boundary triples against a verbatim copy of the pre-r194 body.

### Added

- `benches/inverse_predictor.rs` — three per-mode criterion benches
  (`mode11_256x256`, `mode12_256x256`, `mode13_256x256`) driving
  `inverse_predictor` against a 256×256 ARGB residual buffer plus a
  `size_bits = 0` predictor image whose green channel is a constant
  mode, so every interior-loop pixel exercises one chosen predictor
  body. Lets future rounds A/B-test per-mode rewrites without
  waiting for a real encoder mode pick. The mode 12 / 13 numbers
  (605 µs / 835 µs at r194) are the baseline for the next round's
  arithmetic-rewrite experiment on `clamp_add_subtract_*` — flagged
  as the next target by the round-180 BENCHMARKS note.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).