### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `oxideav-webp` are recorded here.
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/OxideAV/oxideav-webp/compare/v0.2.2...v0.2.3) - 2026-07-03
+
+### Other
+
+- BENCHMARKS + README: round-388 cache-sweep hoists + DP planner rollup
+- shared lengths-only per-stream cost tables (r388)
+- per-position distance-candidate sets in the DP planner (r388)
+- cache-aware DP literal pricing (r388)
+- precompute §5.2.2 decompositions into the DP match table (r388)
+- hoist clustering + transform chains out of the §6.2.2 meta-prefix cache sweeps (r388)
+- size-first §5.2.3 cache-bits sweep via exact plan() mirror (r388)
+- hoist transform forward passes out of the §5.2.3 cache-bits sweep (r388)
+- round-383 compression-density push — corpus table + wall-time note
+- external-oracle direction A over the round-383 encoder wire shapes
+- raise §5.2.2 matcher MAX_CHAIN 64 → 256 (corpus-swept) (r383)
+- §4.4 color-indexing + §6.2.2 multi-meta-prefix stacked sweep; README encoder narrative (r383)
+- agglomerative entropy-merge clustering for the §6.2.2 entropy image (r383)
+- cost-priced LZ77 token planning with exact writer-cost arbitration (r383)
+- §3.5 predictor(±subtract-green) + §6.2.2 multi-meta-prefix stacked candidate (r383)
+- run-length §3.7.2.1.2 code-length tables + §4.4 palette-ordering sweep (r383)
+- §3.5 stacked subtract-green → predictor two-transform candidate (r383)
+- scrub decorative reference-library naming in r335 ICCP fixture-walk comment
+- round 335 — value-validate §2.7.1 metadata extraction (ICCP/EXIF/XMP) against the docs corpus
+- round 327 — pixel-validate the opaque-RGB lossless animation fixture end-to-end
+- webp r322: end-to-end decode coverage for 4 bit-exact docs fixtures
+- webp r318 FUZZ — roundtrip_alpha_filter_lossless differential oracle over §2.7.1.2 ALPH compression-method-1 inverse path
+- webp r314 FUZZ — roundtrip_alpha_filter differential oracle over §2.7.1.2 ALPH inverse filter
+- refresh to current status, drop per-round changelog cruft
+- decode lossy (VP8 ) per-frame ANMF bitstreams in animations
+
 ### Other
 
 - round 388 — **shared per-stream cost tables**: the exact writer mirror and the next DP iteration's pass-1 cost model consumed the same `count_frequencies` + `build_code_lengths` products yet each rebuilt them per stream per cache value; both now share one lengths-only `StreamCostTables` build (the mirror also stops computing canonical code *values* it never used — `CostLengths` skips `canonical_codes` entirely, with the §3.7.2.1 table-cost and single-leaf decisions factored into lengths-only helpers the writer shares). Byte-identical on the measurement corpus; corpus wall 12.6 s → 11.4 s

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-webp"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-webp`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/OxideAV/oxideav-webp/compare/v0.2.2...v0.2.3) - 2026-07-03

### Other

- BENCHMARKS + README: round-388 cache-sweep hoists + DP planner rollup
- shared lengths-only per-stream cost tables (r388)
- per-position distance-candidate sets in the DP planner (r388)
- cache-aware DP literal pricing (r388)
- precompute §5.2.2 decompositions into the DP match table (r388)
- hoist clustering + transform chains out of the §6.2.2 meta-prefix cache sweeps (r388)
- size-first §5.2.3 cache-bits sweep via exact plan() mirror (r388)
- hoist transform forward passes out of the §5.2.3 cache-bits sweep (r388)
- round-383 compression-density push — corpus table + wall-time note
- external-oracle direction A over the round-383 encoder wire shapes
- raise §5.2.2 matcher MAX_CHAIN 64 → 256 (corpus-swept) (r383)
- §4.4 color-indexing + §6.2.2 multi-meta-prefix stacked sweep; README encoder narrative (r383)
- agglomerative entropy-merge clustering for the §6.2.2 entropy image (r383)
- cost-priced LZ77 token planning with exact writer-cost arbitration (r383)
- §3.5 predictor(±subtract-green) + §6.2.2 multi-meta-prefix stacked candidate (r383)
- run-length §3.7.2.1.2 code-length tables + §4.4 palette-ordering sweep (r383)
- §3.5 stacked subtract-green → predictor two-transform candidate (r383)
- scrub decorative reference-library naming in r335 ICCP fixture-walk comment
- round 335 — value-validate §2.7.1 metadata extraction (ICCP/EXIF/XMP) against the docs corpus
- round 327 — pixel-validate the opaque-RGB lossless animation fixture end-to-end
- webp r322: end-to-end decode coverage for 4 bit-exact docs fixtures
- webp r318 FUZZ — roundtrip_alpha_filter_lossless differential oracle over §2.7.1.2 ALPH compression-method-1 inverse path
- webp r314 FUZZ — roundtrip_alpha_filter differential oracle over §2.7.1.2 ALPH inverse filter
- refresh to current status, drop per-round changelog cruft
- decode lossy (VP8 ) per-frame ANMF bitstreams in animations

### Other

- round 388 — **shared per-stream cost tables**: the exact writer mirror and the next DP iteration's pass-1 cost model consumed the same `count_frequencies` + `build_code_lengths` products yet each rebuilt them per stream per cache value; both now share one lengths-only `StreamCostTables` build (the mirror also stops computing canonical code *values* it never used — `CostLengths` skips `canonical_codes` entirely, with the §3.7.2.1 table-cost and single-leaf decisions factored into lengths-only helpers the writer shares). Byte-identical on the measurement corpus; corpus wall 12.6 s → 11.4 s
- round 388 — **per-position distance-candidate sets in the DP planner**: the match table now carries, besides the hash-chain matcher's longest match, fixed-distance run candidates at the §5.2.2 distances with the cheapest map codes — 1 (flat-run RLE), 2, and the row-above 2D neighbourhood width−1 / width / width+1 — from O(n) backward run recurrences with per-distance decomposition templates. The greedy matcher maximises length, so it routinely passes over a slightly-shorter row-above copy whose distance code is near-free; the DP can now weigh them (including length-1/2 copies, cheaper than a literal wherever the above pixel repeats). Special candidates evaluate at full run length only (ladder truncations stay primary-only; corpus-swept within ±2 B of full truncation at −27% of its wall cost). Corpus: gradient ramps −11% (274→244 B), chart-like A 652→640 B and chart-like B 1298→1250 B (both now byte-smaller than the reference encoder's max effort — 9 of 10 corpus images now win), natural 650→644 B, paletted 92 B; every stream re-verified bit-exact through the black-box reference decoder; new `special_distance_candidates_round_trip_and_fire` test pins that the candidates fire and round-trip
- round 388 — **cache-aware DP literal pricing**: §5.2.3 cache state is tokenization-independent (every decoded pixel is inserted in stream order), so per-position hit/index tables are a pure function of `(pixels, cache_code_bits)`; the DP planner now prices a literal at a hit position as the one-symbol GREEN cache reference `cacheify_tokens` will rewrite it into, instead of the four-channel literal it won't be. Non-regressing via the unchanged exact arbitration; corpus: 128×128 natural 672→650 B, chart-like B 1270 B (−2.2%), paletted 96→94 B, photo-like 24668→24654 B, rest unchanged
- round 388 — **precompute the §5.2.2 decompositions into the DP match table**: the round-383 planner's inner loop re-derived the distance-map code (`pixel_distance_to_distance_code`, an up-to-120-entry scan) and two `value_to_prefix` splits per position per DP call — 24× per candidate across the cache-bits sweep — even though all of them depend only on `(len, dist, stream width)`. The match table now stores a `DpMatch` (length/distance plus both prefix + extra-bits decompositions, built once in the memoized `compute_dp_matches` pass), the ladder lengths' cost terms are folded once per DP call, and the memo key gains the stream width the distance codes bake in. Byte-identical on the measurement corpus; corpus encode wall time 15.9 s → 9.2 s (cumulative −55% vs the round-383 baseline at unchanged bytes)
- round 388 — **hoist clustering + transform chains out of the §6.2.2 meta-prefix cache sweeps**: the kmeans block partition depends only on `(pixels, prefix_bits, num_groups)` and the predictor (± subtract-green) chain only on `subtract_green`, yet both sweeps re-ran them per §5.2.3 cache value (12× per shape — the predictor sweep rebuilt the whole §4.1 sub-image + residual pass 12 × 4 × 3 times per branch). Both are now built once per shape/branch and shared across the cache loop via `write_meta_prefix_image_with_codes`; byte-identical on the measurement corpus
- round 388 — **size-first cache-bits sweep**: `select_best_cache_bits_prepared` now *sizes* each of the 12 §5.2.3 sweep values through an exact writer mirror (`PreparedTransform::plan` — prelude bit count + color-cache-info/meta-prefix header bits + the `prefix_codes_and_tokens_bits` body cost the round-383 arbitration already computes) and writes only the winning choice, instead of emitting all 12 full streams and keeping the shortest. Selection order and tie-breaks unchanged; byte-identical on the measurement corpus; new `prepared_plan_len_matches_finish_across_cache_sweep` test pins `plan == finish` on every sweep value across three candidate shapes plus end-to-end sweep equality against the retained brute-force reference
- round 388 — **hoist the transform forward passes out of the §5.2.3 cache-bits sweep**: every transform-candidate encoder is split into a cache-independent `prepare_*` half (a `PreparedTransform` carrying the §3.8.2 optional-transform prelude + the forward-transformed residual buffer) and a cache-dependent `finish` tail (token-plan arbitration + §3.8.3 emission), so the round-148 12-value sweep re-runs only the tail instead of rebuilding the §4.1/§4.2 sub-images, forward residual passes, palette bundling, and prelude bits per value. Byte-identical output on the 10-image measurement corpus (every stream byte-for-byte unchanged); corpus encode wall time −16% (20.3 s → 17.1 s on the usual aarch64-apple-darwin host). This is the round-383 BENCHMARKS follow-up flagged as the dominant residual encode cost

- round 383 — external-oracle coverage of the new wire shapes: a second direction-A test encodes four content regimes that trigger the round-383 machinery (two-regime → multi-group entropy image, palette → §4.4 + ordering sweep, unit-slope → §4.3+§4.1 stack, run/noise-mixed → DP token planner) and asserts each stream decodes bit-exactly through the black-box reference decoder (clean skip when the binary is absent)
- round 383 — §5.2.2 matcher chain-depth A/B: `MAX_CHAIN` 64 → 256 after a corpus sweep (byte-smaller on every image — chart −4.7%, natural −1.8%, gradient −2.6% — for ~25% more matcher time; 1024 was non-monotone and slower, so 256 is kept). Final 10-image corpus standing vs the reference encoder's maximum-effort setting: byte-smaller on 7 of 10 (−3% to −28%), within 9% on the photo-like remainder; every stream bit-exact through a black-box reference decode
- round 383 — §3.5 **color-indexing + §6.2.2 multi-meta-prefix** stacked sweep: the §4.4 transform (across the palette-ordering sweep) bundles the image into packed indices at the subsampled width; the main image is then written with per-region prefix-code groups from the entropy-merge partitions. Completes the transform × multi-group composition space (chart / screen-capture palette content with regionally divergent index statistics); byte-neutral on the measurement corpus, strictly non-regressing by construction. README refreshed with the round-383 encoder narrative
- round 383 — **agglomerative entropy-merge clustering** for the §6.2.2 entropy image: per-block histograms over the five §6.2.3 symbol alphabets the group codes will actually code (green literals + length prefixes, red/blue/alpha literals, distance prefixes), greedily merging the cluster pair whose union costs the fewest Shannon bits; one merge chain snapshots every group count in a 2..=8 ladder, and a codes-taking `write_meta_prefix_image_with_codes` writer lets both the transform-free and the predictor-stacked meta-prefix sweeps consume the partitions. The round-151 pixel-proxy kmeans stays in the sweep (byte-shortest wins). Corpus deltas on top of the earlier r383 milestones: photo-like 160×120 17424→17152 B, gradient 778→762 B, 128×128 natural 696→684 B (−11% vs the reference encoder's best effort), synthetic chart 1956→1934 B; all outputs re-verified bit-exact through a black-box reference decode
- round 383 — **cost-priced LZ77 token planning** (shortest-path parse): every spatially-coded-image writer now arbitrates between the greedy §5.2.2 parse and up to two dynamic-programming re-parses priced by per-symbol Huffman bit costs (literal channel costs vs length-prefix + distance-prefix + extra-bits, per the §5.2.2 band ends), scored by an exact bit-cost mirror of the writer (`prefix_codes_and_tokens_bits`) so the chosen stream is byte-provably never larger than greedy. A long-match inherit rule bounds the per-position match table at roughly greedy cost, and a per-thread single-slot memo shares the greedy parse + match table across the 12-value §5.2.3 cache-bits sweep. Corpus deltas on top of the earlier r383 milestones: 128×128 natural 754→696 B (now −9% vs the reference encoder's best effort), photo-like 160×120 17660→17424 B, palette fixture 100→96 B, gradient 788→778 B; all outputs re-verified bit-exact through a black-box reference decode
- round 383 — §3.5 **(subtract-green →) predictor + §6.2.2 multi-meta-prefix** stacked candidate: the round-151 meta-prefix candidate ran transform-free, so it could never win on photo-like content where the §4.1 predictor is what makes the residual stream compressible; the new candidate writes the (optional §4.3 +) §4.1 transform headers, then hands the residual image to the refactored `write_meta_prefix_image` so per-region prefix-code groups adapt to spatially-varying residual statistics. Swept over subtract-green on/off × `prefix_bits ∈ {4,5,6,7}` × 2..=4 groups × the cache-bits range; non-regressing. Measured: 160×120 photo-like corpus image −288 B (17948→17660); round-trip + beats-single-group tests pin the path
- round 383 — **run-length §3.7.2.1.2 code-length tables**: the normal-form prefix-code-table writer now costs three token layouts — the historical verbatim form, zero-runs-only (codes 17/18), and full RLE with the code-16 nonzero repeat — and writes the cheapest, per table. Sparse literal alphabets (the common case: a handful of used symbols scattered over 256+) collapse their zero streaks into one or two run codes instead of hundreds of per-symbol CLC emissions, shrinking EVERY stream header (5 tables per prefix-code group, sub-images, palette writes). Measured on a 10-image mixed corpus (docs fixtures + synthetic photo/gradient/palette content): every file shrank, e.g. 32×32 palette fixture 188→100 B (−47%), cross-color fixture 112→52 B (−54%), 160×120 gradient 908→788 B (−13%), 128×128 natural 822→756 B (−8%); all outputs re-verified bit-exact through a black-box reference decode. `normal_form_bits` stays an exact mirror of the written layout; new tests pin tokenizer expansion (both variants) against the §3.7.2.1.2 decoder rules, decoder-side round-trip of RLE + repeat-16 tables, cost-mirror equality, and the sparse-table shrink
- round 383 — §4.4 **palette-ordering sweep**: the color-indexing candidates (single-transform and stacked with the §4.1 predictor) now sweep four spec-legal palette permutations — numeric (baseline), luminance-keyed, greedy min-L1-delta chain, and frequency-descending — rebuilding the index map per ordering; the chooser keeps the byte-shortest stream, so the sweep is strictly non-regressing. The ordering shapes both the §4.4 subtraction-coded table deltas and the packed index stream the entropy stage sees
- round 383 — §3.5 stacked **subtract-green → predictor** two-transform encode candidate: the header-free §4.3 front end removes unit-slope red/blue-vs-green correlation without the §4.2 chain's per-block CTE sub-image bytes, then the §4.1 predictor removes the surviving spatial correlation. Swept over per-region + maximal single-block `size_bits`, the round-305 predictor-sub-image strategy set, and the §5.2.3 cache-bits range; non-regressing (chooser keeps the byte-shortest stream). Decoder untouched — the generic §3.5 reverse-read-order inverse chain already covers the pair

- round 335 — close the metadata-extraction-against-docs-corpus gap: mirror `extended-with-icc-profile` and `extended-with-xmp` into `tests/data/` and assert `extract_metadata` returns each fixture's exact §2.7.1.4 `ICCP` / §2.7.1.5 `XMP ` payload bytes end-to-end (length + whole-payload FNV-1a digest + the chunk-body cross-check that no header bytes leak in/out + VP8X flag agreement with the corpus `trace.txt` + an XMP `<?xpacket`/`dc:creator` structural anchor); also upgrade the existing `extended-with-exif` walk from presence-only to a value-validated `extract_metadata` payload check (34-byte TIFF-LE blob, digest-pinned). The three §2.7.1 metadata aux-chunk extraction paths (ICCP / EXIF / XMP) are now each end-to-end value-validated against the docs corpus; previously only the EXIF VP8X *flag* and chunk presence were exercised
- round 327 — close the last *lossless animation* end-to-end pixel gap: mirror the docs corpus's `animated-3-frames-rgb` (3-frame opaque-RGB VP8L animation) into `tests/data/` and assert `decode_webp` reproduces all three §2.7.1.1 ANMF frames pixel-for-pixel against their committed `expected_0000/0001/0002.png` ground truth (per-frame dimensions/duration + 14 edge/interior RGBA samples that uniquely distinguish the red/green/blue field frames and their order, opaque-alpha check, pairwise-distinct frames) plus a whole-buffer FNV-1a digest pin; also locks the ANIM bgcolor=white / loop_count=0 globals. The other in-crate ANIM fixture (`animated-with-alpha`) was already geometry+digest validated; this brings the opaque-RGB animation path under the same end-to-end pixel oracle
- round 322 — close the docs-corpus end-to-end decode gap for the bit-exactly-reconstructible fixtures: mirror `lossless-32x32-rgb`, `lossless-color-cache-stress`, `lossless-cross-color-active`, and `lossy-near-lossless-q40` into `tests/data/` and assert `decode_webp` reproduces each fixture's committed `expected.png` ground truth pixel-for-pixel (dimensions + a spread of edge/interior RGBA samples, plus a whole-buffer opaque-alpha check on the RGB file). Covers the §5.2.3 color-cache, §4.2 CROSS_COLOR transform, opaque-RGB, and near-lossless VP8L container paths, none previously pixel-validated end-to-end
- round 318 FUZZ — add `roundtrip_alpha_filter_lossless` differential oracle for the §2.7.1.2 ALPH **compression-method-1** path (forward-filter → residual packed into a §3 headerless VP8L green channel → method-1 ALPH → decode → byte-identical), exercising the VP8L-decode → green-extract → inverse-filter chain across all four F methods and the §2.7.1.2 border shapes; mirrored by a `decode_method1_lossless_round_trips_all_filters` lib test so the chain is value-pinned in the normal test run
- round 314 FUZZ — add `roundtrip_alpha_filter` differential oracle pinning the §2.7.1.2 ALPH inverse-filter reconstructed *values* (forward-filter → method-0 ALPH → decode → byte-identical), across all four F methods and the interior / left-most-column / top-most-row / (0,0)-corner border cases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).