### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,81 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/OxideAV/oxideav-webp/compare/v0.2.1...v0.2.2) - 2026-06-15
+
+### Other
+
+- §4.2 single-transform entropy-cost per-block CTE chooser (r308)
+- round 307 — §3.5 stacked-transform encode harness, separated by content regime
+- §3.5 stacked chains sweep full sub-image lambda set (r306)
+- §3.5 stacked chains sweep entropy-aware predictor sub-image cost models
+- §3.5 three-transform stacked candidate (color → subtract-green → predictor)
+- §3.5 stacked color-transform + predictor candidate (photo)
+- §3.5 stacked color-indexing + predictor transform candidate
+- distance-code chooser smallest-code early-out (§5.2.2)
+- *(r300)* §5.2.2 encoder distance-code chooser isolated harness
+- *(lossless)* pre-size private argb_to_rgba repack (~14.5x on the byte step)
+- round 298 FUZZ — add parse_vp8_chunk harness over §2.5 VP8 chunk handle
+- round 297 — §5.2.2 decoder LZ77 copy-back bench (apply_backward_reference)
+- README round-296 PROFILE narrative — inverse_predictor per-block hoist evaluation + realistic-block bench
+- round 296 PROFILE — realistic-block inverse_predictor bench + per-block mode-hoist evaluation
+- add decode_alpha_plane libFuzzer target over the file-level still-image alpha path
+- webp r294: meta_prefix_cluster bench + §6.2.2 entropy-image clustering hotspot map
+- webp r293: hoist §2.7.1.2 ALPH inverse-filter border rules out of the per-pixel loop (rank-1 lossy/alpha opt)
+- r292 decode_lossless_image target + fix §3.4-header eager-alloc OOM
+- round 291 — §2.7.1.2 ALPH alpha-plane decode harness + refined lossy hotspot map
+- webp r290: yuv420_to_rgba §9.2 chroma-pair hoist (rank-1 lossy opt, byte-identical)
+- r289 §2.5 VP8 lossy decode harness + ranked hotspot map
+- *(r288)* decode_still_paths differential oracle + fix animation-canvas OOM
+- O(1) length→row side table for the §6.2.1 per-bit walk (r287 PROFILE-OPT)
+- round 286 — isolate §6.2.1 read_symbol (rank-1 decode) + §5.2.2 lz77_chain (rank-3 encode) hotspots; rank next PROFILE-OPT target
+- r285 harnesses #27+#28 — §6.2.1 read-symbol LUT differential + wide-carrier lossless decode
+- r284 — §6.2.1 read_symbol primary lookup table + word-load ReadBits
+- round 283 — end-to-end decode coverage (transform mixes, animation timeline, metadata walk) + full regression refresh
+- r282 harness #25 roundtrip_metadata — §2.7 metadata write-path differential
+- round 281 — §3.5.2 pick_block_cte chooser-walk bench + chunk-granular axis prune
+- r280 — hoist §4.1 border rules + mode dispatch out of the encoder chooser's per-pixel loop
+- r279 harness #24 roundtrip_anim_modes — §2.7.1.1 assembly differential; fix Delta/Auto dispose + AlphaBlend emission
+- r278 — remove §3.7.2 length-cap pass's per-adjustment O(n) target-selection rescan
+- r277 — bit-identical dense-cell rewrite of the §3.7.2/§6.2.1 length-then-code chain
+- round 276 — §6.2.1 PrefixCode::from_code_lengths decoder canonical-table bench
+- add prefix_code target — §6.2.1 single canonical prefix-code reader
+- r274 fuzz harness #23 prefix_code_group — §6.2 prefix-code-group reader
+- r273 decode_lossless fuzz harness + fix BitReader::bits_remaining usize underflow
+- round 272 — §6.2.2 decode_argb top-level ARGB main-image harness (21st)
+- 20th harness — §7.3 decode_entropy_coded_image standalone
+- 19th cargo-fuzz harness decode_entropy_image (§6.2.2 entropy-image decode)
+- round 269 — publish the §4.4 width_bits threshold-table accessor, deduplicate its three private copies
+- round 268 — §6.2.2 MetaPrefixIndex::from_parts validated constructor + block-lookup harness (18th)
+- round 267 — §5.2.2 backward-reference assembler harness (17th)
+- round 266 — §4.3 subtract-green + §4.4 color-table + color-indexing harness (16th)
+- add §4.1 + §4.2 inverse-transform passes harness (15th fuzz target)
+- add §5.2.3 ColorCache primitives harness (14th fuzz target)
+- round 263 — distance_code harness on §5.2.2 distance-code-to-pixel-distance lookup
+- round 262 — parse_container harness on §2.3 / §2.4 RIFF chunk-walker
+- round 261 — parse_meta_prefix harness on §5.2.3 + §6.2.2 + §6.2 preamble reader
+- round 260 — parse_transform_list harness on §4 VP8L transform-list reader
+- round 259 — parse_alph harness on §2.7.1.2 ALPH info-byte parser
+- round 258 — parse_anim harness on §2.7.1.1 ANIM chunk parser
+- round 257 — parse_anmf harness on §2.7.1.1 ANMF chunk header parser
+- round 256 — parse_vp8x harness on §2.7.1 VP8X chunk parser
+- round 255 — decode_alph harness on §2.7.1.2 ALPH standalone entry
+- round 254 — §5.2.2 value_to_prefix per-call bench
+- round 253 — §3.6.2.3 color_cache_hash per-call bench
+- round 252 — §3.6.2.2 read_lz77_value per-call bench
+- round 251 — §3.7.2 canonical_codes per-pass bench
+- round 250 — §3.7.2 build_code_lengths Huffman builder bench
+- round 249 — §4.4 inverse_color_table palette subtraction-decode bench
+- drop release-plz.toml — use release-plz defaults across the workspace
+- round 248 — encoder-side §4.3 apply_subtract_green bench coverage
+- round 238 — roundtrip_animated harness on §2.7.1.1 ANIM/ANMF carrier
+- round 224 — predictor_subtract bench + SWAR experiment
+- round 217 — §4.3 inverse_subtract_green bench coverage
+- round 210 — §4.4 inverse_color_indexing per-bundle hoist + bench
+- round 207 — §4.2 inverse_color per-block CTE hoist + bench
+- round 204 — first cargo-fuzz harness (decode + extract_metadata + lossless roundtrip)
+- round 194 — §4.1 Select algebraic simplification + per-mode bench
+
 ### Added
 
 - Round-308 lossless-encode cost improvement: the single-transform §4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/OxideAV/oxideav-webp/compare/v0.2.1...v0.2.2) - 2026-06-15

### Other

- §4.2 single-transform entropy-cost per-block CTE chooser (r308)
- round 307 — §3.5 stacked-transform encode harness, separated by content regime
- §3.5 stacked chains sweep full sub-image lambda set (r306)
- §3.5 stacked chains sweep entropy-aware predictor sub-image cost models
- §3.5 three-transform stacked candidate (color → subtract-green → predictor)
- §3.5 stacked color-transform + predictor candidate (photo)
- §3.5 stacked color-indexing + predictor transform candidate
- distance-code chooser smallest-code early-out (§5.2.2)
- *(r300)* §5.2.2 encoder distance-code chooser isolated harness
- *(lossless)* pre-size private argb_to_rgba repack (~14.5x on the byte step)
- round 298 FUZZ — add parse_vp8_chunk harness over §2.5 VP8 chunk handle
- round 297 — §5.2.2 decoder LZ77 copy-back bench (apply_backward_reference)
- README round-296 PROFILE narrative — inverse_predictor per-block hoist evaluation + realistic-block bench
- round 296 PROFILE — realistic-block inverse_predictor bench + per-block mode-hoist evaluation
- add decode_alpha_plane libFuzzer target over the file-level still-image alpha path
- webp r294: meta_prefix_cluster bench + §6.2.2 entropy-image clustering hotspot map
- webp r293: hoist §2.7.1.2 ALPH inverse-filter border rules out of the per-pixel loop (rank-1 lossy/alpha opt)
- r292 decode_lossless_image target + fix §3.4-header eager-alloc OOM
- round 291 — §2.7.1.2 ALPH alpha-plane decode harness + refined lossy hotspot map
- webp r290: yuv420_to_rgba §9.2 chroma-pair hoist (rank-1 lossy opt, byte-identical)
- r289 §2.5 VP8 lossy decode harness + ranked hotspot map
- *(r288)* decode_still_paths differential oracle + fix animation-canvas OOM
- O(1) length→row side table for the §6.2.1 per-bit walk (r287 PROFILE-OPT)
- round 286 — isolate §6.2.1 read_symbol (rank-1 decode) + §5.2.2 lz77_chain (rank-3 encode) hotspots; rank next PROFILE-OPT target
- r285 harnesses #27+#28 — §6.2.1 read-symbol LUT differential + wide-carrier lossless decode
- r284 — §6.2.1 read_symbol primary lookup table + word-load ReadBits
- round 283 — end-to-end decode coverage (transform mixes, animation timeline, metadata walk) + full regression refresh
- r282 harness #25 roundtrip_metadata — §2.7 metadata write-path differential
- round 281 — §3.5.2 pick_block_cte chooser-walk bench + chunk-granular axis prune
- r280 — hoist §4.1 border rules + mode dispatch out of the encoder chooser's per-pixel loop
- r279 harness #24 roundtrip_anim_modes — §2.7.1.1 assembly differential; fix Delta/Auto dispose + AlphaBlend emission
- r278 — remove §3.7.2 length-cap pass's per-adjustment O(n) target-selection rescan
- r277 — bit-identical dense-cell rewrite of the §3.7.2/§6.2.1 length-then-code chain
- round 276 — §6.2.1 PrefixCode::from_code_lengths decoder canonical-table bench
- add prefix_code target — §6.2.1 single canonical prefix-code reader
- r274 fuzz harness #23 prefix_code_group — §6.2 prefix-code-group reader
- r273 decode_lossless fuzz harness + fix BitReader::bits_remaining usize underflow
- round 272 — §6.2.2 decode_argb top-level ARGB main-image harness (21st)
- 20th harness — §7.3 decode_entropy_coded_image standalone
- 19th cargo-fuzz harness decode_entropy_image (§6.2.2 entropy-image decode)
- round 269 — publish the §4.4 width_bits threshold-table accessor, deduplicate its three private copies
- round 268 — §6.2.2 MetaPrefixIndex::from_parts validated constructor + block-lookup harness (18th)
- round 267 — §5.2.2 backward-reference assembler harness (17th)
- round 266 — §4.3 subtract-green + §4.4 color-table + color-indexing harness (16th)
- add §4.1 + §4.2 inverse-transform passes harness (15th fuzz target)
- add §5.2.3 ColorCache primitives harness (14th fuzz target)
- round 263 — distance_code harness on §5.2.2 distance-code-to-pixel-distance lookup
- round 262 — parse_container harness on §2.3 / §2.4 RIFF chunk-walker
- round 261 — parse_meta_prefix harness on §5.2.3 + §6.2.2 + §6.2 preamble reader
- round 260 — parse_transform_list harness on §4 VP8L transform-list reader
- round 259 — parse_alph harness on §2.7.1.2 ALPH info-byte parser
- round 258 — parse_anim harness on §2.7.1.1 ANIM chunk parser
- round 257 — parse_anmf harness on §2.7.1.1 ANMF chunk header parser
- round 256 — parse_vp8x harness on §2.7.1 VP8X chunk parser
- round 255 — decode_alph harness on §2.7.1.2 ALPH standalone entry
- round 254 — §5.2.2 value_to_prefix per-call bench
- round 253 — §3.6.2.3 color_cache_hash per-call bench
- round 252 — §3.6.2.2 read_lz77_value per-call bench
- round 251 — §3.7.2 canonical_codes per-pass bench
- round 250 — §3.7.2 build_code_lengths Huffman builder bench
- round 249 — §4.4 inverse_color_table palette subtraction-decode bench
- drop release-plz.toml — use release-plz defaults across the workspace
- round 248 — encoder-side §4.3 apply_subtract_green bench coverage
- round 238 — roundtrip_animated harness on §2.7.1.1 ANIM/ANMF carrier
- round 224 — predictor_subtract bench + SWAR experiment
- round 217 — §4.3 inverse_subtract_green bench coverage
- round 210 — §4.4 inverse_color_indexing per-bundle hoist + bench
- round 207 — §4.2 inverse_color per-block CTE hoist + bench
- round 204 — first cargo-fuzz harness (decode + extract_metadata + lossless roundtrip)
- round 194 — §4.1 Select algebraic simplification + per-mode bench

### Added

- Round-308 lossless-encode cost improvement: the single-transform §4.2
  **cross-color** path now adds an **entropy-cost per-block CTE chooser**
  alongside the existing L1-magnitude one. Where the L1 chooser scores each
  `(green_to_red, green_to_blue, red_to_blue)` candidate by the folded
  residual magnitude, the new strategy scores by the Shannon lower-bound bit
  cost of the resulting per-channel residual histogram — the §4.2 analogue of
  the round-161 §4.1 predictor entropy chooser (RFC 9649 §3.5 authorises
  deciding transform data by entropy minimization). The per-axis greedy stays
  exact: the red residual depends only on `green_to_red` and the blue residual
  only on `(green_to_blue, red_to_blue)`, and red / blue carry independent
  §5.x prefix codes, so red entropy minimises over `green_to_red` alone and
  the blue pair is chosen greedily. The entropy candidate is evaluated at both
  the per-region and single-block `size_bits` across the round-148 cache-bits
  sweep; the super-chooser keeps the byte-shortest stream, so it cannot
  regress against the L1 path. On a 128×128 channel-correlated-noise fixture
  the entropy CTE candidate shrinks the §4.2 stream 41253 → 41195 B. Round-trip
  output is byte-identical regardless of which cost model is recorded — the
  decoder re-applies whatever CTE the §4.2 sub-image carries.

- Round-307 benchmark: new `stacked_transform_encode` criterion bench drives
  the public `encode_webp_lossless` entry point across the three distinct
  content regimes the RFC 9649 §3.5 **stacked-transform chains** target —
  `palette_indexed` (activates the §4.4 color-indexing path and its round-302
  color-indexing → §4.1 predictor chain), `photo_decorrelated` (red/blue as
  affine functions of green, activating the §4.2 cross-color transform and its
  round-303/304 color → predictor and color → subtract-green → predictor
  chains), and `smooth_gradient` (drives the §4.1 predictor sub-image lambda
  sweep across the residual-vs-§7.2-sub-image cost crossover rounds 302–306
  tuned). Rounds 302–306 each reasoned about an "empirically-observed
  crossover" without a committed harness exercising the chooser on per-regime
  inputs; this bench supplies that A/B target for both encode time and output
  size. Encode-only timing (inputs built once outside `b.iter`); all three
  inputs were verified to round-trip losslessly through encode → decode. No
  production-code change — measurement infrastructure only.

- Round-306 lossless-encode cost improvement: the §3.5 **stacked-transform
  chains** now sweep the **full sub-image-aware lambda set** the
  single-transform predictor path has carried since round 162 —
  `4_000` / `16_000` / `64_000` / `256_000` milli-per-bit — instead of the
  single mid-range `16_000` weight round 305 bootstrapped them with. The
  four weights straddle the empirically-observed residual-vs-§7.2-sub-image
  cost crossover (~`64_000`) on smooth transform-decorrelated content, so
  each chain (color + predictor, color + subtract-green + predictor,
  color-indexing + predictor) can land on the crossover its own decorrelated
  residual exhibits rather than one fixed guess. `STACKED_PREDICTOR_STRATEGIES`
  grows from 3 to 6 entries; the chooser keeps the byte-shortest stream
  across all of them, so the wider sweep is strictly non-regressing against
  both the L1 baseline and the round-305 single-lambda setting. Round-trip
  output is unchanged (lambda only biases which §4.1 mode is *recorded* per
  block — the decoder reads the same modes back). No decoder change required.

- Round-305 lossless-encode cost improvement: the §3.5 **stacked-transform
  chains** (color + predictor, color + subtract-green + predictor,
  color-indexing + predictor) now sweep the **predictor-sub-image cost
  model** the same way the single-transform predictor path has since
  rounds 159–162. The chains were bootstrapped (rounds 302–304) with only
  the round-159 folded-L1 magnitude proxy for per-block §4.1 mode
  selection; round 305 threads a `PredictorSubImageStrategy` through each
  chain so the chooser also builds the round-161 Shannon-entropy bit-cost
  and round-162 sub-image-aware entropy candidates over the
  *transform-decorrelated* residual the predictor actually sees, and keeps
  the byte-shortest. On smooth, mildly-noisy photo-like content the
  entropy-aware strategies shrink the color + predictor chain by ~12–21 %
  versus the L1 baseline (the per-block mode histogram concentrates,
  compacting both the §7.2 predictor sub-image and the residual stream).
  The sweep keeps L1 in the strategy set, so it is strictly
  non-regressing; round-trip correctness is strategy-independent (each
  strategy only changes which §4.1 mode is recorded per block — the
  decoder reads the same modes back). No decoder change required.

- Round-304 lossless-encode feature: the first §3.5 **three-transform**
  stacked candidate — §4.2 cross-color → §4.3 subtract-green → §4.1
  spatial predictor, chained into one `optional-transform` list. It is the
  natural three-axis extension of the round-303 color + predictor pair:
  the per-block §4.2 color transform removes the *modeled* inter-channel
  correlation, a header-free §4.3 subtract-green pass then removes the
  *uniform* red/blue-vs-green correlation that survives the coarse
  3.5-bit-fixed-point per-block CTE multipliers, and the §4.1 predictor
  pass removes the *spatial* correlation left in each channel — so the
  entropy stage sees residuals driven closer to zero than any one- or
  two-transform path achieves alone on content where all three
  correlation axes carry mass. RFC 9649 §3.5 permits up to four transforms
  stacked (each used at most once) with inverses applied last-read-first;
  none of the three subsamples the width, so both sub-image bodies and the
  main image run at full canvas width. The decoder's generic
  reverse-read-order chain already applies inverse-predictor →
  inverse-subtract-green → inverse-color, so no decoder change is required.
  The candidate is non-regressing (kept only when strictly smaller than
  the running best) and reuses the existing `width >= block && height >=
  block` gate, with two `size_bits` swept (default per-region granularity
  + a maximal single-block header) each across the `cache_code_bits ∈
  [1..11]` + disabled-cache sweep. New tests:
  `round_304_color_subtract_green_predictor_round_trips_through_decoder`
  (default + single-block `size_bits` × no/4-/9-bit cache),
  `…_single_block_round_trips`, and
  `round_304_chooser_never_regresses_and_round_trips`.

- Round-303 lossless-encode feature: a second §3.5 stacked-transform
  candidate aimed at **photo / natural-image** content — the §4.2
  cross-color transform chained with the §4.1 spatial predictor.
  The encoder now evaluates a candidate that writes the color transform
  first (read first) and the predictor second (read second) into one
  `optional-transform` list. The §4.2 transform removes the
  inter-channel correlation (rewriting red/blue as residuals against
  green per the per-block `ColorTransformElement`); a predictor pass
  over that color-decorrelated image then removes the *spatial*
  correlation surviving in each channel, so the entropy stage sees
  residuals closer to zero than either transform alone. Neither
  transform subsamples the width, so both sub-image bodies and the main
  image run at full canvas width; the decoder already applies the
  inverses last-read-first (inverse-predictor recovering the
  color-transformed image, then inverse-color recovering the original
  pixels), so no decoder change is required. The candidate is
  non-regressing (kept only when strictly smaller than the running best)
  and reuses the existing `width >= block && height >= block` gate, with
  two `size_bits` swept (default per-region granularity + a maximal
  single-block header), each across the `cache_code_bits ∈ [1..11]` +
  disabled-cache sweep. New tests:
  `round_303_color_transform_predictor_round_trips_through_decoder`
  (default + single-block `size_bits` × no/4-/9-bit cache),
  `…_single_block_round_trips`, and
  `round_303_chooser_never_regresses_and_round_trips`.

### Fixed

- Round-303 lossless-encode correctness fix in the §3.7.2.1.2
  *code-length-code* (CLC) writer. The CLC lengths are each written in a
  3-bit on-wire field (range `[0..7]`), but the encoder built them with
  the general 15-bit Huffman builder. A sufficiently skewed CLC
  frequency histogram (one length value far more common than the rest)
  makes the builder assign a length-8-or-more code to a rare CLC symbol;
  the 3-bit field then silently truncated it, corrupting the on-wire
  table into an incomplete (Kraft < 1) prefix code the decoder rejects
  with `Prefix(Incomplete)`. The fix caps CLC lengths at 7 via a Kraft
  re-balancing pass (`build_clc_code_lengths` / the new
  `limit_code_lengths_to`), keeping the table complete. This was a
  latent defect reachable by any encoder candidate whose residual
  distribution produced a skewed CLC histogram — surfaced here by the
  new color-transform + predictor chain at the per-region color
  `size_bits`. New test:
  `clc_code_lengths_capped_at_seven_and_complete`.

- Round-302 lossless-encode feature: the §3.5 stacked-transform path.
  The encoder now evaluates a **chained** candidate that applies the
  §4.4 color-indexing transform followed by the §4.1 spatial predictor
  over the bundled palette-index image, written into one
  `optional-transform` list (color-indexing read first → predictor read
  second → end). RFC 9649 §3.5 permits up to four transforms stacked
  (each used once) with inverses applied last-read-first; the decoder
  already runs that reverse-order chain, so it un-applies the predictor
  over the packed indices first, then un-bundles the color index — no
  decoder change. On palette content (icons, line art, screen captures)
  the bundled indices run in long spatially-coherent stretches, so the
  predictor drives the residuals toward zero and shrinks the entropy
  stage below the single-transform color-indexing path. The candidate
  is non-regressing (kept only when strictly smaller than the running
  best) and self-skips when the packed image is too small to carry a
  predictor block. Two predictor `size_bits` are swept (default
  per-region granularity + a maximal single-block header), each across
  the round-148 `cache_code_bits ∈ [1..11]` + disabled-cache sweep.
  New tests: `round_302_color_indexing_predictor_round_trips_through_decoder`
  (four bundling regimes), `…_round_trips_with_cache_and_single_block`,
  `…_skips_subblock_packed_image`, and
  `round_302_chooser_never_regresses_and_round_trips`.

### Performance

- Round-301 PROFILE-OPT round: gave the encoder-side §5.2.2
  `pixel_distance_to_distance_code` distance-code chooser (the rank-1
  round-300 target) a **smallest-code early-out**. Map codes occupy
  `1..=120` and the scan-line fallback is `D + 120 ≥ 121`, and the
  `DISTANCE_MAP` entries are visited in ascending code order, so the
  first entry whose `max(xi + yi·W, 1)` equals the distance is already
  the smallest valid code; the chooser now returns on that first match
  instead of always scanning all 120 entries. The chosen code — and
  therefore every emitted byte — is unchanged, proven by a new
  `distance_chooser_early_out_matches_full_scan` test that asserts
  identity against an inline full no-early-out scan-with-tie-break over
  distances `1..=400` + `{1000, 4096, 70_000}` across widths
  `{1, 2, 16, 128, 256, 1024}`. On the `distance_code` bench the
  matching cells drop from ~64 µs to ~0.8–2.4 µs per 1024 calls
  (≈30–160×); the genuine no-match worst case (`dist_large_nomatch`)
  still walks all 120 entries since there is no smaller code to find.
  See `BENCHMARKS.md` "Round-301".
- Round-300 BENCH round (no `src/` change): added
  `benches/distance_code.rs`, isolating the encoder-side §5.2.2
  `pixel_distance_to_distance_code` distance-code chooser — run at least
  twice per emitted LZ77 backward reference and performing a no-early-out
  linear scan of all 120 `DISTANCE_MAP` entries to pick the smallest
  valid distance code. Four cells fix `image_width = 256` and vary
  `distance`: `dist1_rle` (RLE, multiple clamp-to-1 hits),
  `dist_row_above` (`distance == width`, code-1 match at scan index 0),
  `dist_small_neighbor` (`distance = 2`), and `dist_large_nomatch`
  (`distance = 70_000`, no map match → full scan + scan-line fallback).
  Baseline: all four cells flat within noise at ~64 µs / 1024 calls
  (~63 ns/call), confirming the cost is the fixed 120-entry scan, not the
  match location — the A/B harness for a future reverse-map early-out.
  See `BENCHMARKS.md` "Round-300".
- Round-299 PROFILE depth round: rewrote the private
  `crate::argb_to_rgba` helper — the ARGB-`u32` → packed `[R, G, B, A]`
  converter the public `decode_webp` lossless still path
  (`decode_lossless_image`) and the animation sub-frame path call — from
  the original four-`push`-per-pixel loop to the pre-sized
  `chunks_exact_mut(4)` form that round 170 already adopted for the
  public `Vp8lImage::to_rgba`. Output is byte-for-byte identical
  (`[R, G, B, A]` order; the full 439-test `--lib` suite passes
  unchanged). New A/B bench cells `repack_push_loop` /
  `repack_chunks_exact` in `benches/argb_to_rgba.rs` measure ~130 µs vs.
  ~8.9 µs over a 256×256 buffer (≈14.5× faster), matching the existing
  `argb_to_rgba` cell. A `chunks_exact_mut` rewrite of the lossy
  `yuv420_to_rgba` interior was also tried but regressed ~2.1–2.4× and
  was reverted. See `BENCHMARKS.md` "Round-299".
- Round-296 PROFILE depth round: evaluated a per-block predictor-mode
  hoist for the §4.1 `vp8l_transform::inverse_predictor` interior loop
  (load the block's mode once per `1 << size_bits` block instead of on
  every pixel, mirroring the round-207 `inverse_color` CTE hoist). The
  hoist was proven byte-identical — the existing randomised cross-check
  test plus an FNV-1a A/B over all seven `lossless-*` fixtures both
  matched — but it produced no measurable win (the interior is
  dominated by the 14-way `predict()` dispatch, not the mode load) and
  the measurement host was saturated by concurrent agents (baseline
  drift of 4–6×), so the original per-pixel body was retained per the
  round-224 precedent. The realistic block path is now benched:
  `benches/inverse_predictor.rs` adds
  `inverse_predictor_blocks16_mixed_256x256` (`size_bits=4`, 16×16
  blocks, per-block LCG mode mix), filling the coverage gap left by the
  pre-existing `size_bits=0` cells (which the on-wire `size_bits =
  ReadBits(3) + 2 ∈ [2, 9]` never reaches). See `BENCHMARKS.md`
  "Round-296".

- Round-293 PROFILE-OPT depth round: hoisted the §2.7.1.2 `ALPH`
  Stage-2 inverse-filter border rules out of the per-pixel loop. The
  loop previously re-evaluated a `match (x, y)` top-left special case
  plus a `match` on the (loop-invariant) filter method, with an inner
  edge test and an index closure, on every one of the `width × height`
  pixels. `decode_alpha`'s Stage 2 now calls a new private
  `inverse_filter` that dispatches on the filter method **once** and
  runs a specialised body per method: a one-shot border pass (top-left,
  first row, and — for Horizontal/Gradient — left-most column) followed
  by a tight interior loop with precomputed row-base indices. The
  `None` method becomes a plain identity buffer move. On this host
  (`aarch64-apple-darwin`, `--quick`): `inverse_filter_none_128x128`
  9.5 µs → 0.23 µs (−97%), `inverse_filter_vertical_128x128`
  13.5 µs → 1.57 µs (−88%, the row-above predictor auto-vectorises once
  the dispatch is gone); `Horizontal` and `Gradient` are flat (their
  left-neighbour serial recurrence, not the dispatch, is the bound).
  **Decoded alpha planes are byte-for-byte unchanged for every filter
  method and dimension** — proven by a new oracle test
  (`hoisted_inverse_filter_matches_per_pixel_reference_across_methods_and_dims`,
  the round-291 per-pixel form as reference, over 9 dimension shapes ×
  4 methods) and by 400 K `decode_alph` fuzz runs plus the
  `decode_still_paths` differential, no divergence. See `BENCHMARKS.md`
  "Round-293".

### Fixed

- Round-292 FUZZ depth round: a malformed §2.6 `VP8L` lossless chunk
  whose §3.4 5-byte image-header declares a huge canvas (the 14-bit
  `width - 1` / `height - 1` fields reach `16384 × 16384 ≈ 2.7e8`
  pixels) but carries only a few backing bytes no longer forces an
  unbounded eager allocation. `vp8l_decode::decode_image` and
  `decode_argb_multi_group` previously pre-sized their output buffer to
  the full declared `width * height` (`Vec::with_capacity`), so a
  ~30-byte chunk could drive an ~800 MiB allocation **before** the
  EOF-checked §5/§6 decode loop read a single symbol — a decode-time
  out-of-memory DoS surfaced by the new `decode_lossless_image` fuzz
  target. The eager reservation is now capped at
  `MAX_EAGER_PIXEL_RESERVATION = 1 << 22` pixels via
  `eager_pixel_capacity`; the buffer still grows on demand for a
  legitimately large image, and the self-terminating decode loop raises
  `DecodeError::Eof` for a truncated stream as before. **Decoded bytes
  for all valid images are unchanged** — the cap only affects the
  *initial* capacity hint, not the final buffer contents (438 lib tests
  pass, including two new `eager_pixel_capacity_*` regression tests).

### Added

- Round-298 FUZZ depth round: added
  `fuzz/fuzz_targets/parse_vp8_chunk.rs`, a libFuzzer panic/OOM-free
  target over the §2.5 simple-lossy `VP8 ` chunk handle standalone entry
  point `vp8_chunk::WebpLossyChunk::from_payload` — the RFC 6386 §9.1
  key-frame-header peek the §2 RIFF walker reaches only along the
  well-formed-container path. The entire fuzz buffer is forwarded
  verbatim as the §2.5 `VP8 ` payload candidate; every successfully-
  decoded field is cross-checked against the §9.1 byte layout the parser
  observed (LE frame tag from bytes 0..3 with the key-frame frame-type,
  `version`/`show_frame`/19-bit `first_partition_size` bitfields, the
  §9.1 start code at bytes 3..6, the 14-bit dimension / 2-bit scale split
  of the width/height words, and the verbatim `bitstream()` borrow), and
  every refusal branch (`PayloadTooShortForKeyframe`, `NotAKeyframe`,
  `BadStartCode`) is cross-checked against its §9.1 / §2.5 trigger.
  87,063,810 executions (~1.43 M exec/s, peak RSS 550 MiB), 0 findings —
  the existing `from_payload` length gate and frame-tag/start-code checks
  already make the path panic-free.

- Round-292 FUZZ depth round: added
  `fuzz/fuzz_targets/decode_lossless_image.rs`, a structure-aware
  libFuzzer panic/OOM-free decode target over the public top-level
  lossless façade `decode_lossless_image` — the layer that walks the
  §2.3 `RIFF`/`WEBP` container, selects the §2.6 `VP8L` chunk, reads the
  chunk's own §3.4 image-header dimensions, and runs the full §4/§5/§6
  decode returning the typed `DecodedImage`. Distinct from the round-286
  `decode_lossless` harness (which supplies `(width, height)` *from the
  harness* over a bare payload): here the decoded dimensions come from
  the **file's own** §3.4 header, exercising the §3.4-header → §4-decode
  dimension-coherence path end to end. A cheap structural pre-pass gates
  the full-decode tail by declared pixel count. Seeded from the in-tree
  `tests/data/*.webp` fixtures; 48,882 executions post-fix, 0 findings.
  The pre-fix run surfaced the eager-allocation OOM fixed above.

### Changed

- Round-294 BENCH depth round: added `benches/meta_prefix_cluster.rs`, a
  criterion harness over the encoder's §6.2.2 entropy-image
  block-clustering heuristic (`cluster_blocks_by_histogram_distance`)
  behind `encode_with_meta_prefix` — the last encode stage sized only by
  subtraction inside the `lossless_encode` end-to-end number. The kernel
  is a coarse-RGB-histogram (16 bins/channel → 48-dim/block) Lloyd's
  k-means over the `1 << prefix_bits`-aligned blocks: a per-pixel
  feature-binning pass, deterministic farthest-point seeding, an
  up-to-8-pass assignment/update loop, and a compaction. Three altitudes:
  content regime (bimodal split / smooth gradient / uniform single-group
  early-out), `num_groups ∈ {2,3,4}`, image side ∈ {128,256,384} px. The
  ranked hotspot map: the per-pixel feature pass dominates (≈70–80% of
  clustering self-time — the uniform cell, which skips the Lloyd loop, is
  122 of 150 µs; the size sweep scales with pixel not block count), the
  Lloyd loop is a clear second only on poorly-separated content (gradient
  204 µs vs. bimodal 150 µs), and `num_groups` 2→4 is nearly flat
  (147→150 µs) at the default block size. **No behavioural change — the
  only `src/` edit is a `fn` → `pub fn` visibility widen on
  `cluster_blocks_by_histogram_distance` so the bench can drive it in
  isolation (matching the `pick_block_cte` exposure pattern); every
  emitted byte is unchanged.** See `BENCHMARKS.md` round-294.

- Round-291 BENCH depth round: added `benches/alpha_decode.rs`, a
  criterion harness over the §2.7.1.2 `ALPH` alpha-plane decode — the
  rank-1 webp-owned cost on the lossy decode path, previously sized only
  by subtraction in the round-289 hotspot map. Five cells: the public
  `decode_alpha_plane` e2e over the committed fixture, `alph::decode_alpha`
  on the extracted `ALPH` payload (RIFF walk removed), and the §2.7.1.2
  Stage-2 inverse-filter per-pixel loop in isolation, one cell per `F`
  method (synthetic uncompressed payloads). The measurements correct the
  r289 estimate: the container walk is ≈1 µs (negligible), and the rank-1
  cost is almost entirely the headerless VP8L lossless decode inside
  `decode_alpha` (already covered by `read_symbol` / `lossless_decode*`).
  The genuinely alpha-specific inverse-filter loop ranks Gradient (43.7 µs)
  > Horizontal (21.8 µs) > Vertical (13.5 µs) > None (9.5 µs) at 128×128.
  **No `src/` change — bench-only; decoded bytes are unchanged.** See
  `BENCHMARKS.md` round-291.

- Round-290 PROFILE-OPT depth round: `vp8_decode::yuv420_to_rgba` (the
  §2.5 lossy decode's crate-owned 4:2:0 chroma up-sample + RFC 6386 §9.2
  BT.601 YCbCr→RGB loop, ranked rank-1 webp-owned lossy hot path in r289)
  now hoists the chroma-matrix terms out of the per-pixel loop. The two
  luma pixels of a 4:2:0 pair share one chroma column, so the three
  `(Cb−128, Cr−128)` contributions are computed once per column
  (`chroma_offsets`) and reused; the output is written through pre-sized
  per-row slices instead of four `Vec::push` calls per pixel.
  **Decoded bytes are byte-for-byte identical** — the per-pixel
  `ycbcr_to_rgb` form is retained as a `#[cfg(test)]` oracle, and the new
  `yuv420_to_rgba_matches_per_pixel_reference_across_dimensions` test
  proves equivalence across 9 even/odd dimensions with non-neutral chroma;
  `cargo fuzz` (decode_still_paths, decode) over the corpus showed no
  divergence. The conversion drops from ≈34 µs to ≈10.5 µs at 128×128
  fixture size (−68%; −72% at 256×256) — see `BENCHMARKS.md` round-290.

### Fixed

- Round-288 FUZZ depth round: `decode_webp`'s §2.7.1.1 animation path no
  longer eagerly allocates the full `VP8X` canvas before validating its
  size. §2.7.1 permits a canvas up to 2^24 per side (product capped at
  2^32 - 1); a ~60-byte file declaring a 16 777 154 × 64 canvas forced a
  ~4 GiB `Vec` (libFuzzer OOM, surfaced by the new `decode_still_paths`
  harness below). The canvas is now bounded at the §3.4 still-image
  ceiling (`MAX_DECODE_DIMENSION = 16384` per side) — a dimension above
  that can never be fully covered by a spec-valid `ANMF` sub-frame (each
  sub-frame is itself a `VP8L` image) — and an over-ceiling canvas is
  rejected with `WebpError::InvalidData`, allocating nothing. Covered by
  the `oversized_anim_canvas_is_rejected_without_eager_allocation`
  regression test (inclusive of the 16384 ceiling).

### Added

- Round-289 BENCH depth round: `benches/lossy_decode.rs`, the first
  isolated harness for the §2.5 `VP8 ` (lossy) decode path. Three
  altitudes — full public `decode_webp` over the 128×128 `VP8 `+`ALPH`
  fixture (`decode_webp_lossy_e2e`, ≈359 µs), `decode_lossy_rgba` over
  the extracted `VP8 ` bitstream with the RIFF walk removed
  (`decode_lossy_rgba_extracted`, ≈173 µs), and the crate-owned
  post-I420 reconstruction loop `yuv420_to_rgba` (4:2:0 chroma up-sample
  + RFC 6386 §9.2 BT.601 YCbCr→RGB) in isolation at 16/128/256 px
  (≈551 ns / 34 µs / 137 µs, linear per-pixel). The sibling
  `oxideav-vp8` decoder owns the entropy/IDCT/intra-pred/loop-filter
  work (≈39% of lossy e2e, out of this crate's scope); the bench isolates
  and ranks the lossy stage `oxideav-webp` itself can act on. The ranked
  hotspot map is in `BENCHMARKS.md` (Round-289). `vp8_decode::yuv420_to_rgba`
  widened `fn` → `pub fn` so the bench can isolate it — a visibility
  change only; decoded bytes are identical (all 435 lib tests + fixture
  SHA-256s unchanged). No behavior change.

- Round-288 FUZZ depth round: a twenty-ninth `cargo-fuzz` harness,
  `decode_still_paths`, a differential oracle on the two public
  still-image decode entry points `decode_webp` (the published
  `WebpImage` surface) and `decode_webp_image` (the low-level
  `DecodedWebp` surface), seeded from the in-tree §2.6 lossless +
  §2.7-extended fixtures. For a non-animated input the published façade
  builds its single still frame by literally calling `decode_webp_image`,
  so the harness asserts the two surfaces agree exactly (`Ok` ⇒
  `frames.len() == 1` with byte-identical `frames[0].{rgba,width,height}`
  + canvas-dimension echo + `duration_ms == 0` + no §2.7.1.1 carrier;
  `Err` ⇒ the published path also `Err`), re-checks the §2.5/§2.6
  flat-buffer carrier invariant (`rgba.len() == width * height * 4`) on
  every still + every composited animation frame, and asserts
  `decode_webp_image` determinism. A ~300 s ASan campaign over 25 772
  runs is crash-free post-fix. The §2.5 `VP8 ` *lossy* decode (routed to
  the `oxideav-vp8` sibling) is deliberately skipped from the cross-check
  pending a sibling-side hardening — see the round report.

### Changed

- Round-287 PROFILE-OPT (depth round): the §6.2.1 canonical-decoder
  per-bit walk (`PrefixCode::read_symbol_walk` and its long-code
  continuation `read_symbol_long`) now resolves "is there a code row at
  this length?" through a 16-byte direct length→row side table
  (`len_to_row`, built once in `from_code_lengths`) instead of a linear
  `length_rows.iter().find(..)` rescan on every consumed bit. The walk
  is the decode path for every code below the `MIN_LOOKUP_USED` gate and
  the > 8-bit / near-EOF fallback for the round-284 primary table, so
  the rescan cost grew with the number of distinct code lengths. Output
  is byte-identical (the `read_symbol_reference` differential test and
  the `read_symbol_lut_diff` fuzz oracle both still pass; all 435 unit
  tests + the fixture-walk and round-trip suites are green). The
  round-284 candidate — a 9–`LOOKUP2_BITS`-bit second-level *spill*
  table — was prototyped and **rejected**: it measured a net regression
  on `read_symbol_long9_11` / `read_symbol_dense256` (the extra 4–16 KiB
  table thrashes L1 against the 1 KiB primary, and a single-bit walk
  from length 8 already beats a second peeked word-load + random table
  access). The chosen side-table change adds no cache footprint. New
  `read_symbol_manylen16_walk` bench cell (one symbol at each of lengths
  1..=14 plus two at 15 — a Kraft-exact, maximally length-diverse code
  the uniform-length cells can't exercise) isolates the targeted regime:
  **86.8 µs → 37.2 µs per 4096 reads, a 2.33× speedup** on the
  worst-case walk; the uniform short-code, 9–11-bit, dense-literal, and
  end-to-end `lossless_decode*` benches show no statistically
  significant change (the linear scan was already cheap when few
  distinct lengths are present).

### Added

- Round-286 benchmark-mode coverage of the two hotspots the round-283 /
  round-284 profiles flagged but never benched in isolation
  (`src/` byte-identical this round — both harnesses build their inputs
  through the existing public API, no probe accessor needed). New
  `benches/read_symbol.rs` isolates the decoder's §6.2.1
  `PrefixCode::read_symbol` per-symbol reader — the rank-1 decode
  hotspot at ~82% of decode self-time post-round-284 — across five
  cells that separate the round-284 primary-table fast path
  (`short8_uniform` / `short6_uniform`, all codes ≤ 8 bits resolve in
  one table load), the long-code (> 8-bit) walk continuation the
  round-284 follow-up targets (`long9_11`, every read spills past the
  table), the realistic blended literal channel (`dense256`), and the
  below-`MIN_LOOKUP_USED`-gate walk-only baseline (`belowgate16_walk`);
  each cell packs a deterministic LCG symbol stream via the public
  `canonical_codes` + `BitWriter` and times 4096 back-to-back reads
  through a fresh `BitReader`. New `benches/lz77_chain.rs` isolates the
  §5.2.2 LZ77 matcher (`Lz77Matcher::find` + `insert`, rank 3 in the
  round-283 encode profile) across five hash-chain-depth regimes
  (period-2/4/64 repeats, near-unique, gradient), driven through the
  public `encode_argb_literals_with_width` entry. Measured the
  long-code read path at +27% per symbol over the primary-table floor
  (`dense256` at +11%) and found the matcher's expensive regime is the
  shallow/unique insert+miss path (6.5–7× the deep-repeat cost), not
  the deep walk — reframing the r283 chain-cut candidate. `BENCHMARKS.md`
  ranks the decoder 9–11-bit second-level spill table (or
  alphabet-size-aware primary width) as the next PROFILE-OPT target.
- Round-285 fuzz hardening of the round-284 §6.2.1 read-symbol fast
  path + word-load `BitReader` (depth round, fuzz mode). Two new
  `cargo-fuzz` harnesses (#27 / #28, total now twenty-eight):
  `read_symbol_lut_diff` runs `PrefixCode::read_symbol` (256-entry
  primary lookup table, > 8-bit continuation walk, near-EOF per-bit
  fallback, used-symbol amortization gate) in lockstep against the
  crate's own pre-table per-bit row walk — kept as the new
  `#[doc(hidden)]` `PrefixCode::read_symbol_reference` oracle
  (behaviour-neutral; delegates to the existing private walk) — over
  the same bytes, asserting the decoded symbol / typed refusal
  (including `PrefixError::Eof` position fields), the cursor position
  after every symbol, and the alphabet bound identical, with the code
  under test built either off the wire (`PrefixCode::read` at a
  §6.2.3 alphabet) or from fuzz-shaped lengths repaired to an exact
  §6.2.1 Kraft sum so the mutator steers the used-symbol count and
  the length profile freely; `decode_lossless_lut` re-drives
  `decode_lossless` / `decode_lossless_headerless` at carrier
  dimensions widened into `[1, 64]`, corpus-seeded from the fixture
  corpus's VP8L chunk payloads plus entropy-heavy
  reference-encoder-produced 64×64 noise / gradient tiles, so the
  lookup-table fast path and continuation rows run hot inside the
  assembled pipeline under adversarial mutation. Campaigns: 36.1 M
  execs (`read_symbol_lut_diff`, 15 min ASan) + 16.8 M execs
  (`decode_lossless_lut`, 15 min ASan) with zero divergences and zero
  crashes, plus clean 4-minute regression re-runs of `prefix_code`
  (32.2 M), `decode_lossless` (9.4 M), and `prefix_code_group`
  (24.2 M); a matching in-tree unit
  test (`read_symbol_reference_matches_fast_path_on_lut_built_code`)
  pins the differential on a 256-symbol code mixing ≤ 8-bit and
  > 8-bit lengths. No findings: the round-284 fast path survived both
  oracles unchanged.

### Changed

- §6.2.1 decoder `PrefixCode::read_symbol` fast path (round 284 —
  the round-283 decode profile's rank-1 symbol at ~85–89% of decode
  self-time on every entropy-heavy fixture): codes built from 32 or
  more used symbols now carry a 256-entry primary lookup table keyed
  on the next 8 peeked stream bits (wire order), resolving any code of
  length ≤ 8 with one load + one cursor advance; longer codes consume
  the 8 peeked bits and continue the per-bit row walk from length 9,
  and codes below the used-symbol gate (tiny delta frames,
  sub-resolution transform images, the 19-symbol code-length code)
  keep the pre-table per-bit walk so the table cost is never paid
  where it cannot amortize. `BitReader::read_bits` now assembles its
  result from one zero-padded little-endian word load instead of a
  per-bit gather (same value bit for bit), and grew `peek_bits` /
  `advance_bits` for the fast path. Decoded output is bit-identical:
  an FNV-1a-64 digest sweep over the full docs + in-crate fixture
  corpus plus the five synthetic transform-mix fixtures is unchanged
  against the pre-change implementation, and the `prefix_code` fuzz
  harness ran 19.3 M execs clean on the new path. End-to-end decode
  benches: `lossless_decode_mix_crosscolor` 2.947 ms → 1.591 ms
  (−46%), `mix_none` 1.803 ms → 0.923 ms (−49%), `mix_subgreen`
  1.236 ms → 0.778 ms (−37%); see `BENCHMARKS.md` round 284.

- §3.5.2 color-transform-element chooser (`pick_block_cte`, the
  per-pixel-heavy stage of `encode_with_color_transform` — rank 2 at
  ~9% self-time in the round-280 encode profile): the three per-axis
  candidate sweeps now share a `sweep_cte_axis` helper that checks the
  worse-than-best prune at 32-sample chunk granularity instead of per
  sample, leaving the interior cost loop branch-free
  (auto-vectorisable). Encoded output is bit-identical (FNV digest over
  an 81-image encode sweep unchanged). New
  `pick_block_cte_walk_256x256` bench: 1.6012 ms → 752.03 µs (−52.6%);
  see `BENCHMARKS.md` round 281. `pick_block_cte` is now `pub` so the
  bench harness can drive it directly.

### Added

- Corpus-wide decoded-output digest pin
  (`round284_fixture_corpus_decode_digests_are_pinned` in
  `tests/fixture_walks.rs`): FNV-1a-64 over geometry + every decoded
  frame's RGBA for all eight in-crate fixtures, locked to the
  pre-round-284 reference decode so any future entropy-path rewrite
  has a byte-exact regression gate in CI.

- Three end-to-end criterion benches (round 283, BENCH depth round —
  `src/` untouched), closing the decode-side coverage gaps above the
  per-pass level: `lossless_decode_mixes` (full-file `decode_webp`
  per elected §4 transform mix — predictor / color-indexing /
  cross-color / subtract-green / no-transform, each fixture's elected
  list asserted at setup via `read_vp8l_transform_list`),
  `anim_decode` (§2.7.1.1 full-timeline animation decode of the same
  12-frame 128×128 timeline in all-keyframe and dirty-rect-delta
  `ANMF` layouts), and `metadata_walk` (`extract_metadata` chunk walk
  over a simple no-metadata file, a 5-chunk `VP8X` still with
  ICC + Exif + XMP, and a 64-frame animation carrying the same
  payloads after the `ANMF` run). Full regression re-run of all 21
  bench targets (stable + nightly `simd`) plus fresh decode / encode
  profiles and the ranked next-hotspot list recorded in
  `BENCHMARKS.md` round 283.

- Fuzz target `roundtrip_metadata` (round 282) — differential oracle
  on the §2.7 metadata *write* path: the two independent
  extended-layout writers (`build::build_webp_file_with_metadata` and
  `encode_vp8l_argb_with_metadata`) are driven with fuzz-controlled
  §2.7.1.4 `ICCP` / §2.7.1.5 `EXIF` / `XMP ` payloads (presence,
  length, content — odd lengths exercising the §2.3 pad byte), a
  fuzz-controlled §2.7.1 `L` alpha-hint flag, and fuzz-controlled
  canvas dimensions + ARGB pixels, with every emitted file
  cross-checked against the §2.7 canonical chunk order, the §2.7.1
  flag-octet derivation, byte-exact metadata round trips through both
  `extract_metadata` and the `decode_webp` metadata carry, the
  lossless pixel contract, and the writer-B no-alpha/no-metadata
  demotion to the §2.6 simple layout. The prior coverage fuzzed the
  metadata chunks from the read side only (raw bytes into
  `extract_metadata`), which a coverage-guided mutator almost never
  grows into a well-formed multi-chunk extended file.

- Criterion bench `pick_block_cte` (`pick_block_cte_walk_256x256`) —
  the §3.5.2 encoder color-transform chooser walk at the
  encoder-default `size_bits = 4` (256 blocks of a 256×256
  correlated-channel image), closing the encoder bench-shelf gap
  named by the round-280 followups.

### Changed

- §4.1 encoder block-mode chooser hot path (round-280 profile: the
  per-pixel `predictor_at` helper was 36% of total encode self-time):
  the per-block per-mode cost walks (`block_mode_cost`, the L1 pickers
  `pick_block_mode_with_hint` / `_slack`, and
  `block_mode_entropy_cost`) now run through a shared block-residual
  walker that hoists the §4.1 border-rule branch chain and the 14-way
  predictor-mode dispatch out of the per-pixel inner loop
  (monomorphised per mode), and prunes worse-than-best modes at
  block-row granularity instead of per pixel so the interior loop is
  branch-free. Encoded output is bit-identical (FNV digest over an
  82-image encode sweep unchanged; pinned by the new
  `block_walker_matches_predictor_at_reference_random` test against
  verbatim pre-change reference loops). `lossless_encode_natural_128`
  −19% to −28%, `lossless_encode_rgba_256` −16% to −21%; see
  `BENCHMARKS.md` round 280.

### Added

- Fuzz harness #24 `roundtrip_anim_modes` — a differential oracle on
  the §2.7.1.1 animation assembly path `build_animated_webp_with_options`
  → `decode_webp` with every per-frame carrier field fuzz-driven: even
  `(x, y)` sub-canvas offsets, mixed `Auto` / `Delta` / `Lossless` frame
  modes, `None` / `Background` disposal, `Overwrite` / `AlphaBlend`
  blending, and the `ANIM` loop-count + background-colour options. Every
  decoded full-canvas frame snapshot is asserted byte-identical to an
  independent §2.7.1.1 canvas simulation; duration, loop count and
  background colour are asserted to carry through. The existing
  `roundtrip_animated` harness only drove `AnimFrame::new` defaults
  (full-canvas Lossless frames at the origin), leaving the dirty-rect
  encoder and the dispose/blend carrier semantics unfuzzed.

### Fixed

- `AnimFrameMode::Delta` / `Auto` dirty-rect emission (both found by the
  new `roundtrip_anim_modes` harness within its first seed pass, each
  pinned by a regression test in `tests/published_anim_api.rs`):
  - a delta-emitted frame with `dispose == Background` forced `D = 0`
    into the stream while the encoder's reference canvas applied the
    caller's dispose, so the decoder never cleared the rect and every
    subsequent delta frame was diffed against a canvas state the decoder
    did not have — the displayed frames diverged from the §2.7.1.1
    semantics of the supplied frame list. Background-disposed Delta/Auto
    frames now fall back to a full keyframe with the caller's flags
    honoured verbatim (a smaller dirty-rect ANMF cannot carry the
    full-rect clear).
  - a delta-emitted frame with `blend == AlphaBlend` diffed and emitted
    its *raw source* pixels with `B` forced to overwrite, so
    semi-transparent pixels landed on the decoder canvas unblended. The
    dirty rect is now computed between the post-composite drawn canvas
    and the previous canvas, and the emitted sub-frame carries the drawn
    (already-blended) pixels, which a plain overwrite reproduces
    bit-exactly; the no-diff degenerate 2×2 emission likewise re-writes
    drawn-canvas pixels instead of raw source pixels.

### Optimized

- `vp8l_encode::limit_code_lengths` — the §3.7.2 length-cap
  re-balancing pass that only fires when a pathological frequency
  distribution would push a code past 15 bits — no longer rescans all
  used symbols to select each adjustment target. A fresh profile of
  the length-capped `build_code_lengths_dense_green2328` bench input
  attributed ~81% of `build_code_lengths` self-time to that rescan
  (3 491 of ~4 280 in-process samples), confirming the round-277
  flag. The over-subscribed loop now drains one bucket per code
  length, filled in used-symbol order so the back of the highest
  non-empty bucket is exactly the symbol the historical rescan's
  `l >= best_len` tie-break picked, and drives each popped symbol
  upward in place (once lengthened it is strictly the unique deepest
  eligible leaf, so the rescan re-picked it every step until it hit
  the cap) — the original O(n)-per-adjustment pick sequence,
  reproduced step for step at O(1) per adjustment. Output is
  bit-identical: the FNV digest over the 8 bench cells plus 600
  randomized frequency tables (zero densities, tie-heavy, exponential
  cap-tripping skews) is unchanged, a 20 M-table differential fuzz
  against the literal pre-change implementation (~5.8 M of them
  producing max-length-15 codes) found zero divergence, and a 5-minute
  `roundtrip_lossless` fuzz run plus the full test suite pass
  unchanged. `build_code_lengths_dense_green2328` median:
  111.9 µs → 26.4 µs (4.2×); the cell now sits at the leaf-sort +
  two-queue-merge floor and uncapped cells are unaffected (within
  noise). Round-278 section in `BENCHMARKS.md` has the numbers.
- The §3.7.2 / §6.2.1 length-then-code canonical build chain — the
  dense-cell optimization target flagged by the round-250 / round-276
  benches — was rewritten bit-identically on both sides, verified by an
  FNV digest of every length table and built decoder table over the
  full bench input set plus 600 randomized frequency tables (including
  length-limit-triggering exponential skews): the digest is unchanged
  from the previous implementation, and the round-275 `prefix_code`
  differential fuzz harness ran 13.6 M execs clean on the rewrite.
  - Encoder `vp8l_encode::build_code_lengths`: the hand-rolled binary
    min-heap is replaced by a sorted-leaf + internal-FIFO two-queue
    merge (leaves sorted once by a packed `(freq, symbol)` `u64` key;
    internal nodes are created with nondecreasing frequencies, so a
    plain FIFO stays sorted and each merge step compares the two queue
    fronts in O(1), preferring the leaf on a frequency tie exactly as
    the old `(freq, order)` heap key did). Leaf depths are now
    recovered with a single reverse pass over the internal nodes
    instead of one parent-chain walk per leaf, and the
    `limit_code_lengths` re-balancing pass updates its Kraft sum
    incrementally instead of recomputing the O(n) sum after every
    single-leaf adjustment. Dense-cell medians: distance-40
    2.09 µs → 408 ns, literal-256 15.07 µs → 2.07 µs, green-281
    17.66 µs → 2.37 µs, and the headline green-2328 dense cell
    382.0 µs → 113.5 µs (3.4× same-session; 3.7× against the recorded
    round-250 417.8 µs). Sparse cells improve 2.1×–3.5×.
  - Decoder `vp8l_prefix::PrefixCode::from_code_lengths`: the
    `(length, value)` symbol ordering is now a single-rescan counting
    sort — `bl_count` prefix sums fix every length bucket's start
    index up front and ONE pass over `code_lengths` drops each used
    symbol at its bucket cursor — replacing the one-full-rescan-per-
    used-length assignment loop. Dense green-2328 7.44 µs → 4.63 µs
    (1.6×), sparse green-2328 5.84 µs → 1.81 µs (3.2×), the other
    cells 1.1×–2.4×. Full before/after tables in `BENCHMARKS.md`
    (round-277 section).

### Fixed

- `vp8l_stream::BitReader::bits_remaining` underflowed when the cursor sat
  *past* the end of the slice. `BitReader::new_after_image_header` places
  the cursor at bit 40 (past the §3.4 5-byte image-header) before any
  bytes are read, so a VP8L chunk payload shorter than that header — an
  empty or truncated chunk — left `bit_pos > data.len() * 8`. The
  `data.len() * 8 - bit_pos` subtraction then wrapped in `usize`, the
  `n > available` EOF guard in `read_bits` passed against the wrapped
  count, and `read_bits` indexed `data[bit_pos >> 3]` out of bounds — a
  debug-build panic and a release-build out-of-bounds read reachable from
  `decode_webp` whenever a VP8L chunk payload is shorter than 5 bytes. The
  count is now `saturating_sub`, so a past-the-end cursor reports `0` bits
  remaining and `read_bits` cleanly returns the typed `BitReaderEof`.
  Found by the round-273 `decode_lossless` fuzz harness; regression test
  `vp8l_stream::tests::bits_remaining_saturates_when_cursor_past_end`
  pins both the empty- and short-payload cases.

### Added

- `benches/prefix_from_code_lengths.rs`: criterion bench — the
  seventeenth — for the decoder-side §6.2.1 canonical-table build
  `vp8l_prefix::PrefixCode::from_code_lengths`, the decode mirror of
  the §3.7.2 length-then-code encoder pair benched in rounds 250
  (`build_code_lengths`) and 251 (`canonical_codes`) and the
  round-170 decode-profile rank-4 symbol (~2% of decode self-time).
  Parameterised over the same four §3.7.1 prefix-code-group alphabets
  (distance-40, literal-256, green-281, green-2328) and the same two
  dense / sparse frequency regimes with identical LCG constants, so
  every cell is directly comparable to its encoder-mirror
  counterpart; the length tables are produced by `build_code_lengths`
  at setup and the per-iteration `Vec` clone (the function takes the
  table by value) is excluded from the measured interval via
  `iter_batched`. Medians: 187.7 ns / 100.7 ns (dense/sparse
  distance-40), 918.0 ns / 546.3 ns (literal-256), 1.006 µs /
  623.2 ns (green-281), 7.300 µs / 5.249 µs (green-2328) — linear in
  alphabet size, dense/sparse ratio ~1.4–1.9× (between
  `canonical_codes`'s regime-blind ~1.2× and `build_code_lengths`'s
  18×–84×, matching the body's one-full-rescan-per-used-length
  shape), and the cheapest link in the `green2328` dense
  length-then-code chain (417.8 µs builder ≫ 15.70 µs encoder codes >
  7.30 µs decoder table). Function body unchanged; the bench is the
  A/B reference for a future single-rescan bucket-sort rewrite, with
  the round-275 `prefix_code` differential fuzz harness as the
  byte-exact regression guard. Full analysis in `BENCHMARKS.md`
  (round-276 section).
- `fuzz/fuzz_targets/prefix_code.rs`: cargo-fuzz harness — the
  twenty-fourth — driving the §6.2.1 *single canonical prefix-code* reader
  standalone entry point `oxideav_webp::vp8l_prefix::PrefixCode::read`
  directly across an `(alphabet_size, bitstream)` cross-product. This is
  the surface immediately *below* the round-274 `prefix_code_group`
  harness: `PrefixCodeGroup::read` calls `PrefixCode::read` five times in
  green/red/blue/alpha/distance order, and this harness isolates one such
  call. `PrefixCode::read` reads one code's lengths off the wire — the
  §6.2.1 simple/normal `read_code_lengths` dispatch — and builds the
  canonical decoder via `from_code_lengths` with its §6.2.1 Kraft
  completeness gate and single-leaf-node exception. No prior harness drove
  the single code standalone or across a free alphabet sweep:
  `prefix_code_group` (round 274) only ever drives the five reads as a unit
  at the fixed `{40, 256, green}` alphabet sizes. The first input byte
  selects one of the wire-reachable §6.2.3 alphabets — `40` (distance),
  `256` (red/blue/alpha), or the green `256 + 24 + color_cache_size` for
  the full `color_cache_size ∈ {0} ∪ {2, …, 2048}` range — and the
  remaining bytes feed a zero-positioned `BitReader`. Every `Ok(code)` is
  cross-checked against the §6.2.3 / §6.2.1 carrier rules:
  `code_lengths().len()` equals the selected alphabet, every nonzero length
  is `<= 15` (the `MAX_CODE_LENGTH` ceiling), `single_symbol()` is `Some(s)`
  iff the length table has exactly one nonzero entry (at `s`) and `None`
  iff two or more, `read_symbol` against an all-zero reader resolves an
  in-range symbol index, rebuilding from the returned length table through
  `from_code_lengths` reproduces an equal code (the §6.2.1 `sum 2^-len == 1`
  completeness invariant a built code satisfies), the reader never advances
  past the slice bit length, and replaying the same bytes + alphabet yields
  an equal code at an identical bit position. A 14 s smoke pass cleared
  2.00 M runs with no crashes. Run with `cargo +nightly fuzz run
  prefix_code --manifest-path crates/oxideav-webp/fuzz/Cargo.toml`.
- `fuzz/fuzz_targets/prefix_code_group.rs`: cargo-fuzz harness — the
  twenty-third — driving the §6.2 / §6.2.1 *prefix-code-group* reader
  standalone entry point `oxideav_webp::meta_prefix::PrefixCodeGroup::read`
  directly across a `(color_cache_size, bitstream)` cross-product. A §6.2
  group is the five canonical §6.2.1 prefix codes every VP8L pixel is
  decoded with — green + backref-length + color-cache (alphabet `256 + 24 +
  color_cache_size` per §6.2.3), red/blue/alpha (each `256`), and backref
  distance (`40`) — read in that order via `PrefixCode::read` and the
  §6.2.1 simple/normal `read_code_lengths` + canonical `from_code_lengths`
  Kraft completeness build. This is the surface immediately *below* the
  round-271 `vp8l_decode::decode_entropy_coded_image` (§7.3), which reads a
  §5.2.3 color-cache-info bit then exactly one `PrefixCodeGroup::read`
  before the §5.2 pixel loop. No prior harness drove the group standalone:
  `parse_meta_prefix` (round 261) reaches it only through the §5.2.3 +
  §6.2.2 preamble (so the cache size is whatever the 4-bit
  `color_cache_code_bits` produced, never the cache-disabled `0` and a wide
  enabled size in one corpus), and `decode_entropy_coded_image` /
  `decode_argb` consume the group's symbols in the same call so a parse
  failure inside it is indistinguishable from a later §5.2 refusal. The
  first input byte selects the §5.2.3 cache size from `{0}` (disabled) or
  `1 << code_bits` for `code_bits ∈ [1, 11]` (`{2, 4, …, 2048}`), sizing
  the §6.2.3 green alphabet; the remaining bytes feed a zero-positioned
  `BitReader`. Every `Ok(group)` is cross-checked against the §6.2.3 /
  §6.2.1 carrier rules: each of the five codes' `code_lengths().len()`
  equals its alphabet, every nonzero length is `<= 15` (the `MAX_CODE_LENGTH`
  ceiling), `single_symbol()` is `Some(s)` iff the length table has exactly
  one nonzero entry (at `s`) and `None` iff it has two or more, `read_symbol`
  against an all-zero reader resolves an in-range symbol index, the reader
  never advances past the slice bit length, and replaying the same bytes +
  cache size yields an equal group at an identical bit position; the §5.2.3
  `InvalidColorCacheCodeBits` variant is asserted unreachable (the cache
  size is caller-supplied, never read here). A 41 s smoke pass cleared
  4.97 M runs with no crashes. Run with `cargo +nightly fuzz run
  prefix_code_group --manifest-path crates/oxideav-webp/fuzz/Cargo.toml`.
- `fuzz/fuzz_targets/decode_lossless.rs`: cargo-fuzz harness — the
  twenty-second — driving the §4 transform-list + main-image full
  lossless-bitstream decode path standalone entry points
  `oxideav_webp::vp8l_transform::{decode_lossless,
  decode_lossless_headerless}` directly. `decode_lossless` is the layer
  immediately *above* the round-272 §6.2.2 `vp8l_decode::decode_argb`: it
  walks the §4 / §7.2 optional-transform loop (per-transform §4.x fixed
  fields plus its §5-encoded body via the §7.3
  `decode_entropy_coded_image`, the §4 "allowed to be used only once"
  duplicate refusal, the §4.4 `color_table_size` / `width_bits` width
  subsampling), decodes the main §5.1 ARGB image at the possibly-
  subsampled width, then applies the §4 inverse-transform chain in
  reverse read order (§4: "last one first").
  `decode_lossless_headerless` is the §2.7.1.2 / §3 twin used by the
  compressed `ALPH` alpha bitstream — identical save that the 5-byte
  §3.4 image-header is not skipped (the `BitReader` starts at bit 0). No
  prior harness drove this assembled surface: `parse_transform_list`
  (round 260) reads the §4 transform-presence loop's *header* fields but
  stops at the §5 entropy body; `inverse_predictor_color` (round 265) and
  `inverse_subtract_green_indexing` (round 266) drive the four §4.x
  inverse passes in isolation over synthesised buffers, never out of a §4
  transform-list bitstream nor in reverse read order; `decode_argb`
  (round 272) drives only the main §5.1 ARGB image, *after* the transform
  list is consumed; `decode` / `roundtrip_lossless` reach
  `decode_lossless` only through a complete §2 RIFF + §3.4 image-header
  walk with the `(width, height)` pair bounded by an upstream §3.4 field
  and the bitstream constrained to round-trip from the encoder. The fuzz
  buffer fixes the §4 / §6.2.2 carrier dimensions from the first two bytes
  (`width` / `height` each clamped into `[1, 8]` — always nonempty,
  mirroring the §3.4-validated dimensions the driver is reachable with,
  and small so the §4 / §5 / §6 decode loop stays bounded at ≤ 64 pixels)
  and feeds the remaining bytes to both entry points: `decode_lossless`
  reads them past the §3.4 5-byte image-header (transform list at bit 40),
  `decode_lossless_headerless` reads the same bytes from bit 0. Every
  `Ok` image is cross-checked against the §4 / §6.2.2 carrier rules
  (`width()` / `height()` echo the carrier even after a §4.4
  color-indexing transform un-bundles the internal width back to the
  canvas width, `pixels().len() == width * height`), with pure-function
  determinism cross-checked by replaying the same bytes + dimensions for a
  byte-identical pixel buffer; every refusal is required only to return a
  `Result` rather than panic (the granular §4 / §5 / §6 refusal modes are
  cross-checked by the sibling `parse_transform_list` /
  `inverse_predictor_color` / `inverse_subtract_green_indexing` /
  `decode_argb` harnesses through their own entry points). A 40 s smoke
  pass cleared 3.62 M runs with no crashes after the `bits_remaining`
  underflow fix above (which the harness surfaced on its first run).

- `fuzz/fuzz_targets/decode_argb.rs`: cargo-fuzz harness — the
  twenty-first — driving the §6.2.2 top-level VP8L ARGB main-image decode
  path standalone entry point `oxideav_webp::vp8l_decode::decode_argb`
  directly. `decode_argb` is the §5.1 `spatially-coded-image` ARGB-role
  decoder — the layer immediately *above* the round-270 §6.2.2
  `decode_entropy_image` and the round-271 §7.3
  `decode_entropy_coded_image`. It reads the round-106 `MetaPrefixHeader`
  for `ImageRole::Argb` (the §5.2.3 `color-cache-info` bit, then the
  §6.2.2 meta-prefix bit) and dispatches between the single-group path
  (one §6.2 prefix-code group drives the §6.2.3 decode loop everywhere)
  and the multi-group path (the §6.2.2 entropy image is decoded,
  `num_prefix_groups = max(entropy image) + 1` groups are read, and the
  §6.2.3 loop selects a group per pixel block via
  `MetaPrefixIndex::meta_code_for`, with a single §5.2.3 color cache
  maintained in stream order across the whole image). No prior harness
  drove this assembled surface: `parse_meta_prefix` (round 261) stops at
  the §5.2 entropy body without decoding a pixel or reading the per-group
  prefix-code groups; `decode_entropy_image` (round 270) and
  `decode_entropy_coded_image` (round 271) drive only the §6.2.2 entropy
  sub-image and the §7.3 building block beneath it, never the §5.2.3 +
  §6.2.2 ARGB preamble, the single-vs-multi-group dispatch, the per-group
  reads, nor the per-pixel-block group selection `decode_argb` assembles
  on top of them; `decode` / `roundtrip_lossless` reach `decode_argb`
  only through a complete §2 RIFF + §3 image-header walk with the
  `(width, height)` pair bounded by an upstream §3.4 field and the
  bitstream constrained to round-trip from the encoder. The fuzz buffer
  fixes the §6.2.2 carrier dimensions from the first two bytes (`width` /
  `height` each clamped into `[1, 8]` — always nonempty, mirroring the
  §3.4-validated dimensions `decode_argb` is reachable with, and small so
  the §6.2.3 decode loop stays bounded at ≤ 64 pixels) and feeds the
  remaining bytes through a zero-positioned `BitReader` as the §6.2.2 ARGB
  image bit sequence (color-cache-info bit, meta-prefix bit, then the
  dispatched body). Every `Ok` image is cross-checked against the §6.2.2
  carrier rules: `width()` / `height()` echo the carrier;
  `pixels().len() == width as usize * height as usize` (§6.2.2 emits
  exactly one pixel per position); and the reader never advances past the
  slice's bit length. Pure-function determinism is cross-checked by
  replaying the same bytes + `(width, height)` and asserting a
  byte-identical pixel buffer at an identical bit position. Every `Err`
  (truncation, meta-prefix/color-cache-info parse failure, entropy-image
  fault, prefix-code parse failure, out-of-range green symbol, color-cache
  or backward-reference fault, or a meta-prefix code beyond
  `num_prefix_groups`) is required only to return a `Result` rather than
  panic — the granular §5.2 / §6.2 refusal modes are cross-checked by the
  sibling `parse_meta_prefix` / `decode_entropy_image` /
  `decode_entropy_coded_image` / `distance_code` / `color_cache` /
  `backward_reference` / `meta_prefix_index` harnesses through their own
  entry points. This brings the §3 lossless decoder's fuzz coverage to 21
  standalone harnesses, with the §6.2.2 ARGB main-image decode now
  exercised both through the full `decode` path and at its own standalone
  surface — the cap of the round-255→271 bottom-up walk that previously
  fuzzed every layer beneath it. A 30 s smoke pass cleared 2.66 M runs
  with no crashes (476 cov / 1690 features over a 269-input corpus).
- `fuzz/fuzz_targets/decode_entropy_coded_image.rs`: cargo-fuzz harness —
  the twentieth — driving the §7.3 *entropy-coded-image* decode path
  standalone entry point
  `oxideav_webp::vp8l_decode::decode_entropy_coded_image` directly. The
  §7.3 ABNF `entropy-coded-image` is the indivisible building block every
  VP8L pixel surface is assembled from: a §5.2.3 `color-cache-info` bit, a
  single §6.2 prefix-code group (no §6.2.2 meta-prefix bit — that bit
  belongs to the §5.1 `spatially-coded-image` ARGB role only), and the
  §5.2 LZ77 / literal / color-cache data that emits exactly
  `width * height` ARGB pixels in scan-line order. It is the function the
  §4.1 / §4.2 / §4.4 sub-resolution images and the §6.2.2 entropy image
  are all decoded through; the round-270 `decode_entropy_image` harness
  *wraps* this function (it calls it, then folds each pixel's red+green
  channels into a per-block meta-code) and already used it as a
  cross-check sibling, but no harness drove §7.3 standalone across an
  attacker-controlled `(width, height, bitstream)` cross-product. The
  fuzz buffer fixes the §7.3 carrier dimensions from the first two bytes
  (`width` / `height` each modulo 9 so the §5.2 / §6.2 decode loop stays
  bounded — at most 8×8 = 64 pixels — and 0 reaches the §7.3
  degenerate-dimension `EmptyEntropyImage` refusal) and feeds the
  remaining bytes through a zero-positioned `BitReader` as the §7.3
  entropy-coded-image bit sequence. Every `Ok` image is cross-checked
  against the §7.3 carrier rules: `width()` / `height()` echo the carrier;
  `pixels().len() == width as usize * height as usize` (§7.3 emits exactly
  one pixel per position); the success path is reachable only with both
  dimensions ≥ 1 (a zero dimension short-circuits to `EmptyEntropyImage`
  before any header bit is read); and the reader never advances past the
  slice's bit length. The §6.2.2 fold consistency with the round-270
  wrapper is cross-checked by an **independent** `decode_entropy_image`
  decode of the same bytes (`prefix_bits = 2`, inside the §6.2.2 `[2, 9]`
  wire window): the harness folds this function's pixels via
  `(argb >> 8) & 0xffff` and asserts byte-equality with the wrapper's
  per-block meta-codes plus both readers advancing to the same
  `bit_position()`, and the wrapper's `block_width()` / `block_height()`
  echoing the §7.3 dimensions. Pure-function determinism is cross-checked
  by